### PR TITLE
Fall back to ~/.mip when path-based root detection fails

### DIFF
--- a/+mip/root.m
+++ b/+mip/root.m
@@ -24,12 +24,17 @@ root = fileparts(packages_dir);               % .../root
 if ~isfolder(fullfile(root, 'packages'))
     % Path-based detection failed (e.g., editable install where
     % mfilename returns the source path). Fall back to ~/.mip.
-    root = fullfile(getenv('HOME'), '.mip');
+    if ispc
+        home_dir = char(java.lang.System.getProperty('user.home'));
+    else
+        home_dir = '~';
+    end
+    root = fullfile(home_dir, '.mip');
     if ~isfolder(fullfile(root, 'packages'))
         error('mip:rootNotFound', ...
             ['Could not determine the mip root directory.\n' ...
              'Set the MIP_ROOT environment variable to point to your mip root directory.\n' ...
-             'For example: setenv(''MIP_ROOT'', ''%s/.mip'')'], getenv('HOME'));
+             'For example: setenv(''MIP_ROOT'', ''%s/.mip'')'], home_dir);
     end
 end
 


### PR DESCRIPTION
Closes #54

## Summary
- When mip is installed as editable, `mfilename('fullpath')` returns the source directory rather than the wrapper path under `~/.mip`, so the path-based root detection fails
- Now falls back to `~/.mip` before erroring, which is the standard root location
- Resolution priority is preserved: `MIP_ROOT` env var > path navigation > `~/.mip` fallback

## Test plan
- [ ] `mip.root()` works when mip is installed normally (path navigation)
- [ ] `mip.root()` works when mip is installed as editable (`~/.mip` fallback)
- [ ] `MIP_ROOT` env var still takes precedence over both methods
- [ ] Error message is clear when neither method works