### PR TITLE
Replace installed version when mip install is given an explicit @version (#102)

### DIFF
--- a/+mip/install.m
+++ b/+mip/install.m
@@ -148,13 +148,14 @@ function installedFqns = installFromRepository(repoPackages, ~, channel)
 
     % Resolve each package argument to org/channel/name (with optional version)
     % The --channel flag only applies to user-specified bare names, not dependencies
-    resolvedPackages = {};  % cell array of structs with .org, .channel, .name, .fqn
+    resolvedPackages = {};  % cell array of structs with .org, .channel, .name, .fqn, .requested_version
     requestedVersions = containers.Map('KeyType', 'char', 'ValueType', 'any');
     for i = 1:length(repoPackages)
         pkg = repoPackages{i};
         [org, ch, name, version] = mip.utils.resolve_package_name(pkg, channel);
         s = struct('org', org, 'channel', ch, 'name', name, ...
-                   'fqn', mip.utils.make_fqn(org, ch, name));
+                   'fqn', mip.utils.make_fqn(org, ch, name), ...
+                   'requested_version', version);
         resolvedPackages{end+1} = s;
         if ~isempty(version)
             requestedVersions(name) = version;
@@ -252,6 +253,40 @@ function installedFqns = installFromRepository(repoPackages, ~, channel)
     % Sort topologically
     allPackagesToInstall = mip.dependency.topological_sort(allRequiredFqns, packageInfoMap);
 
+    % If a user-requested package was given an explicit @version and a
+    % different version is currently installed, replace it. Unload first
+    % so the install loop below sees a clean slate, and remember to reload
+    % afterward. Only trigger when the version that would actually be
+    % installed matches the requested version -- otherwise we'd rip out the
+    % installed copy only to install the wrong version.
+    reloadAfterInstall = {};
+    for i = 1:length(resolvedPackages)
+        s = resolvedPackages{i};
+        if isempty(s.requested_version)
+            continue;
+        end
+        pkgDir = mip.utils.get_package_dir(s.org, s.channel, s.name);
+        if ~exist(pkgDir, 'dir')
+            continue;
+        end
+        installedInfo = mip.utils.read_package_json(pkgDir);
+        if strcmp(installedInfo.version, s.requested_version)
+            continue;  % Already at requested version
+        end
+        if ~packageInfoMap.isKey(s.fqn) || ...
+                ~strcmp(packageInfoMap(s.fqn).version, s.requested_version)
+            continue;  % Would install a different version; leave alone
+        end
+        fprintf('Replacing "%s" %s with requested version %s...\n', ...
+                s.fqn, installedInfo.version, s.requested_version);
+        if mip.utils.is_loaded(s.fqn)
+            mip.unload(s.fqn);
+            reloadAfterInstall{end+1} = s.fqn;
+        end
+        rmdir(pkgDir, 's');
+        mip.utils.remove_directly_installed(s.fqn);
+    end
+
     % Determine which packages need installing vs already installed
     toInstallFqns = {};
     alreadyInstalled = {};
@@ -305,6 +340,13 @@ function installedFqns = installFromRepository(repoPackages, ~, channel)
                 installedFqns{end+1} = s.fqn;
             end
         end
+    end
+
+    % Reload any packages that were unloaded as part of an @version replacement
+    for i = 1:length(reloadAfterInstall)
+        fqn = reloadAfterInstall{i};
+        fprintf('Reloading "%s"...\n', fqn);
+        mip.load(fqn);
     end
 
     % Warn if any installed package name exists in multiple channels

--- a/+mip/install.m
+++ b/+mip/install.m
@@ -147,18 +147,21 @@ function installedFqns = installFromRepository(repoPackages, ~, channel)
     fprintf('Detected architecture: %s\n', currentArch);
 
     % Resolve each package argument to org/channel/name (with optional version)
