### PR TITLE
Show helpful message when no packages are loaded

### DIFF
--- a/matlab/+mip/list.m
+++ b/matlab/+mip/list.m
@@ -64,7 +64,9 @@ loadedPackages = sort(loadedPackages);
 notLoadedPackages = sort(notLoadedPackages);
 
 % Display loaded packages section
-if ~isempty(loadedPackages)
+if isempty(loadedPackages)
+    fprintf('No packages are currently loaded. Use "mip load <package>" to load one.\n\n');
+else
     fprintf('=== Loaded Packages ===\n');
     for i = 1:length(loadedPackages)
         pkgName = loadedPackages{i};


### PR DESCRIPTION
## Summary

- `mip list` now shows `No packages are currently loaded. Use "mip load <package>" to load one.` when no packages are loaded, instead of silently skipping the loaded section

Closes #16