### PR TITLE
Roll back orphaned dependencies on failed install (#100)

### DIFF
--- a/+mip/+utils/prune_unused_packages.m
+++ b/+mip/+utils/prune_unused_packages.m
@@ -1,0 +1,132 @@
+function prune_unused_packages()
+%PRUNE_UNUSED_PACKAGES   Remove installed packages that are no longer needed.
+%
+% A package is considered needed if it is in `directly_installed.txt` or
+% is a transitive dependency of any directly-installed package.
+%
+% `mip-org/core/mip` (the package manager itself) is never pruned.
+%
+% Used by:
+%   - `mip uninstall`: prune orphans after removing requested packages.
+%   - `mip install`: roll back successfully-installed dependencies when a
+%     later package in the same operation fails.
+
+    allInstalled = mip.utils.list_installed_packages();
+
+    if isempty(allInstalled)
+        return
+    end
+
+    directlyInstalled = mip.utils.get_directly_installed();
+
+    % Build set of all needed packages (directly installed + their dependencies)
+    neededPackages = {};
+    for i = 1:length(directlyInstalled)
+        directPkg = directlyInstalled{i};
+        if ismember(directPkg, allInstalled)
+            neededPackages = [neededPackages, getAllDependencies(directPkg)]; %#ok<AGROW>
+        end
+    end
+
+    neededPackages = unique([directlyInstalled, neededPackages]);
+
+    % Find packages to prune (installed but not needed)
+    % Never prune mip-org/core/mip - it is the package manager itself
+    packagesToPrune = {};
+    for i = 1:length(allInstalled)
+        fqn = allInstalled{i};
+        if ~ismember(fqn, neededPackages) && ...
+                ~strcmp(fqn, 'mip-org/core/mip')
+            packagesToPrune{end+1} = fqn; %#ok<AGROW>
+        end
+    end
+
+    if ~isempty(packagesToPrune)
+        fprintf('\nPruning unnecessary packages: %s\n', strjoin(packagesToPrune, ', '));
+        for i = 1:length(packagesToPrune)
+            fqn = packagesToPrune{i};
+            r = mip.utils.parse_package_arg(fqn);
+            pkgDir = mip.utils.get_package_dir(r.org, r.channel, r.name);
+
+            try
+                rmdir(pkgDir, 's');
+                fprintf('  Pruned package "%s"\n', fqn);
+                cleanupEmptyDirs(fullfile(mip.utils.get_packages_dir(), r.org, r.channel));
+                cleanupEmptyDirs(fullfile(mip.utils.get_packages_dir(), r.org));
+            catch ME
+                warning('mip:pruneFailed', ...
+                        'Failed to prune package "%s": %s', fqn, ME.message);
+            end
+        end
+    end
+end
+
+function deps = getAllDependencies(fqn)
+    deps = {};
+
+    result = mip.utils.parse_package_arg(fqn);
+    if ~result.is_fqn
+        return
+    end
+
+    pkgDir = mip.utils.get_package_dir(result.org, result.channel, result.name);
+    mipJsonPath = fullfile(pkgDir, 'mip.json');
+
+    if ~exist(mipJsonPath, 'file')
+        return
+    end
+
+    try
+        fid = fopen(mipJsonPath, 'r');
+        jsonText = fread(fid, '*char')';
+        fclose(fid);
+        mipConfig = jsondecode(jsonText);
+
+        if isfield(mipConfig, 'dependencies') && ~isempty(mipConfig.dependencies)
+            depNames = mipConfig.dependencies;
+            if ~iscell(depNames)
+                depNames = {depNames};
+            end
+            for i = 1:length(depNames)
+                dep = depNames{i};
+                depResult = mip.utils.parse_package_arg(dep);
+                if depResult.is_fqn
+                    depFqn = dep;
+                else
+                    % Same channel first, then resolve
+                    sameDir = mip.utils.get_package_dir(result.org, result.channel, dep);
+                    if exist(sameDir, 'dir')
+                        depFqn = mip.utils.make_fqn(result.org, result.channel, dep);
+                    else
+                        depFqn = mip.utils.resolve_bare_name(dep);
+                        if isempty(depFqn)
+                            continue
+                        end
+                    end
+                end
+                if ~ismember(depFqn, deps)
+                    deps{end+1} = depFqn; %#ok<AGROW>
+                    transitiveDeps = getAllDependencies(depFqn);
+                    deps = unique([deps, transitiveDeps]);
+                end
+            end
+        end
+    catch ME
+        warning('mip:jsonParseError', ...
+                'Could not parse mip.json for package "%s": %s', ...
+                fqn, ME.message);
+    end
+end
+
+function cleanupEmptyDirs(dirPath)
+% Remove directory if it is empty (no subdirectories or files)
+    if ~exist(dirPath, 'dir')
+        return
+    end
+    contents = dir(dirPath);
+    % Filter out . and ..
+    contents = contents(~ismember({contents.name}, {'.', '..'}));
+    if isempty(contents)
+        rmdir(dirPath);
+    end
+end

--- a/+mip/install.m
+++ b/+mip/install.m
@@ -288,13 +288,27 @@ function installedFqns = installFromRepository(repoPackages, ~, channel)
         end
         fprintf('\n');
 
-        % Install each package
-        for i = 1:length(toInstallFqns)
-            fqn = toInstallFqns{i};
-            pkgInfo = packageInfoMap(fqn);
-            result = mip.utils.parse_package_arg(fqn);
-            pkgDir = mip.utils.get_package_dir(result.org, result.channel, result.name);
-            downloadAndInstall(fqn, pkgInfo, pkgDir);
+        % Install each package. If any package fails midway, the
+        % already-installed-during-this-call dependencies are still on disk
+        % but not in directly_installed.txt -- prune them so a failed
+        % install doesn't leave orphans behind.
+        try
+            for i = 1:length(toInstallFqns)
+                fqn = toInstallFqns{i};
+                pkgInfo = packageInfoMap(fqn);
+                result = mip.utils.parse_package_arg(fqn);
+                pkgDir = mip.utils.get_package_dir(result.org, result.channel, result.name);
+                downloadAndInstall(fqn, pkgInfo, pkgDir);
+            end
+        catch ME
+            fprintf('\nInstall failed; rolling back any orphaned dependencies...\n');
+            try
+                mip.utils.prune_unused_packages();
+            catch pruneErr
+                warning('mip:rollbackFailed', ...
+                        'Rollback prune failed: %s', pruneErr.message);
+            end
+            rethrow(ME);
         end
 
         % Mark requested packages as directly installed and collect their FQNs
@@ -384,6 +398,16 @@ function installedFqn = installFromMhl(mhlSource, packagesDir, channel)
         % Clean up on error
         if exist(tempDir, 'dir')
             rmdir(tempDir, 's');
+        end
+        % If installFromRepository succeeded for the dependencies but the
+        % .mhl install itself failed (or vice-versa), prune any orphans
+        % that were left behind.
+        fprintf('\nInstall failed; rolling back any orphaned dependencies...\n');
+        try
+            mip.utils.prune_unused_packages();
+        catch pruneErr
+            warning('mip:rollbackFailed', ...
+                    'Rollback prune failed: %s', pruneErr.message);
         end
         rethrow(ME);
     end

--- a/+mip/uninstall.m
+++ b/+mip/uninstall.m
@@ -105,7 +105,10 @@ function uninstall(varargin)
     end
 
     % Prune packages that are no longer needed
-    pruneUnusedPackages();
+    mip.utils.prune_unused_packages();
+
+    % After pruning, check for broken dependencies
+    checkForBrokenDependencies();
 end
 
 function cleanupEmptyDirs(dirPath)
@@ -118,119 +121,6 @@ function cleanupEmptyDirs(dirPath)
     contents = contents(~ismember({contents.name}, {'.', '..'}));
     if isempty(contents)
         rmdir(dirPath);
-    end
-end
-
-function pruneUnusedPackages()
-% Prune packages that are no longer needed
-
-    allInstalled = mip.utils.list_installed_packages();
-
-    if isempty(allInstalled)
-        return
-    end
-
-    directlyInstalled = mip.utils.get_directly_installed();
-
-    % Build set of all needed packages (directly installed + their dependencies)
-    neededPackages = {};
-    for i = 1:length(directlyInstalled)
-        directPkg = directlyInstalled{i};
-        if ismember(directPkg, allInstalled)
-            neededPackages = [neededPackages, getAllDependencies(directPkg)]; %#ok<AGROW>
-        end
-    end
-
-    neededPackages = unique([directlyInstalled, neededPackages]);
-
-    % Find packages to prune (installed but not needed)
-    % Never prune mip-org/core/mip - it is the package manager itself
-    packagesToPrune = {};
-    for i = 1:length(allInstalled)
-        fqn = allInstalled{i};
-        if ~ismember(fqn, neededPackages) && ...
-                ~strcmp(fqn, 'mip-org/core/mip')
-            packagesToPrune{end+1} = fqn; %#ok<AGROW>
-        end
-    end
-
-    if ~isempty(packagesToPrune)
-        fprintf('\nPruning unnecessary packages: %s\n', strjoin(packagesToPrune, ', '));
-        for i = 1:length(packagesToPrune)
-            fqn = packagesToPrune{i};
-            r = mip.utils.parse_package_arg(fqn);
-            pkgDir = mip.utils.get_package_dir(r.org, r.channel, r.name);
-
-            try
-                rmdir(pkgDir, 's');
-                fprintf('  Pruned package "%s"\n', fqn);
-                cleanupEmptyDirs(fullfile(mip.utils.get_packages_dir(), r.org, r.channel));
-                cleanupEmptyDirs(fullfile(mip.utils.get_packages_dir(), r.org));
-            catch ME
-                warning('mip:pruneFailed', ...
-                        'Failed to prune package "%s": %s', fqn, ME.message);
-            end
-        end
-    end
-
-    % After pruning, check for broken dependencies
-    checkForBrokenDependencies();
-end
-
-function deps = getAllDependencies(fqn)
-    deps = {};
-
-    result = mip.utils.parse_package_arg(fqn);
-    if ~result.is_fqn
-        return
-    end
-
-    pkgDir = mip.utils.get_package_dir(result.org, result.channel, result.name);
-    mipJsonPath = fullfile(pkgDir, 'mip.json');
-
-    if ~exist(mipJsonPath, 'file')
-        return
-    end
-
-    try
-        fid = fopen(mipJsonPath, 'r');
-        jsonText = fread(fid, '*char')';
-        fclose(fid);
-        mipConfig = jsondecode(jsonText);
-
-        if isfield(mipConfig, 'dependencies') && ~isempty(mipConfig.dependencies)
-            depNames = mipConfig.dependencies;
-            if ~iscell(depNames)
-                depNames = {depNames};
-            end
-            for i = 1:length(depNames)
-                dep = depNames{i};
-                depResult = mip.utils.parse_package_arg(dep);
-                if depResult.is_fqn
-                    depFqn = dep;
-                else
-                    % Same channel first, then resolve
-                    sameDir = mip.utils.get_package_dir(result.org, result.channel, dep);
-                    if exist(sameDir, 'dir')
-                        depFqn = mip.utils.make_fqn(result.org, result.channel, dep);
-                    else
-                        depFqn = mip.utils.resolve_bare_name(dep);
-                        if isempty(depFqn)
-                            continue
-                        end
-                    end
-                end
-                if ~ismember(depFqn, deps)
-                    deps{end+1} = depFqn; %#ok<AGROW>
-                    transitiveDeps = getAllDependencies(depFqn);
-                    deps = unique([deps, transitiveDeps]);
-                end
-            end
-        end
-    catch ME
-        warning('mip:jsonParseError', ...
-                'Could not parse mip.json for package "%s": %s', ...
-                fqn, ME.message);
     end
 end
 

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -221,6 +221,8 @@ Priority: exact match > `numbl_wasm` fallback > `any`.
 2. Mark the **user-requested** packages (not their dependencies) as "directly installed" in `directly_installed.txt`.
 3. Print a summary with load hints.
 
+If any package in step 1 fails (download error, extraction failure, etc.), the install loop aborts and `mip install` runs the same prune logic that `mip uninstall` uses (`mip.utils.prune_unused_packages`). Because the user-requested packages haven't been added to `directly_installed.txt` yet, any dependencies that did install successfully during this call get pruned as orphans, leaving the package set as it was before the call -- modulo any pre-existing orphans, which the prune sweep will also remove. The original install error is then re-raised. See [§14.11](#1411-no-rollback-on-failed-install).
+
 #### 3.1.7 Already-Installed Behavior
 
 If a package is already installed, `mip install` prints a message and skips it. It does **not** error. It does **not** reinstall or upgrade. Use `mip update` for that.
@@ -843,9 +845,15 @@ A potential middle ground: at install time, resolve bare-name deps using same-ch
 
 **Question**: Should there be a `mip update --recursive` or `mip update --all` that updates a package and all its dependencies?
 
-### 14.11 No Rollback on Failed Install
+### 14.11 Rollback on Failed Install
 
-**Current behavior**: If an install fails mid-way (e.g., download error), cleanup removes the partial directory. But if the package had dependencies that were installed as part of the same operation, those dependencies are not rolled back.
+**Current behavior**: If an install fails mid-way (e.g., download error), `downloadAndInstall` removes its own partial directory and `mip install` then runs `mip.utils.prune_unused_packages` to roll back any dependencies that were installed during the same call. The user-requested packages haven't been added to `directly_installed.txt` yet, so anything installed by this call that isn't already a directly-installed package or one of its needed dependencies is pruned as an orphan. The original install error is re-raised.
+
+**Resolved in [#100](https://github.com/mip-org/mip/issues/100)** by extracting `mip.utils.prune_unused_packages` (formerly a private helper inside `mip uninstall`) and reusing it from the install failure path.
+
+**Caveats**:
+- The rollback prune sweep also removes any *pre-existing* orphans (packages that were already on disk but not in `directly_installed.txt`). In practice this is fine -- those should have been pruned already -- but it's a minor side effect to be aware of.
+- If `mip.utils.prune_unused_packages` itself fails, a `mip:rollbackFailed` warning is printed and the original install error is still re-raised.
 
 ### 14.12 Empty `MIP_ROOT` Environment Variable
 

--- a/tests/TestUninstallPackage.m
+++ b/tests/TestUninstallPackage.m
@@ -153,5 +153,70 @@ classdef TestUninstallPackage < matlab.unittest.TestCase
             testCase.verifyTrue(result.is_fqn);
         end
 
+        %% --- prune_unused_packages utility (issue #100) ---
+
+        function testPruneRemovesOrphans(testCase)
+            % A package that is on disk but not in directly_installed.txt
+            % and not a dep of anything directly installed should be pruned.
+            orphanDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'orphan');
+
+            mip.utils.prune_unused_packages();
+
+            testCase.verifyFalse(exist(orphanDir, 'dir') > 0, ...
+                'Orphan should be pruned');
+        end
+
+        function testPrunePreservesDirectlyInstalled(testCase)
+            % A directly-installed package should never be pruned, even
+            % if nothing else references it.
+            keepDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'keep');
+            mip.utils.add_directly_installed('mip-org/core/keep');
+
+            mip.utils.prune_unused_packages();
+
+            testCase.verifyTrue(exist(keepDir, 'dir') > 0, ...
+                'Directly-installed package should be preserved');
+        end
+
+        function testPrunePreservesTransitiveDeps(testCase)
+            % A package reachable from a directly-installed package via
+            % its mip.json dependencies should be preserved.
+            parentDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'parent', ...
+                'dependencies', {'child'});
+            childDir  = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'child');
+            mip.utils.add_directly_installed('mip-org/core/parent');
+
+            mip.utils.prune_unused_packages();
+
+            testCase.verifyTrue(exist(parentDir, 'dir') > 0, ...
+                'Directly-installed parent should be preserved');
+            testCase.verifyTrue(exist(childDir, 'dir') > 0, ...
+                'Bare-name dep of directly-installed parent should be preserved');
+        end
+
+        function testPruneRemovesOrphanAlongsideDirectlyInstalled(testCase)
+            % Mixed state: a directly-installed package coexists with an
+            % orphan. Only the orphan is removed.
+            keepDir   = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'keep');
+            orphanDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'orphan');
+            mip.utils.add_directly_installed('mip-org/core/keep');
+
+            mip.utils.prune_unused_packages();
+
+            testCase.verifyTrue(exist(keepDir, 'dir') > 0);
+            testCase.verifyFalse(exist(orphanDir, 'dir') > 0);
+        end
+
+        function testPruneNeverRemovesMipItself(testCase)
+            % mip-org/core/mip is the package manager and must be exempt
+            % from pruning even when it isn't in directly_installed.txt.
+            mipDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'mip');
+
+            mip.utils.prune_unused_packages();
+
+            testCase.verifyTrue(exist(mipDir, 'dir') > 0, ...
+                'mip-org/core/mip must never be pruned');
+        end
+
     end
 end