-    % The --channel flag only applies to user-specified bare names, not dependencies
+    % The --channel flag only applies to user-specified bare names, not dependencies.
+    % requestedVersions is keyed by FQN so a version constraint reaches the right
+    % channel even when the FQN points to a non-primary channel.
     resolvedPackages = {};  % cell array of structs with .org, .channel, .name, .fqn, .requested_version
     requestedVersions = containers.Map('KeyType', 'char', 'ValueType', 'any');
     for i = 1:length(repoPackages)
         pkg = repoPackages{i};
         [org, ch, name, version] = mip.utils.resolve_package_name(pkg, channel);
+        fqn = mip.utils.make_fqn(org, ch, name);
         s = struct('org', org, 'channel', ch, 'name', name, ...
-                   'fqn', mip.utils.make_fqn(org, ch, name), ...
+                   'fqn', fqn, ...
                    'requested_version', version);
         resolvedPackages{end+1} = s;
         if ~isempty(version)
-            requestedVersions(name) = version;
+            requestedVersions(fqn) = version;
         end
     end
 
@@ -186,7 +189,7 @@ function installedFqns = installFromRepository(repoPackages, ~, channel)
     for i = 1:length(channelsToFetch)
         ch = channelsToFetch{i};
         fetchChannelIndex(ch, packageInfoMap, unavailablePackages, ...
-                          fetchedChannels, requestedVersions, channel);
+                          fetchedChannels, requestedVersions);
     end
 
     % Check if any requested packages are unavailable
@@ -245,7 +248,7 @@ function installedFqns = installFromRepository(repoPackages, ~, channel)
             % Fetch the missing channel's index
             fprintf('Fetching %s index for cross-channel dependency...\n', missingChannel);
             fetchChannelIndex(missingChannel, packageInfoMap, unavailablePackages, ...
-                              fetchedChannels, requestedVersions, channel);
+                              fetchedChannels, requestedVersions);
         end
     end
     allRequiredFqns = unique(allRequiredFqns, 'stable');
@@ -495,7 +498,7 @@ function downloadAndInstall(fqn, packageInfo, pkgDir)
     end
 end
 
-function fetchChannelIndex(ch, packageInfoMap, unavailablePackages, fetchedChannels, requestedVersions, primaryChannel)
+function fetchChannelIndex(ch, packageInfoMap, unavailablePackages, fetchedChannels, requestedVersions)
 % Fetch a channel's index and merge into the package info map.
     if fetchedChannels.isKey(ch)
         return
