### PR TITLE
Make `mip install <bare>` always prefer channel over local dir

### DIFF
--- a/+mip/install.m
+++ b/+mip/install.m
@@ -21,9 +21,14 @@ function install(varargin)
 %   --no-compile        Skip compilation (editable installs only)
 %
 % Local packages:
-%   If the argument is a directory path containing a mip.yaml file,
-%   the package is installed locally. In editable mode, changes to
-%   the source directory are reflected immediately without reinstalling.
+%   To install a local directory, the path must start with '~', '.', or
+%   '/' (e.g. './mypkg', '/abs/path/mypkg'). The directory must contain
+%   a mip.yaml file. In editable mode, changes to the source directory
+%   are reflected immediately without reinstalling.
+%
+%   Bare names like 'chebfun' are always resolved against channels, even
+%   if a directory of the same name exists in the current folder. Use
+%   './chebfun' to force a local install.
 %
 % Packages can be specified by bare name or fully qualified name
 % (org/channel/package). Fully qualified names override the --channel flag.
@@ -58,28 +63,59 @@ function install(varargin)
         error('mip:install:noPackage', 'At least one package name is required for install command.');
     end
 
-    % Check if any argument is a local directory with mip.yaml
+    % Categorize each argument by how it should be installed:
+    %   - mhl source   (.mhl file or http(s) URL)
+    %   - local path   (starts with ~, ., or /)
+    %   - repo package (bare name or org/channel/package FQN)
+    % Anything else (e.g. 'foo/bar', 'a/b/c/d') is rejected with a hint
+    % about prefixing with './' for local installs.
+    mhlSources = {};
+    localPaths = {};
+    repoPackages = {};
     for i = 1:length(args)
-        pkg = args{i};
-        % Resolve '.' and relative paths
-        if isfolder(pkg)
-            mipYamlPath = fullfile(pkg, 'mip.yaml');
-            if isfile(mipYamlPath)
-                mip.utils.install_local(pkg, editable, noCompile);
-                return;
-            else
-                error('mip:install:noMipYaml', ...
-                      'Directory "%s" does not contain a mip.yaml file.', pkg);
+        pkg = char(args{i});
+        if endsWith(pkg, '.mhl') || startsWith(pkg, 'http://') || startsWith(pkg, 'https://')
+            mhlSources{end+1} = pkg; %#ok<*AGROW>
+        elseif startsWith(pkg, '~') || startsWith(pkg, '.') || startsWith(pkg, '/')
+            localPaths{end+1} = pkg;
+        else
+            parts = strsplit(pkg, '/');
+            if length(parts) ~= 1 && length(parts) ~= 3
+                error('mip:install:invalidPackageSpec', ...
+                      ['Invalid package specifier "%s".\n' ...
+                       'Use "package" for a bare name or "org/channel/package" for a fully qualified name.\n' ...
+                       'To install a local package, prefix the path with "./":\n' ...
+                       '  mip install ./%s'], pkg, pkg);
             end
+            repoPackages{end+1} = pkg;
         end
     end
 
-    if editable
+    if editable && isempty(localPaths)
         error('mip:install:editableRequiresLocal', ...
               '--editable can only be used with local directory packages.');
     end
 
-    packageNames = args;
+    % Process local directory installs first
+    for i = 1:length(localPaths)
+        localPath = localPaths{i};
+        if ~isfolder(localPath)
+            error('mip:install:notADirectory', ...
+                  '"%s" is not a directory.', localPath);
+        end
+        mipYamlPath = fullfile(localPath, 'mip.yaml');
+        if ~isfile(mipYamlPath)
+            error('mip:install:noMipYaml', ...
+                  'Directory "%s" does not contain a mip.yaml file.', localPath);
+        end
+        mip.utils.install_local(localPath, editable, noCompile);
+    end
+
+    % If only local installs were requested, we're done
+    if isempty(repoPackages) && isempty(mhlSources)
+        return;
+    end
+
     packagesDir = mip.utils.get_packages_dir();
 
     % Create packages directory if it doesn't exist
@@ -87,24 +123,23 @@ function install(varargin)
         mkdir(packagesDir);
     end
 
-    % Separate packages by type
-    repoPackages = {};
-    mhlSources = {};
-
-    for i = 1:length(packageNames)
-        pkg = packageNames{i};
-        if endsWith(pkg, '.mhl') || startsWith(pkg, 'http://') || startsWith(pkg, 'https://')
-            mhlSources = [mhlSources, {pkg}]; %#ok<*AGROW>
-        else
-            repoPackages = [repoPackages, {pkg}];
-        end
-    end
-
     % Handle repository packages
     installedFqns = {};
 
     if ~isempty(repoPackages)
