### PR TITLE
Don't strip MEX binaries in editable mode

### DIFF
--- a/+mip/+utils/install_local.m
+++ b/+mip/+utils/install_local.m
@@ -93,6 +93,9 @@ end
 
 function installEditable(sourceDir, mipConfig, pkgDir, fqn)
 % Editable install: create thin wrapper pointing to original source.
+% Unlike installCopy, this intentionally skips prepare_package (and
+% therefore skips MEX binary stripping and compilation) because the
+% install references the user's source directory directly.
 
     fprintf('Installing "%s" in editable mode...\n', fqn);
 


### PR DESCRIPTION
## Summary

- Editable installs (`mip install -e`) already skip `prepare_package` (and therefore skip MEX binary stripping), since they reference the source directory directly rather than copying files. Added an explicit comment in `installEditable` documenting this intent.

Fixes #44