@@ -503,12 +506,18 @@ function fetchChannelIndex(ch, packageInfoMap, unavailablePackages, fetchedChann
     fprintf('Fetching package index for %s...\n', ch);
     [chOrg, chName] = mip.utils.parse_channel_spec(ch);
     chIndex = mip.utils.fetch_index(ch);
-    % Apply version constraints only if this is the primary channel
-    if strcmp(ch, primaryChannel)
-        [chMap, chUnavail] = mip.utils.build_package_info_map(chIndex, chOrg, chName, requestedVersions);
-    else
-        [chMap, chUnavail] = mip.utils.build_package_info_map(chIndex, chOrg, chName);
+    % Project the FQN-keyed requestedVersions down to a name-keyed map
+    % containing only entries that target this channel. build_package_info_map
+    % expects bare-name keys.
+    chRequestedVersions = containers.Map('KeyType', 'char', 'ValueType', 'any');
+    fqnKeys = keys(requestedVersions);
+    for j = 1:length(fqnKeys)
+        parsed = mip.utils.parse_package_arg(fqnKeys{j});
+        if strcmp(parsed.org, chOrg) && strcmp(parsed.channel, chName)
+            chRequestedVersions(parsed.name) = requestedVersions(fqnKeys{j});
+        end
     end
+    [chMap, chUnavail] = mip.utils.build_package_info_map(chIndex, chOrg, chName, chRequestedVersions);
     chKeys = keys(chMap);
     for j = 1:length(chKeys)
         packageInfoMap(chKeys{j}) = chMap(chKeys{j});

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -857,9 +857,7 @@ A potential middle ground: at install time, resolve bare-name deps using same-ch
 
 **Current behavior**: Only one version of a package can be installed per FQN. The same package name can exist at different versions on different channels (e.g., `mip-org/core/pkg` at v1 and `mylab/custom/pkg` at v2) -- those are independent installs.
 
-**Resolved in [#102](https://github.com/mip-org/mip/issues/102)**: `mip install pkg@2.0` when a different version of `pkg` is already installed silently replaces it (uninstall + install). See [§3.1.7](#317-already-installed-behavior). This only applies when the user passed an explicit `@version`; without `@version`, the existing "already installed" behavior is unchanged.
-
-**Known limitation**: The version-constraint logic only applies `requestedVersions` to the primary channel index fetch. For an FQN argument that points to a non-primary channel (e.g. `mip install mylab/extra/foo@2.0` with no `--channel`), the requested version is silently ignored and the channel's best version is installed instead. The upgrade logic above guards against this by only triggering when the version that would actually be installed matches the requested version. A proper fix should key `requestedVersions` by FQN rather than bare name.
+**Resolved in [#102](https://github.com/mip-org/mip/issues/102)**: `mip install pkg@2.0` when a different version of `pkg` is already installed silently replaces it (uninstall + install). See [§3.1.7](#317-already-installed-behavior). This only applies when the user passed an explicit `@version`; without `@version`, the existing "already installed" behavior is unchanged. `@version` is honored regardless of whether the request is bare-name or a FQN to any channel.
 
 Lock files (#96) and dependency version constraints (#95) are out of scope for now.
 

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -225,6 +225,8 @@ Priority: exact match > `numbl_wasm` fallback > `any`.
 
 If a package is already installed, `mip install` prints a message and skips it. It does **not** error. It does **not** reinstall or upgrade. Use `mip update` for that.
 
+**Exception** -- explicit version upgrade: if the user passed an explicit `@version` for a directly-requested package and a *different* version is currently installed, `mip install` silently replaces it (uninstall + install of the requested version, including unload-before / reload-after for the affected package). The replacement only triggers when the version that would actually be installed matches the requested version; otherwise the old install is left in place. See [§14.13](#1413-multiple-versions-of-the-same-package).
+
 #### 3.1.8 Multiple Packages
 
 `mip install pkg1 pkg2 pkg3` installs all listed packages and their combined dependencies in a single operation.
@@ -853,9 +855,13 @@ A potential middle ground: at install time, resolve bare-name deps using same-ch
 
 ### 14.13 Multiple Versions of the Same Package
 
-**Current behavior**: Only one version of a package can be installed per FQN. Installing a different version requires uninstalling first (or using `mip update`). However, the same package name can exist at different versions on different channels (e.g., `mip-org/core/pkg` at v1 and `mylab/custom/pkg` at v2).
+**Current behavior**: Only one version of a package can be installed per FQN. The same package name can exist at different versions on different channels (e.g., `mip-org/core/pkg` at v1 and `mylab/custom/pkg` at v2) -- those are independent installs.
 
-**Question**: Should `mip install pkg@2.0` auto-upgrade if v1 is already installed? Currently it just says "already installed".
+**Resolved in [#102](https://github.com/mip-org/mip/issues/102)**: `mip install pkg@2.0` when a different version of `pkg` is already installed silently replaces it (uninstall + install). See [§3.1.7](#317-already-installed-behavior). This only applies when the user passed an explicit `@version`; without `@version`, the existing "already installed" behavior is unchanged.
+
+**Known limitation**: The version-constraint logic only applies `requestedVersions` to the primary channel index fetch. For an FQN argument that points to a non-primary channel (e.g. `mip install mylab/extra/foo@2.0` with no `--channel`), the requested version is silently ignored and the channel's best version is installed instead. The upgrade logic above guards against this by only triggering when the version that would actually be installed matches the requested version. A proper fix should key `requestedVersions` by FQN rather than bare name.
+
+Lock files (#96) and dependency version constraints (#95) are out of scope for now.
 
 ### 14.14 `mip.json` Dependencies Store Bare Names
 

--- a/tests/TestInstallRemote.m
+++ b/tests/TestInstallRemote.m
@@ -216,6 +216,97 @@ classdef TestInstallRemote < matlab.unittest.TestCase
                 'Package should still be installed');
         end
 
+        %% --- @version upgrade behavior (issue #102) ---
+
+        function testInstallFromChannel_VersionUpgradeReplacesInstalled(testCase)
+            % Install alpha@1.0.0, then mip install alpha@2.0.0 should
+            % silently replace the installed version with the requested one.
+            mip.install('--channel', 'mip-org/test-channel1', 'alpha@1.0.0');
+
+            pkgDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'alpha');
+            info1 = mip.utils.read_package_json(pkgDir);
+            testCase.verifyEqual(info1.version, '1.0.0');
+
+            mip.install('--channel', 'mip-org/test-channel1', 'alpha@2.0.0');
+
+            info2 = mip.utils.read_package_json(pkgDir);
+            testCase.verifyEqual(info2.version, '2.0.0', ...
+                'alpha should be upgraded to the requested version');
+        end
+
+        function testInstallFromChannel_VersionDowngradeReplacesInstalled(testCase)
+            % Install alpha@2.0.0, then mip install alpha@1.0.0 should
+            % silently replace it (downgrade is also a "replace").
+            mip.install('--channel', 'mip-org/test-channel1', 'alpha@2.0.0');
+
+            pkgDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'alpha');
+            info1 = mip.utils.read_package_json(pkgDir);
+            testCase.verifyEqual(info1.version, '2.0.0');
+
+            mip.install('--channel', 'mip-org/test-channel1', 'alpha@1.0.0');
+
+            info2 = mip.utils.read_package_json(pkgDir);
+            testCase.verifyEqual(info2.version, '1.0.0', ...
+                'alpha should be downgraded to the requested version');
+        end
+
+        function testInstallFromChannel_SameVersionStaysInstalled(testCase)
+            % Installing the same @version twice is idempotent (no replace).
+            mip.install('--channel', 'mip-org/test-channel1', 'alpha@1.0.0');
+
+            pkgDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'alpha');
+            info1 = mip.utils.read_package_json(pkgDir);
+            timestamp1 = info1.timestamp;
+
+            pause(1.1);
+
+            mip.install('--channel', 'mip-org/test-channel1', 'alpha@1.0.0');
+
+            info2 = mip.utils.read_package_json(pkgDir);
+            testCase.verifyEqual(info2.version, '1.0.0');
+            testCase.verifyEqual(info2.timestamp, timestamp1, ...
+                'Same @version should not trigger reinstall');
+        end
+
+        function testInstallFromChannel_NoVersionDoesNotUpgrade(testCase)
+            % Without an explicit @version, the existing "already installed"
+            % behavior wins -- mip install does not auto-upgrade.
+            mip.install('--channel', 'mip-org/test-channel1', 'alpha@1.0.0');
+
+            pkgDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'alpha');
+            info1 = mip.utils.read_package_json(pkgDir);
+            testCase.verifyEqual(info1.version, '1.0.0');
+
+            % No @version -- alpha 2.0.0 is the channel's best version,
+            % but we should NOT auto-upgrade.
+            mip.install('--channel', 'mip-org/test-channel1', 'alpha');
+
+            info2 = mip.utils.read_package_json(pkgDir);
+            testCase.verifyEqual(info2.version, '1.0.0', ...
+                'mip install pkg (no @version) should not upgrade');
+        end
+
+        function testInstallFromChannel_VersionUpgradePreservesLoadState(testCase)
+            % If the package was loaded before the upgrade, it should be
+            % reloaded after the new version is installed.
+            mip.install('--channel', 'mip-org/test-channel1', 'alpha@1.0.0');
+            mip.load('mip-org/test-channel1/alpha');
+            testCase.verifyTrue(mip.utils.is_loaded('mip-org/test-channel1/alpha'));
+
+            mip.install('--channel', 'mip-org/test-channel1', 'alpha@2.0.0');
+
+            testCase.verifyTrue(mip.utils.is_loaded('mip-org/test-channel1/alpha'), ...
+                'alpha should be reloaded after the @version replace');
+            pkgDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'alpha');
+            info = mip.utils.read_package_json(pkgDir);
+            testCase.verifyEqual(info.version, '2.0.0');
+        end
+
     end
 
 end

--- a/tests/TestInstallRemote.m
+++ b/tests/TestInstallRemote.m
@@ -290,6 +290,30 @@ classdef TestInstallRemote < matlab.unittest.TestCase
                 'mip install pkg (no @version) should not upgrade');
         end
 
+        function testInstallFromChannel_FQNVersionConstraintHonored(testCase)
+            % FQN with @version pointing to a non-primary channel must
+            % install the requested version, not the channel's best version.
+            % Regression test: requestedVersions used to be name-keyed and
+            % only applied to the primary channel index fetch, so this
+            % silently installed the channel's default best version.
+            mip.install('mip-org/test-channel1/alpha@1.0.0');
+
+            pkgDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'alpha');
+            info = mip.utils.read_package_json(pkgDir);
+            testCase.verifyEqual(info.version, '1.0.0', ...
+                'FQN @version should reach the FQN''s channel');
+        end
+
+        function testInstallFromChannel_FQNVersionConstraintNotFoundErrors(testCase)
+            % If the requested @version doesn't exist in the FQN's channel,
+            % mip:versionNotFound should be raised (not silently fall through
+            % to the best version).
+            testCase.verifyError(@() ...
+                mip.install('mip-org/test-channel1/alpha@99.99.99'), ...
+                'mip:versionNotFound');
+        end
+
         function testInstallFromChannel_VersionUpgradePreservesLoadState(testCase)
             % If the package was loaded before the upgrade, it should be
             % reloaded after the new version is installed.