-        installedFqns = [installedFqns, installFromRepository(repoPackages, packagesDir, channel)];
+        try
+            installedFqns = [installedFqns, installFromRepository(repoPackages, packagesDir, channel)];
+        catch ME
+            % If a repo install failed and one of the requested names also
+            % exists as a relative directory in the current folder, augment
+            % the error with a hint about prefixing with './'.
+            hint = buildLocalDirHint(repoPackages);
+            if ~isempty(hint)
+                wrapped = MException(ME.identifier, '%s\n\n%s', ME.message, hint);
+                throw(wrapped);
+            end
+            rethrow(ME);
+        end
     end
 
     % Handle .mhl file installations
@@ -511,4 +546,20 @@ function fetchChannelIndex(ch, packageInfoMap, unavailablePackages, fetchedChann
         unavailablePackages(chUnavailKeys{j}) = chUnavail(chUnavailKeys{j});
     end
     fetchedChannels(ch) = true;
+end
+
+function hint = buildLocalDirHint(repoPackages)
+% If any of the repo-style args also exists as a relative directory in
+% the current folder, build a hint suggesting the './' form.
+    lines = {};
+    for i = 1:length(repoPackages)
+        pkg = repoPackages{i};
+        if isfolder(pkg)
+            lines{end+1} = sprintf( ...
+                ['Note: a local directory "%s" exists in the current folder.\n' ...
+                 'To install it as a local package instead, run:\n' ...
+                 '  mip install ./%s'], pkg, pkg);
+        end
+    end
+    hint = strjoin(lines, sprintf('\n\n'));
 end

--- a/+mip/install.m
+++ b/+mip/install.m
@@ -21,10 +21,10 @@ function install(varargin)
 %   --no-compile        Skip compilation (editable installs only)
 %
 % Local packages:
-%   To install a local directory, the path must start with '~', '.', or
-%   '/' (e.g. './mypkg', '/abs/path/mypkg'). The directory must contain
-%   a mip.yaml file. In editable mode, changes to the source directory
-%   are reflected immediately without reinstalling.
+%   To install a local directory, the path must start with '~', '.', '/',
+%   or a Windows drive letter (e.g. 'C:\path\mypkg', 'C:/path/mypkg').
+%   The directory must contain a mip.yaml file. In editable mode, changes
+%   to the source directory are reflected immediately without reinstalling.
 %
 %   Bare names like 'chebfun' are always resolved against channels, even
 %   if a directory of the same name exists in the current folder. Use
@@ -65,7 +65,8 @@ function install(varargin)
 
     % Categorize each argument by how it should be installed:
     %   - mhl source   (.mhl file or http(s) URL)
-    %   - local path   (starts with ~, ., or /)
+    %   - local path   (starts with ~, ., /, or a Windows drive letter
+    %                   like C:\ or C:/)
     %   - repo package (bare name or org/channel/package FQN)
     % Anything else (e.g. 'foo/bar', 'a/b/c/d') is rejected with a hint
     % about prefixing with './' for local installs.
@@ -76,7 +77,7 @@ function install(varargin)
         pkg = char(args{i});
         if endsWith(pkg, '.mhl') || startsWith(pkg, 'http://') || startsWith(pkg, 'https://')
             mhlSources{end+1} = pkg; %#ok<*AGROW>
-        elseif startsWith(pkg, '~') || startsWith(pkg, '.') || startsWith(pkg, '/')
+        elseif isLocalPathArg(pkg)
             localPaths{end+1} = pkg;
         else
             parts = strsplit(pkg, '/');
@@ -546,6 +547,27 @@ function fetchChannelIndex(ch, packageInfoMap, unavailablePackages, fetchedChann
         unavailablePackages(chUnavailKeys{j}) = chUnavail(chUnavailKeys{j});
     end
     fetchedChannels(ch) = true;
+end
+
+function tf = isLocalPathArg(pkg)
+% Return true if pkg should be treated as a local directory path.
+% Recognizes:
+%   - POSIX-style paths starting with '~', '.', or '/'
+%   - Windows drive-letter paths like 'C:\foo' or 'C:/foo' (any letter)
+    tf = false;
+    if isempty(pkg)
+        return
+    end
+    if startsWith(pkg, '~') || startsWith(pkg, '.') || startsWith(pkg, '/')
+        tf = true;
+        return
+    end
+    % Windows drive-letter absolute path: <letter>:[\/]...
+    if length(pkg) >= 3 && isstrprop(pkg(1), 'alpha') && pkg(2) == ':' ...
+            && (pkg(3) == '\' || pkg(3) == '/')
+        tf = true;
+        return
+    end
 end
 
 function hint = buildLocalDirHint(repoPackages)

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -171,7 +171,7 @@ Used by: `mip install` for remote packages
 `mip install` accepts a mix of argument types in a single call. Each positional argument is categorized **before** any installation work happens:
 
 1. If the argument ends in `.mhl` or starts with `http://` / `https://`, it is an **mhl source** (see [§3.3](#33-installation-from-mhl-file)).
-2. Else if the argument starts with `~`, `.`, or `/`, it is a **local directory path** (see [§3.2](#32-local-installation)).
+2. Else if the argument starts with `~`, `.`, `/`, or a Windows drive letter followed by `:\` or `:/` (e.g. `C:\path\mypkg`, `D:/path/mypkg`), it is a **local directory path** (see [§3.2](#32-local-installation)).
 3. Else the argument must parse as a package spec — either a bare name (`pkg`) or a fully qualified name (`org/channel/pkg`). Anything with 2 or 4+ slash-separated parts (e.g. `foo/bar`, `a/b/c/d`) is rejected with `mip:install:invalidPackageSpec`. The error message hints at the `./` form for users who actually meant a local path.
 
 This means a bare name like `chebfun` is **always** treated as a channel install, even if a directory called `chebfun` happens to exist in the current folder. To install a local directory, the user must write `./chebfun`. This was decided in [#107](https://github.com/mip-org/mip/issues/107) to avoid the surprise of a local directory shadowing a channel package.
@@ -248,7 +248,7 @@ If a package is already installed, `mip install` prints a message and skips it. 
 
 ### 3.2 Local Installation
 
-An argument is treated as a local install only when it begins with `~`, `.`, or `/` (see [§3.0](#30-argument-categorization)). Examples: `./mypkg`, `../mypkg`, `.`, `~/proj/mypkg`, `/abs/path/mypkg`. The path must point to an existing directory containing a `mip.yaml` file:
+An argument is treated as a local install only when it begins with `~`, `.`, `/`, or a Windows drive letter followed by `:\` or `:/` (see [§3.0](#30-argument-categorization)). Examples: `./mypkg`, `../mypkg`, `.`, `~/proj/mypkg`, `/abs/path/mypkg`, `C:\path\mypkg`, `D:/path/mypkg`. The path must point to an existing directory containing a `mip.yaml` file:
 
 - If the path is not a directory, raises `mip:install:notADirectory`.
 - If the directory does not contain `mip.yaml`, raises `mip:install:noMipYaml`.

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -166,6 +166,20 @@ Used by: `mip install` for remote packages
 
 ## 3. Installation
 
+### 3.0 Argument Categorization
+
+`mip install` accepts a mix of argument types in a single call. Each positional argument is categorized **before** any installation work happens:
+
+1. If the argument ends in `.mhl` or starts with `http://` / `https://`, it is an **mhl source** (see [§3.3](#33-installation-from-mhl-file)).
+2. Else if the argument starts with `~`, `.`, or `/`, it is a **local directory path** (see [§3.2](#32-local-installation)).
+3. Else the argument must parse as a package spec — either a bare name (`pkg`) or a fully qualified name (`org/channel/pkg`). Anything with 2 or 4+ slash-separated parts (e.g. `foo/bar`, `a/b/c/d`) is rejected with `mip:install:invalidPackageSpec`. The error message hints at the `./` form for users who actually meant a local path.
+
+This means a bare name like `chebfun` is **always** treated as a channel install, even if a directory called `chebfun` happens to exist in the current folder. To install a local directory, the user must write `./chebfun`. This was decided in [#107](https://github.com/mip-org/mip/issues/107) to avoid the surprise of a local directory shadowing a channel package.
+
+If a channel install fails (e.g. `mip:packageNotFound`, `mip:indexFetchFailed`) and one of the requested names also exists as a relative directory in the current folder, the error message is augmented with a hint about prefixing with `./` so the user knows how to install it as a local package instead.
+
+The `--editable` / `-e` flag is only valid when at least one local path is present in the argument list. Using `-e` with only bare-name or FQN arguments raises `mip:install:editableRequiresLocal`.
+
 ### 3.1 Remote Installation (`mip install <package>`)
 
 #### 3.1.1 Channel Resolution
@@ -232,9 +246,14 @@ If a package is already installed, `mip install` prints a message and skips it. 
 
 `mip install pkg1 pkg2 pkg3` installs all listed packages and their combined dependencies in a single operation.
 
-### 3.2 Local Installation (`mip install <directory>`)
+### 3.2 Local Installation
 
-A directory argument is detected by checking `isfolder()`. The directory must contain a `mip.yaml` file, otherwise `mip:install:noMipYaml` is raised.
+An argument is treated as a local install only when it begins with `~`, `.`, or `/` (see [§3.0](#30-argument-categorization)). Examples: `./mypkg`, `../mypkg`, `.`, `~/proj/mypkg`, `/abs/path/mypkg`. The path must point to an existing directory containing a `mip.yaml` file:
+
+- If the path is not a directory, raises `mip:install:notADirectory`.
+- If the directory does not contain `mip.yaml`, raises `mip:install:noMipYaml`.
+
+Bare names without a path prefix are **never** dispatched to local install, even if a directory of the same name exists in the current folder ([§3.0](#30-argument-categorization), [#107](https://github.com/mip-org/mip/issues/107)).
 
 #### 3.2.1 Non-Editable (Copy) Install
 

--- a/tests/TestInstallLocal.m
+++ b/tests/TestInstallLocal.m
@@ -262,5 +262,30 @@ classdef TestInstallLocal < matlab.unittest.TestCase
                 'mip:install:editableRequiresLocal');
         end
 
+        function testInstall_WindowsDrivePathBackslashTreatedAsLocal(testCase)
+            % A Windows drive-letter path like 'C:\nonexistent' must be
+            % categorized as a local path, not a bare name. On non-Windows
+            % platforms it will fail with notADirectory rather than be
+            % parsed as a package spec.
+            testCase.verifyError(@() mip.install('C:\nonexistent_mip_pkg'), ...
+                'mip:install:notADirectory');
+        end
+
+        function testInstall_WindowsDrivePathForwardSlashTreatedAsLocal(testCase)
+            % Forward-slash form of a Windows drive path is also accepted.
+            % Without the drive-letter rule, 'C:/foo/bar' would have 3
+            % slash-separated parts and look like a (malformed) FQN.
+            testCase.verifyError(@() mip.install('D:/nonexistent/mip_pkg'), ...
+                'mip:install:notADirectory');
+        end
+
+        function testInstall_WindowsDrivePathRespectsEditableFlag(testCase)
+            % `-e C:\path` should be accepted as an editable local install
+            % attempt (and fail at the directory check, not the
+            % editableRequiresLocal check).
+            testCase.verifyError(@() mip.install('-e', 'C:\nonexistent_mip_pkg'), ...
+                'mip:install:notADirectory');
+        end
+
     end
 end

--- a/tests/TestInstallLocal.m
+++ b/tests/TestInstallLocal.m
@@ -214,5 +214,53 @@ classdef TestInstallLocal < matlab.unittest.TestCase
             testCase.verifyTrue(contains(info.source_path, testCase.SourceDir));
         end
 
+        %% --- Path-vs-name dispatch (issue #107) ---
+
+        function testInstall_TwoPartSpecRaisesInvalidPackageSpec(testCase)
+            % "foo/bar" is neither a bare name nor a FQN; it should be
+            % rejected with a parse error before any channel fetch.
+            testCase.verifyError(@() mip.install('foo/bar'), ...
+                'mip:install:invalidPackageSpec');
+        end
+
+        function testInstall_FourPartSpecRaisesInvalidPackageSpec(testCase)
+            testCase.verifyError(@() mip.install('a/b/c/d'), ...
+                'mip:install:invalidPackageSpec');
+        end
+
+        function testInstall_TwoPartSpecHintsAtSlashPrefix(testCase)
+            % The error message for an invalid spec should hint at './foo/bar'
+            % so the user knows how to install it as a local package.
+            try
+                mip.install('foo/bar');
+                testCase.verifyFail('Expected mip.install to error');
+            catch ME
+                testCase.verifyEqual(ME.identifier, 'mip:install:invalidPackageSpec');
+                testCase.verifyTrue(contains(ME.message, './foo/bar'), ...
+                    'Error message should hint at ./foo/bar');
+            end
+        end
+
+        function testInstall_RelativeDotPathInstallsLocally(testCase)
+            % A path starting with './' should be treated as a local install.
+            srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg');
+            origCwd = pwd;
+            cleanupCwd = onCleanup(@() cd(origCwd));
+            cd(testCase.SourceDir);
+
+            mip.install('./mypkg');
+
+            pkgDir = fullfile(testCase.TestRoot, 'packages', 'local', 'local', 'mypkg');
+            testCase.verifyTrue(exist(pkgDir, 'dir') > 0, ...
+                './mypkg should install locally');
+            testCase.verifyTrue(exist(srcDir, 'dir') > 0);
+        end
+
+        function testInstall_EditableRequiresLocalForBareName(testCase)
+            % `-e bare_name` should error since bare names are not local.
+            testCase.verifyError(@() mip.install('-e', 'somepkg'), ...
+                'mip:install:editableRequiresLocal');
+        end
+
     end
 end

--- a/tests/TestInstallRemote.m
+++ b/tests/TestInstallRemote.m
@@ -265,6 +265,67 @@ classdef TestInstallRemote < matlab.unittest.TestCase
                 'FQN beta should be installed from its own channel');
         end
 
+        %% --- Bare-name vs local directory dispatch (issue #107) ---
+
+        function testInstall_BareNamePrefersChannelOverLocalDir(testCase)
+            % If a directory with the same name exists in the cwd, a bare
+            % name should still install from the channel -- not as a local
+            % directory install.
+            scratch = [tempname '_mip_cwd'];
+            mkdir(scratch);
+            cleanupScratch = onCleanup(@() rmdir(scratch, 's'));
+            origCwd = pwd;
+            cleanupCwd = onCleanup(@() cd(origCwd));
+            cd(scratch);
+
+            % Create a local 'alpha/' directory with a valid mip.yaml that
+            % would otherwise have been picked up by the old behavior.
+            localAlpha = fullfile(scratch, 'alpha');
+            mkdir(localAlpha);
+            fid = fopen(fullfile(localAlpha, 'mip.yaml'), 'w');
+            fprintf(fid, 'name: alpha\nversion: "9.9.9"\naddpaths:\n  - path: "."\nbuilds:\n  - architectures: [any]\n');
+            fclose(fid);
+
+            mip.install('--channel', 'mip-org/test-channel1', 'alpha');
+
+            channelDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'alpha');
+            localPkgDir = fullfile(testCase.TestRoot, 'packages', ...
+                'local', 'local', 'alpha');
+
+            testCase.verifyTrue(exist(channelDir, 'dir') > 0, ...
+                'alpha should be installed from test-channel1');
+            testCase.verifyFalse(exist(localPkgDir, 'dir') > 0, ...
+                'alpha should NOT be installed as a local package');
+
+            % Keep cleanup objects alive until end of test
+            assert(isobject(cleanupScratch) && isobject(cleanupCwd));
+        end
+
+        function testInstall_BareNameFailureMentionsLocalDirHint(testCase)
+            % If the channel install fails AND a directory with the bare
+            % name exists in cwd, the error message should hint at './name'.
+            scratch = [tempname '_mip_cwd'];
+            mkdir(scratch);
+            cleanupScratch = onCleanup(@() rmdir(scratch, 's'));
+            origCwd = pwd;
+            cleanupCwd = onCleanup(@() cd(origCwd));
+            cd(scratch);
+
+            % Create a local 'no_such_pkg_xyz/' directory in cwd
+            mkdir(fullfile(scratch, 'no_such_pkg_xyz'));
+
+            try
+                mip.install('no_such_pkg_xyz');
+                testCase.verifyFail('Expected mip.install to fail');
+            catch ME
+                testCase.verifyTrue(contains(ME.message, './no_such_pkg_xyz'), ...
+                    'Error message should hint at ./no_such_pkg_xyz');
+            end
+
+            assert(isobject(cleanupScratch) && isobject(cleanupCwd));
+        end
+
     end
 
 end


### PR DESCRIPTION
Closes #107.

## Summary
- `mip install` now categorizes each argument up front: starts with `~`/`./`/`/` → local path; bare name or `org/channel/pkg` FQN → channel; anything with 2 or 4+ slash-separated parts is rejected with `mip:install:invalidPackageSpec` and a hint about prefixing with `./`.
- A bare name like `chebfun` always tries the channel, even if a `chebfun/` directory happens to exist in the current folder. To force a local install, the user must write `./chebfun`.
- If the channel install fails and one of the requested names also exists as a relative directory in cwd, the error message is augmented with a `./<name>` hint so the user knows how to install it as a local package instead.
- `--editable`/`-e` is now only valid when at least one local-path argument is present.

## Tests
- New offline tests in `TestInstallLocal.m` cover the parsing rules (length-2 / length-4+ rejection, `./mypkg` dispatch, `-e bare` rejection).
- New integration tests in `TestInstallRemote.m` verify that a colliding local `alpha/` directory does not shadow `mip-org/test-channel1/alpha`, and that a failing bare-name install surfaces the `./` hint when a same-named local directory exists.
- All 217 tests pass.

## Docs
- Added §3.0 *Argument Categorization* to `docs/behavior-reference.md` explaining the new dispatch rules.
- Updated §3.2 *Local Installation* to drop the old `isfolder()` wording.