### PR TITLE
Fully ignore --channel when all install args are FQN

### DIFF
--- a/+mip/install.m
+++ b/+mip/install.m
@@ -140,18 +140,19 @@ function installedFqns = installFromRepository(repoPackages, ~, channel)
 
     [defaultOrg, defaultChan] = mip.utils.parse_channel_spec(channel);
 
-    fprintf('Using channel: %s/%s\n', defaultOrg, defaultChan);
-
-    % Get current architecture
-    currentArch = mip.arch();
-    fprintf('Detected architecture: %s\n', currentArch);
-
-    % Resolve each package argument to org/channel/name (with optional version)
-    % The --channel flag only applies to user-specified bare names, not dependencies
+    % Resolve each package argument to org/channel/name (with optional version).
+    % FQN arguments use the org/channel encoded in the name; the --channel flag
+    % only applies to bare-name arguments. If every argument is a FQN, the
+    % --channel value is ignored entirely (no warning, no index fetch).
     resolvedPackages = {};  % cell array of structs with .org, .channel, .name, .fqn
     requestedVersions = containers.Map('KeyType', 'char', 'ValueType', 'any');
+    hasBareName = false;
     for i = 1:length(repoPackages)
         pkg = repoPackages{i};
+        parsed = mip.utils.parse_package_arg(pkg);
+        if ~parsed.is_fqn
+            hasBareName = true;
+        end
         [org, ch, name, version] = mip.utils.resolve_package_name(pkg, channel);
         s = struct('org', org, 'channel', ch, 'name', name, ...
                    'fqn', mip.utils.make_fqn(org, ch, name));
@@ -161,17 +162,27 @@ function installedFqns = installFromRepository(repoPackages, ~, channel)
         end
     end
 
+    if hasBareName
+        fprintf('Using channel: %s/%s\n', defaultOrg, defaultChan);
+    end
+
+    % Get current architecture
+    currentArch = mip.arch();
+    fprintf('Detected architecture: %s\n', currentArch);
+
     % Build package info map by fetching indexes for all needed channels.
     % Always fetch mip-org/core (bare-name deps resolve there).
-    % Also fetch the default channel and any channels referenced by FQN args.
+    % Fetch the primary channel only if there is at least one bare-name
+    % argument (otherwise --channel is being ignored entirely).
+    % Also fetch any channels referenced by FQN args.
     packageInfoMap = containers.Map('KeyType', 'char', 'ValueType', 'any');
     unavailablePackages = containers.Map('KeyType', 'char', 'ValueType', 'any');
     fetchedChannels = containers.Map('KeyType', 'char', 'ValueType', 'logical');
 
     % Collect all channels we need upfront
-    channelsToFetch = {channel};
-    if ~(strcmp(defaultOrg, 'mip-org') && strcmp(defaultChan, 'core'))
-        channelsToFetch{end+1} = 'mip-org/core';
+    channelsToFetch = {'mip-org/core'};
+    if hasBareName && ~ismember(channel, channelsToFetch)
+        channelsToFetch{end+1} = channel;
     end
     for i = 1:length(resolvedPackages)
         s = resolvedPackages{i};

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -170,13 +170,14 @@ Used by: `mip install` for remote packages
 
 #### 3.1.1 Channel Resolution
 
