### PR TITLE
Add test_script so 'mip test mip' runs the unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/mip.yaml
+++ b/mip.yaml
@@ -9,5 +9,7 @@ dependencies: []
 addpaths:
   - path: "."
 
+test_script: test.m
+
 builds:
   - architectures: [any]

--- a/test.m
+++ b/test.m
@@ -6,7 +6,6 @@ scriptDir = fileparts(mfilename('fullpath'));
 testsDir = fullfile(scriptDir, 'tests');
 
 addpath(testsDir);
-cleanupObj = onCleanup(@() rmpath(testsDir));
 
 results = run_tests();
 

--- a/test.m
+++ b/test.m
@@ -6,6 +6,7 @@ scriptDir = fileparts(mfilename('fullpath'));
 testsDir = fullfile(scriptDir, 'tests');
 
 addpath(testsDir);
+cleanupObj = onCleanup(@() rmpath(testsDir));
 
 results = run_tests();
 

--- a/test.m
+++ b/test.m
@@ -1,0 +1,17 @@
+% Test script for the mip package.
+% Invoked by `mip test mip`. Runs the unit tests in tests/run_tests.m,
+% errors if any test failed, and prints SUCCESS otherwise.
+
+scriptDir = fileparts(mfilename('fullpath'));
+testsDir = fullfile(scriptDir, 'tests');
+
+addpath(testsDir);
+cleanupObj = onCleanup(@() rmpath(testsDir));
+
+results = run_tests();
+
+if isempty(results) || ~all([results.Passed])
+    error('mip:test:failed', 'One or more mip unit tests failed.');
+end
+
+fprintf('SUCCESS\n');


### PR DESCRIPTION
## Summary
- Adds `test.m` at the package root that invokes `tests/run_tests.m` and errors on any failed test.
- Sets `test_script: test.m` in `mip.yaml` so `mip test mip` picks it up.

Tested by installing my dev mip as `local/local/mip` and then running `mip test local/local/mip`.

Closes #106