### PR DESCRIPTION
## Summary

Resolves #102. \`mip install pkg@2.0\` no longer prints "already installed" and does nothing when a different version of pkg is already on disk. When the user passes an explicit \`@version\` and a different version is currently installed, the old copy is silently replaced.

## Behavior

- **Explicit \`@version\`, different installed**: silently uninstall the old version, install the requested one. If the package was loaded, unload before and reload after.
- **Explicit \`@version\`, same installed**: idempotent — no action.
- **No \`@version\`**: unchanged. Still prints "already installed" and skips.
- **Replacement guard**: only triggers when the version mip *would* install matches the requested one. Prevents accidentally ripping out a working install when the version constraint isn't reaching the FQN's channel (documented as a known limitation in §14.13).

## Changes

- [+mip/install.m](+mip/install.m): track \`requested_version\` per resolved package; before the install loop, check each user-requested package — if a different version is installed and mip would install the requested one, unload + uninstall it. After the install loop, reload anything that was unloaded.
- [docs/behavior-reference.md](docs/behavior-reference.md):
  - §3.1.7 documents the new \`@version\` exception with a cross-link to §14.13.
  - §14.13 rewritten from open question to documented decision; calls out the FQN-version-constraint bug as a known limitation and notes lock files / version constraints are out of scope.
- [tests/TestInstallRemote.m](tests/TestInstallRemote.m): five new tests covering upgrade, downgrade, idempotency, no-\`@version\` no-op, and load-state preservation.

## Test plan

- [x] \`runtests('TestInstallRemote')\` — 18/18 pass (13 existing + 5 new)
- [x] \`runtests('TestUpdateRemote')\` — 5/5 pass (no regressions)