### PR TITLE
Support commit_hash tracking for branch-version update detection

### DIFF
--- a/+mip/+build/create_mip_json.m
+++ b/+mip/+build/create_mip_json.m
@@ -65,6 +65,10 @@ if isfield(opts, 'source_hash') && ~isempty(opts.source_hash)
     mipData.source_hash = opts.source_hash;
 end
 
+if isfield(opts, 'commit_hash') && ~isempty(opts.commit_hash)
+    mipData.commit_hash = opts.commit_hash;
+end
+
 if isfield(opts, 'editable') && opts.editable
     mipData.editable = true;
     if isfield(opts, 'source_path')

--- a/+mip/+build/prepare_package.m
+++ b/+mip/+build/prepare_package.m
@@ -94,6 +94,13 @@ if exist(sourceHashFile, 'file')
     fclose(fid);
     delete(sourceHashFile);
 end
+commitHashFile = fullfile(pkgSubdir, '.commit_hash');
+if exist(commitHashFile, 'file')
+    fid = fopen(commitHashFile, 'r');
+    jsonOpts.commit_hash = strtrim(fread(fid, '*char')');
+    fclose(fid);
+    delete(commitHashFile);
+end
 mip.build.create_mip_json(stagingDir, mipConfig, resolvedConfig, effectiveArch, jsonOpts);
 
 end

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -113,10 +113,25 @@ function updateSinglePackage(packageArg, channelOverride)
     latestInfo = packageInfoMap(packageName);
     latestVersion = latestInfo.version;
 
-    % Compare versions
+    % Compare versions and commit hashes
     if strcmp(installedVersion, latestVersion)
-        fprintf('Package "%s" is already up to date (%s)\n', fqn, installedVersion);
-        return
+        % Versions match — check if commit hash has changed (e.g. branch tracking)
+        installedHash = '';
+        if isfield(pkgInfo, 'commit_hash')
+            installedHash = pkgInfo.commit_hash;
+        end
+        latestHash = '';
+        if isfield(latestInfo, 'commit_hash')
+            latestHash = latestInfo.commit_hash;
+        end
+
+        if isempty(latestHash) || strcmp(installedHash, latestHash)
+            fprintf('Package "%s" is already up to date (%s)\n', fqn, installedVersion);
+            return
+        end
+
+        fprintf('Version is "%s" but commit hash has changed (%s -> %s)\n', ...
+                installedVersion, installedHash, latestHash);
     end
 
     fprintf('Updating "%s": %s -> %s\n', fqn, installedVersion, latestVersion);


### PR DESCRIPTION
## Summary
- When versions match (e.g. both "main"), `mip update` now compares `commit_hash` from installed `mip.json` vs the channel index entry
- If hashes differ, the package is re-downloaded
- Reads `.commit_hash` file during package build and embeds it in `mip.json`

Closes #55

Companion PR: mip-org/mip-core#3