### PR TITLE
Select latest version when multiple versions exist

### DIFF
--- a/matlab/+mip/+utils/compare_versions.m
+++ b/matlab/+mip/+utils/compare_versions.m
@@ -1,0 +1,32 @@
+function result = compare_versions(v1, v2)
+%COMPARE_VERSIONS  Compare two version strings component-by-component.
+%
+%   result = mip.utils.compare_versions(v1, v2)
+%
+%   Returns:
+%     1  if v1 > v2
+%    -1  if v1 < v2
+%     0  if v1 == v2
+%
+%   Version strings are split on '.' and compared numerically.
+%   Varying component counts are handled by treating missing components as 0.
+
+    parts1 = str2double(strsplit(v1, '.'));
+    parts2 = str2double(strsplit(v2, '.'));
+
+    maxLen = max(length(parts1), length(parts2));
+    parts1(end+1:maxLen) = 0;
+    parts2(end+1:maxLen) = 0;
+
+    for i = 1:maxLen
+        if parts1(i) > parts2(i)
+            result = 1;
+            return
+        elseif parts1(i) < parts2(i)
+            result = -1;
+            return
+        end
+    end
+
+    result = 0;
+end

--- a/matlab/+mip/info.m
+++ b/matlab/+mip/info.m
@@ -69,8 +69,9 @@ try
         versionMap(version) = [variants, {variant}];
     end
     
-    % Get all versions (sorted)
+    % Get all versions (sorted by version number)
     allVersions = keys(versionMap);
+    allVersions = sortVersions(allVersions);
     
     % Find compatible variant for current architecture (latest version)
     latestVersion = allVersions{end};
@@ -200,4 +201,20 @@ catch ME
     end
 end
 
+end
+
+function sorted = sortVersions(versions)
+% Sort version strings by version number (ascending)
+    n = length(versions);
+    sorted = versions;
+    % Simple insertion sort using compare_versions
+    for i = 2:n
+        key = sorted{i};
+        j = i - 1;
+        while j >= 1 && mip.utils.compare_versions(sorted{j}, key) > 0
+            sorted{j+1} = sorted{j};
+            j = j - 1;
+        end
+        sorted{j+1} = key;
+    end
 end

--- a/matlab/+mip/install.m
+++ b/matlab/+mip/install.m
@@ -358,8 +358,18 @@ function bestVariant = selectBestVariant(variants, currentArch)
     end
 
     if ~isempty(exactMatches)
-        bestVariant = exactMatches{1};
+        bestVariant = selectLatest(exactMatches);
     else
-        bestVariant = compatible{1};
+        bestVariant = selectLatest(compatible);
+    end
+end
+
+function best = selectLatest(variants)
+% Select the variant with the latest version from a list of variants
+    best = variants{1};
+    for i = 2:length(variants)
+        if mip.utils.compare_versions(variants{i}.version, best.version) > 0
+            best = variants{i};
+        end
     end
 end


### PR DESCRIPTION
## Summary
- Add `mip.utils.compare_versions` utility that compares version strings numerically (component-by-component, handling varying component counts)
- Update `selectBestVariant` in `install.m` to pick the latest version among compatible architecture matches instead of the first in the list
- Update `info.m` to sort versions numerically instead of alphabetically, so the latest version is correctly identified

Fixes #14

## Test plan
- [ ] Verify `mip.utils.compare_versions('2.0', '1.2.5')` returns 1
- [ ] Verify `mip.utils.compare_versions('1.9.0', '1.10.0')` returns -1
- [ ] Verify `mip install` picks latest version when multiple exist
- [ ] Verify `mip info` displays versions in correct order with latest on bottom