### PR TITLE
Unload packages before uninstalling them

### DIFF
--- a/+mip/uninstall.m
+++ b/+mip/uninstall.m
@@ -87,6 +87,14 @@ function uninstall(varargin)
         return
     end
 
+    % Unload any packages that are currently loaded
+    for i = 1:length(resolvedPackages)
+        fqn = resolvedPackages{i};
+        if mip.utils.is_loaded(fqn)
+            mip.unload(fqn);
+        end
+    end
+
     % Uninstall each requested package
     fprintf('\n');
     for i = 1:length(resolvedPackages)


### PR DESCRIPTION
## Summary
- Calls `mip.unload` for loaded packages before removing them from disk during `mip uninstall`
- Ensures MATLAB path entries and loaded-package tracking lists are cleaned up

Fixes #47