### PR TITLE
Add mip test command

### DIFF
--- a/+mip/+build/create_mip_json.m
+++ b/+mip/+build/create_mip_json.m
@@ -81,6 +81,10 @@ if isfield(opts, 'compile_script') && ~isempty(opts.compile_script)
     mipData.compile_script = opts.compile_script;
 end
 
+if isfield(opts, 'test_script') && ~isempty(opts.test_script)
+    mipData.test_script = opts.test_script;
+end
+
 jsonText = jsonencode(mipData);
 mipJsonPath = fullfile(outputDir, 'mip.json');
 fid = fopen(mipJsonPath, 'w');

--- a/+mip/+build/resolve_build_config.m
+++ b/+mip/+build/resolve_build_config.m
@@ -14,7 +14,7 @@ function resolved = resolve_build_config(mipConfig, buildEntry)
 resolved = struct();
 
 % Top-level defaults
-mergeFields = {'addpaths', 'compile_script', 'release_number', 'build_on'};
+mergeFields = {'addpaths', 'compile_script', 'test_script', 'release_number', 'build_on'};
 for i = 1:length(mergeFields)
     key = mergeFields{i};
     if isfield(mipConfig, key)

--- a/+mip/+utils/install_local.m
+++ b/+mip/+utils/install_local.m
@@ -186,10 +186,19 @@ function installEditable(sourceDir, mipConfig, pkgDir, fqn, noCompile)
         compileScript = resolvedConfig.compile_script;
     end
 
-    % Create mip.json (include compile_script for mip compile)
+    % Determine test_script
+    testScript = '';
+    if isfield(resolvedConfig, 'test_script') && ~isempty(resolvedConfig.test_script)
+        testScript = resolvedConfig.test_script;
+    end
+
+    % Create mip.json (include compile_script and test_script)
     jsonOpts = struct('editable', true, 'source_path', sourceDir);
     if ~isempty(compileScript)
         jsonOpts.compile_script = compileScript;
+    end
+    if ~isempty(testScript)
+        jsonOpts.test_script = testScript;
     end
     mip.build.create_mip_json(pkgDir, mipConfig, resolvedConfig, effectiveArch, jsonOpts);
 

--- a/+mip/test.m
+++ b/+mip/test.m
@@ -1,0 +1,122 @@
+function test(varargin)
+%TEST   Run the test script for an installed package.
+%
+% Usage:
+%   mip.test('packageName')
+%   mip.test('org/channel/packageName')
+%
+% Loads the package (if not already loaded) and runs the test script
+% defined in the package's mip.yaml (test_script field). If no test
+% script is defined, prints a message and returns.
+%
+% The test script should error on failure and print 'SUCCESS' on success.
+%
+% Accepts both bare package names and fully qualified names.
+
+if nargin < 1
+    error('mip:test:noPackage', 'Package name is required for test command.');
+end
+
+packageArg = varargin{1};
+if isstring(packageArg)
+    packageArg = char(packageArg);
+end
+
+% Resolve to FQN
+result = mip.utils.parse_package_arg(packageArg);
+
+if result.is_fqn
+    fqn = packageArg;
+    org = result.org;
+    channelName = result.channel;
+    packageName = result.name;
+else
+    fqn = mip.utils.resolve_bare_name(result.name);
+    if isempty(fqn)
+        error('mip:test:notInstalled', ...
+              'Package "%s" is not installed.', result.name);
+    end
+    r = mip.utils.parse_package_arg(fqn);
+    org = r.org;
+    channelName = r.channel;
+    packageName = r.name;
+end
+
+pkgDir = mip.utils.get_package_dir(org, channelName, packageName);
+
+if ~exist(pkgDir, 'dir')
+    error('mip:test:notInstalled', ...
+          'Package "%s" is not installed.', fqn);
+end
+
+% Load the package if not already loaded
+if ~mip.utils.is_loaded(fqn)
+    fprintf('Loading package "%s"...\n', fqn);
+    mip.load(fqn);
+end
+
+% Determine test script
+testScript = '';
+
+% First check mip.json (editable installs may store it there)
+pkgInfo = mip.utils.read_package_json(pkgDir);
+if isfield(pkgInfo, 'test_script') && ~isempty(pkgInfo.test_script)
+    testScript = pkgInfo.test_script;
+end
+
+% If not in mip.json, try reading from mip.yaml
+if isempty(testScript)
+    yamlSearchDir = pkgDir;
+    if isfield(pkgInfo, 'source_path') && ~isempty(pkgInfo.source_path) ...
+            && isfolder(pkgInfo.source_path)
+        yamlSearchDir = pkgInfo.source_path;
+    end
+
+    mipYamlPath = fullfile(yamlSearchDir, 'mip.yaml');
+    if isfile(mipYamlPath)
+        mipConfig = mip.utils.read_mip_yaml(yamlSearchDir);
+        [buildEntry, ~] = mip.build.match_build(mipConfig);
+        resolvedConfig = mip.build.resolve_build_config(mipConfig, buildEntry);
+        if isfield(resolvedConfig, 'test_script') && ~isempty(resolvedConfig.test_script)
+            testScript = resolvedConfig.test_script;
+        end
+    end
+end
+
+if isempty(testScript)
+    fprintf('No test script defined for package "%s".\n', fqn);
+    return
+end
+
+% Determine test directory
+if isfield(pkgInfo, 'source_path') && ~isempty(pkgInfo.source_path) ...
+        && isfolder(pkgInfo.source_path)
+    testDir = pkgInfo.source_path;
+else
+    testDir = fullfile(pkgDir, pkgInfo.name);
+end
+
+if ~isfolder(testDir)
+    error('mip:test:dirMissing', ...
+          'Test directory "%s" does not exist.', testDir);
+end
+
+scriptPath = fullfile(testDir, testScript);
+if ~exist(scriptPath, 'file')
+    error('mip:test:scriptNotFound', ...
+          'Test script not found: %s', scriptPath);
+end
+
+fprintf('Running test script for "%s": %s\n', fqn, testScript);
+originalDir = pwd;
+try
+    cd(testDir);
+    run(testScript);
+catch ME
+    cd(originalDir);
+    error('mip:test:failed', ...
+          'Test failed for "%s": %s', fqn, ME.message);
+end
+cd(originalDir);
+
+end

--- a/mip.m
+++ b/mip.m
@@ -23,6 +23,7 @@ function varargout = mip(command, varargin)
 %   mip avail --channel dev                  - List packages from a specific channel
 %   mip index                                - Display the mip package index URL
 %   mip version                              - Display mip version
+%   mip test <package>                         - Run package test script
 %   mip compile <package>                     - Compile/recompile MEX files
 %   mip bundle <directory> [--output <dir>]   - Build .mhl from local package
 %   mip help [command]                       - Show help text for command
@@ -94,6 +95,12 @@ switch command
             error('mip:noPackage', 'No package specified for info command.');
         end
         mip.info(varargin{:});
+
+    case 'test'
+        if nargin < 2
+            error('mip:noPackage', 'Package name is required for test command.');
+        end
+        mip.test(varargin{:});
 
     case 'compile'
         if nargin < 2


### PR DESCRIPTION
## Summary
- Adds `mip test <package>` command that loads the package and runs its `test_script` from `mip.yaml`
- Supports `test_script` at both top-level and per-build in `mip.yaml` (same as `compile_script`)
- Persists `test_script` in `mip.json` for editable installs
- Packages without a test script print a message and return gracefully