### PR TITLE
Document local-update reinstall semantics as intentional (#103)

### DIFF
--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -494,7 +494,7 @@ Using an FQN bypasses this check entirely.
 5. Reinstall from source (preserving editable/non-editable mode).
 6. Reload if it was previously loaded.
 
-Local updates **always** reinstall (no up-to-date check). Timestamps change on every update.
+Local updates **always** reinstall (no up-to-date check). Timestamps change on every update. For editable installs the `compile_script` runs again on every update; the `--no-compile` flag from the original install is **not** preserved. See [§14.16](#1416-mip-update-on-local-package-always-reinstalls).
 
 ### 7.3 Force Update (`--force`)
 
@@ -880,9 +880,12 @@ The following behaviors are specified in this document but not fully covered by 
 
 ### 14.16 `mip update` on Local Package Always Reinstalls
 
-**Current behavior**: `mip update local/local/pkg` always deletes and reinstalls from source, even if nothing changed. This is because there's no way to compare local state efficiently.
+**Current behavior**: `mip update local/local/pkg` always deletes and reinstalls from source, even if nothing changed (see [§7.2](#72-local-package-update)). For editable installs the `compile_script` runs again on every update.
 
-**Question**: Should there be a source hash comparison to skip unnecessary reinstalls?
+This behavior is intentional and was confirmed in [#103](https://github.com/mip-org/mip/issues/103):
+- Unconditional uninstall + reinstall is the expected semantics for `mip update` on a local package — `mip update` is the user's "rebuild from source" hammer.
+- For editable installs, recompiling is wanted: the user almost certainly edited source that needs rebuilding.
+- A future `mip update --all` should **not** include local packages.
 
 ### 14.17 `load_package.m` Error Handling
 

--- a/tests/TestUpdateLocal.m
+++ b/tests/TestUpdateLocal.m
@@ -98,6 +98,45 @@ classdef TestUpdateLocal < matlab.unittest.TestCase
             testCase.verifyTrue(exist(pkgDir, 'dir') > 0);
         end
 
+        function testUpdateLocalPackage_EditableRerunsCompileScript(testCase)
+            % Editable update should re-run the compile_script (issue #103).
+            srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg', ...
+                'compile_script', 'compile.m');
+            mip.install('-e', srcDir);
+
+            % Compile script writes a .compiled marker into the source dir
+            markerPath = fullfile(srcDir, '.compiled');
+            testCase.verifyTrue(exist(markerPath, 'file') > 0, ...
+                'compile_script should run on initial install');
+
+            % Delete the marker, then update
+            delete(markerPath);
+            testCase.verifyFalse(exist(markerPath, 'file') > 0);
+
+            mip.update('local/local/mypkg');
+
+            testCase.verifyTrue(exist(markerPath, 'file') > 0, ...
+                'compile_script should run again on update');
+        end
+
+        function testUpdateLocalPackage_NoCompileFlagNotPreserved(testCase)
+            % `mip install -e --no-compile` followed by `mip update` should
+            % run the compile_script -- the original --no-compile flag is
+            % not preserved across updates (issue #103).
+            srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg', ...
+                'compile_script', 'compile.m');
+            mip.install('-e', srcDir, '--no-compile');
+
+            markerPath = fullfile(srcDir, '.compiled');
+            testCase.verifyFalse(exist(markerPath, 'file') > 0, ...
+                'compile_script should NOT run with --no-compile');
+
+            mip.update('local/local/mypkg');
+
+            testCase.verifyTrue(exist(markerPath, 'file') > 0, ...
+                'compile_script should run on update even though original install used --no-compile');
+        end
+
         %% --- Load state preserved across update ---
 
         function testUpdateLocalPackage_PreservesLoadState(testCase)


### PR DESCRIPTION
## Summary

Resolves #103. The current \`mip update local/local/<pkg>\` behavior — always uninstall + reinstall from source, always re-run \`compile_script\` for editable installs — is intentional. Documents the resolved decisions in [docs/behavior-reference.md](docs/behavior-reference.md) and adds two tests that pin the editable-recompile behavior.

## Changes

- [docs/behavior-reference.md](docs/behavior-reference.md):
  - §7.2: explicitly notes that for editable installs, \`compile_script\` runs again on every update and the original \`--no-compile\` flag is not preserved.
  - §14.16: rewritten from open question to documented decision. Cites #103 and includes the forward-looking note that a future \`mip update --all\` should not include local packages.
- [tests/TestUpdateLocal.m](tests/TestUpdateLocal.m): two new tests using the existing \`compile_script\` helper:
  - \`testUpdateLocalPackage_EditableRerunsCompileScript\` — delete the compile-marker, run \`mip update\`, verify the marker is recreated.
  - \`testUpdateLocalPackage_NoCompileFlagNotPreserved\` — \`mip install -e --no-compile\` produces no marker; \`mip update\` produces one, proving the flag isn't carried across.

## Test plan

- [x] \`runtests('TestUpdateLocal')\` — 12/12 pass (10 existing + 2 new)