### PR TITLE
Rename package-info command to info

### DIFF
--- a/matlab/+mip/info.m
+++ b/matlab/+mip/info.m
@@ -1,8 +1,8 @@
-function package_info(packageName)
-    % PACKAGE_INFO Display detailed information about a package
+function info(packageName)
+    % INFO Display detailed information about a package
     %
     % Usage:
-    %   mip.package_info('packageName')
+    %   mip.info('packageName')
     %
     % Args:
     %   packageName - Name of the package to display information for
@@ -11,7 +11,7 @@ function package_info(packageName)
     % name, version, dependencies, exposed symbols, and installation path.
     %
     % Example:
-    %   mip.package_info('chebfun')
+    %   mip.info('chebfun')
     
     if nargin < 1
         error('mip:noPackage', 'Package name is required');

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -52,7 +52,7 @@ mip list
 mip list-loaded
 
 % Get detailed package information
-mip package-info chebfun
+mip info chebfun
 ```
 
 ### Uninstalling Packages
@@ -120,7 +120,7 @@ matlab/
 │   ├── list.m                 # List command
 │   ├── architecture.m         # Architecture command
 │   ├── find_name_collisions.m # Collision detection
-│   ├── package_info.m         # Package info command
+│   ├── info.m                 # Package info command
 │   ├── load.m                 # Load package
 │   ├── unload.m               # Unload package
 │   ├── pin.m                  # Pin package
@@ -254,7 +254,7 @@ mip install mypackage
 %   - mypackage 1.5.0
 
 % Get package info to see dependencies
-mip package-info mypackage
+mip info mypackage
 ```
 
 ### Finding Collisions

--- a/matlab/mip.m
+++ b/matlab/mip.m
@@ -13,7 +13,7 @@ function varargout = mip(command, varargin)
     %   mip list-loaded                 - List currently loaded packages
     %   mip find-name-collisions        - Find symbol name collisions
     %   mip architecture                - Display current architecture tag
-    %   mip package-info <package>      - Display package information
+    %   mip info <package>              - Display package information
     %
     % Examples:
     %   mip install chebfun
@@ -25,7 +25,7 @@ function varargout = mip(command, varargin)
     %   mip unload --all
     %   mip find-name-collisions
     %   mip architecture
-    %   mip package-info chebfun
+    %   mip info chebfun
     
     if nargin < 1
         error('mip:noCommand', 'No command specified. Use "help mip" for usage information.');
@@ -92,12 +92,12 @@ function varargout = mip(command, varargin)
         case 'architecture'
             mip.architecture();
             
-        case 'package-info'
+        case 'info'
             if nargin < 2
-                error('mip:noPackage', 'No package specified for package-info command.');
+                error('mip:noPackage', 'No package specified for info command.');
             end
             packageName = varargin{1};
-            mip.package_info(packageName);
+            mip.info(packageName);
             
         case 'help'
             help mip;


### PR DESCRIPTION
Changes the MATLAB client command from `mip package-info <package name>` to `mip info <package name>` for brevity and simplicity.

**Changes:**
- Updated `matlab/mip.m` to use 'info' command instead of 'package-info'
- Renamed `matlab/+mip/package_info.m` to `matlab/+mip/info.m`
- Updated function name and documentation in `info.m`
- Updated all references in `matlab/README.md`