### PR TITLE
Warn when a package name is installed from multiple channels

### DIFF
--- a/+mip/+utils/find_all_installed_by_name.m
+++ b/+mip/+utils/find_all_installed_by_name.m
@@ -1,0 +1,34 @@
+function matches = find_all_installed_by_name(packageName)
+%FIND_ALL_INSTALLED_BY_NAME   Find all installed packages with a given bare name.
+%
+% Returns cell array of FQN strings for all org/channel combinations
+% where this package name is installed.
+
+matches = {};
+packagesDir = mip.utils.get_packages_dir();
+if ~exist(packagesDir, 'dir')
+    return
+end
+
+orgDirs = dir(packagesDir);
+for i = 1:length(orgDirs)
+    if ~orgDirs(i).isdir || startsWith(orgDirs(i).name, '.')
+        continue
+    end
+    org = orgDirs(i).name;
+    orgPath = fullfile(packagesDir, org);
+    chanDirs = dir(orgPath);
+    for j = 1:length(chanDirs)
+        if ~chanDirs(j).isdir || startsWith(chanDirs(j).name, '.')
+            continue
+        end
+        ch = chanDirs(j).name;
+        pkgDir = fullfile(orgPath, ch, packageName);
+        if exist(pkgDir, 'dir')
+            matches{end+1} = mip.utils.make_fqn(org, ch, packageName); %#ok<AGROW>
+        end
+    end
+end
+
+matches = sort(matches);
+end

--- a/+mip/+utils/install_local.m
+++ b/+mip/+utils/install_local.m
@@ -58,6 +58,15 @@ end
 mip.utils.add_directly_installed(fqn);
 fprintf('Successfully installed "%s"\n', fqn);
 
+% Warn if package exists in multiple channels
+allInstalled = mip.utils.find_all_installed_by_name(packageName);
+if length(allInstalled) > 1
+    fprintf('\nWarning: Package "%s" is installed from multiple channels:\n', packageName);
+    for i = 1:length(allInstalled)
+        fprintf('  - %s\n', allInstalled{i});
+    end
+end
+
 end
 
 

--- a/+mip/install.m
+++ b/+mip/install.m
@@ -246,6 +246,18 @@ function count = installFromRepository(repoPackages, packagesDir, channel)
         end
     end
 
+    % Warn if any installed package name exists in multiple channels
+    for i = 1:length(resolvedPackages)
+        s = resolvedPackages{i};
+        allInstalled = mip.utils.find_all_installed_by_name(s.name);
+        if length(allInstalled) > 1
+            fprintf('\nWarning: Package "%s" is installed from multiple channels:\n', s.name);
+            for k = 1:length(allInstalled)
+                fprintf('  - %s\n', allInstalled{k});
+            end
+        end
+    end
+
 end
 
 function success = installFromMhl(mhlSource, packagesDir, channel)


### PR DESCRIPTION
## Summary

- Add `find_all_installed_by_name` utility that returns all installed FQNs for a given bare package name
- After installing from a repository or locally, warn if the same package name exists in multiple channels

Fixes #42