-1. If `--channel` is provided, use it. Otherwise default to `mip-org/core`.
-2. FQN arguments override `--channel` -- the org/channel from the FQN is used.
+1. If `--channel` is provided, use it as the primary channel for any bare-name arguments. Otherwise default to `mip-org/core`.
+2. FQN arguments use the org/channel encoded in the name; `--channel` does not apply to them.
+3. If every package argument is a FQN, the `--channel` value is ignored entirely (no warning, no index fetch). See [§14.18](#1418--channel-flag-interaction-with-fqn).
 
 #### 3.1.2 Index Fetching
 
-1. Always fetch the primary channel index.
-2. Always fetch `mip-org/core` index (unless it is the primary channel).
+1. Always fetch the `mip-org/core` index (bare-name dependencies always resolve there -- see [§3.1.5](#315-dependency-resolution)).
+2. If at least one bare-name argument is present, fetch the primary channel index (`--channel` value, or `mip-org/core` by default). When all arguments are FQNs, the primary channel is not fetched.
 3. Also fetch indexes for any channels referenced by FQN arguments.
 4. During dependency resolution, if a cross-channel FQN dependency is missing, fetch its channel lazily (up to 10 retry attempts).
 
@@ -892,6 +893,6 @@ The following behaviors are specified in this document but not fully covered by 
 
 ### 14.18 `--channel` Flag Interaction with FQN
 
-**Current behavior**: When using `mip install org/chan/pkg --channel other/chan`, the FQN takes precedence and `--channel` is ignored for that package. But `--channel` still affects the channel index fetch for bare-name dependencies.
+**Current behavior**: When using `mip install org/chan/pkg --channel other/chan`, the FQN takes precedence and `--channel` is silently ignored for that package -- no warning, no error. If every package argument is a FQN, `--channel` is ignored entirely: its index is not fetched and the "Using channel" line is not printed. In a mixed call (`mip install <fqn> <bare> --channel <other>`), `--channel` applies only to the bare-name argument.
 
-**Question**: Should using `--channel` with a FQN argument produce a warning that it's being ignored?
+This behavior is intentional and was confirmed in [#105](https://github.com/mip-org/mip/issues/105). Bare-name dependencies in `mip.json` are always resolved to `mip-org/core` (see [§3.1.5](#315-dependency-resolution)) and are unaffected by `--channel`.

--- a/tests/TestInstallRemote.m
+++ b/tests/TestInstallRemote.m
@@ -216,6 +216,55 @@ classdef TestInstallRemote < matlab.unittest.TestCase
                 'Package should still be installed');
         end
 
+        %% --- --channel + FQN interaction (issue #105) ---
+
+        function testInstallFromChannel_FQNIgnoresChannelFlag(testCase)
+            % FQN takes precedence over --channel; the package should be
+            % installed in the FQN's channel, not the --channel value.
+            mip.install('--channel', 'mip-org/test-channel2', ...
+                        'mip-org/test-channel1/alpha');
+
+            installedDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'alpha');
+            wrongDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel2', 'alpha');
+
+            testCase.verifyTrue(exist(installedDir, 'dir') > 0, ...
+                'alpha should be installed in test-channel1 (from FQN)');
+            testCase.verifyFalse(exist(wrongDir, 'dir') > 0, ...
+                'alpha should NOT be installed in test-channel2 (--channel ignored)');
+        end
+
+        function testInstallFromChannel_FQNOnlySkipsSpuriousFetch(testCase)
+            % When all args are FQNs, --channel is ignored entirely --
+            % including its index fetch. Pointing --channel at a
+            % nonexistent channel must NOT cause an error.
+            mip.install('--channel', 'nonexistent-org/nonexistent-channel', ...
+                        'mip-org/test-channel1/alpha');
+
+            pkgDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'alpha');
+            testCase.verifyTrue(exist(pkgDir, 'dir') > 0, ...
+                'alpha should be installed even with bogus --channel');
+        end
+
+        function testInstallFromChannel_MixedFQNAndBareUsesChannelForBare(testCase)
+            % Mixed call: --channel applies to the bare-name arg,
+            % FQN arg uses its own channel.
+            mip.install('--channel', 'mip-org/test-channel1', ...
+                        'alpha', 'mip-org/test-channel2/beta');
+
+            alphaDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'alpha');
+            betaDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel2', 'beta');
+
+            testCase.verifyTrue(exist(alphaDir, 'dir') > 0, ...
+                'bare-name alpha should be installed from --channel value');
+            testCase.verifyTrue(exist(betaDir, 'dir') > 0, ...
+                'FQN beta should be installed from its own channel');
+        end
+
     end
 
 end


### PR DESCRIPTION
## Summary

Resolves #105. When every `mip install` argument is a fully qualified name, `--channel` is now ignored *entirely* — no spurious index fetch, no misleading "Using channel" line. Mixed bare+FQN calls are unchanged. The silent-ignore behavior for FQN args was confirmed in the issue thread.

## Changes

- [+mip/install.m](+mip/install.m): track `hasBareName` while resolving args. Skip the primary-channel fetch and the "Using channel" print when no bare-name arg is present. `mip-org/core` is still fetched unconditionally so bare-name dependencies can resolve.
- [docs/behavior-reference.md](docs/behavior-reference.md):
  - §3.1.1 / §3.1.2: documented the new index-fetching rule.
  - §14.18: rewrote from open question to documented decision; removed the incorrect "still affects the channel index fetch for bare-name dependencies" claim (bare-name deps always resolve to `mip-org/core` per §3.1.5).
- [tests/TestInstallRemote.m](tests/TestInstallRemote.m): three new tests covering FQN-with-`--channel`, FQN-only with bogus `--channel` (proves the spurious fetch is gone), and mixed bare+FQN.

## Test plan

- [x] `runtests('TestUtilsParsing')` — 26/26 pass
- [x] `runtests('TestInstallRemote')` — 16/16 pass (13 existing + 3 new)