### PR DESCRIPTION
## Summary

Resolves #100. If a multi-package install fails midway, the dependencies that already succeeded are now rolled back instead of being left as orphans. The implementation extracts the existing prune logic from \`mip uninstall\` into a shared utility and calls it from the install failure path.

## Behavior

- **Successful install**: unchanged.
- **Failed install (any package in the topological install loop fails)**: \`mip install\` runs \`mip.utils.prune_unused_packages\` and re-raises the original error. Because user-requested packages haven't been added to \`directly_installed.txt\` yet, anything installed by this call but not needed by an already-directly-installed package is pruned as an orphan.
- **\`.mhl\` install with remote deps that fails**: same path -- prune any orphans, re-raise.
- **\`mip uninstall\`**: unchanged behavior. The local \`pruneUnusedPackages\` was extracted, not changed.

## Changes

- New: [+mip/+utils/prune_unused_packages.m](+mip/+utils/prune_unused_packages.m) -- the prune logic, lifted from \`uninstall.m\`. The broken-dependency check stayed in \`uninstall.m\` because it's uninstall-specific.
- [+mip/uninstall.m](+mip/uninstall.m): replace local \`pruneUnusedPackages\` (and its \`getAllDependencies\` helper) with a call to the new utility, followed by \`checkForBrokenDependencies\` as before.
- [+mip/install.m](+mip/install.m): wrap the install loop in \`try/catch\`; on failure, call \`mip.utils.prune_unused_packages\` and re-raise. Same treatment for \`installFromMhl\`. If the prune itself fails, emit a \`mip:rollbackFailed\` warning and still re-raise the original error.
- [docs/behavior-reference.md](docs/behavior-reference.md):
  - §3.1.6 documents the new failure-path behavior.
  - §14.11 rewritten from open question to documented decision; notes the (mild) caveat that the prune sweep also removes any pre-existing orphans.
- [tests/TestUninstallPackage.m](tests/TestUninstallPackage.m): five new tests pinning the extracted utility:
  - removes orphans
  - preserves directly-installed packages
  - preserves transitive deps
  - mixed orphan + directly-installed state
  - never prunes \`mip-org/core/mip\`

I did not add an integration test that triggers a real failed-install rollback -- making the install loop fail at a controlled point would require a deliberately-broken test channel package or mocking, which is more effort than it's worth for this PR. The existing \`mip uninstall\` test suite plus the new direct unit tests cover the prune logic; the wiring in \`install.m\` is small enough to review by inspection.

## Test plan

- [x] \`runtests('TestUninstallPackage')\` -- 24/24 pass (19 existing + 5 new)
- [x] \`runtests('TestInstallLocal')\` -- 10/10 pass
- [x] \`runtests('TestInstallRemote')\` -- 13/13 pass