### PR TITLE
Read mip version from mip.json instead of hardcoding

### DIFF
--- a/+mip/version.m
+++ b/+mip/version.m
@@ -4,14 +4,14 @@ function v = version()
 thisDir = fileparts(mfilename('fullpath'));  % +mip directory
 pkgRoot = fileparts(thisDir);  % package root
 mipJsonPath = fullfile(pkgRoot, 'mip.json');
-if exist(mipJsonPath, 'file')
-    pkgInfo = mip.utils.read_package_json(pkgRoot);
-    v = pkgInfo.version;
-    if isnumeric(v)
-        v = num2str(v);
-    end
-else
-    v = 'dev';
+if ~exist(mipJsonPath, 'file')
+    error('mip:version:noMipJson', ...
+          'mip.json not found at %s. Is mip installed correctly?', pkgRoot);
+end
+pkgInfo = mip.utils.read_package_json(pkgRoot);
+v = pkgInfo.version;
+if isnumeric(v)
+    v = num2str(v);
 end
 
 end


### PR DESCRIPTION
## Summary

Read the mip package version from `mip.json` at runtime instead of returning a hardcoded `'0.0.1'`. Falls back to `'dev'` when `mip.json` is not present (e.g., running from source).

Fixes #49