### PR TITLE
Raise mip:loadError instead of marking failed load as loaded

### DIFF
--- a/+mip/load.m
+++ b/+mip/load.m
@@ -121,38 +121,41 @@ function loadSingle(packageArg, installIfMissing, stickyPackage, channel, isDire
         return
     end
 
-    % Check for mip.json and process dependencies
+    % Check for mip.json and process dependencies. Only the parse step is
+    % wrapped in try/catch so that recursive dependency-load errors propagate
+    % instead of being silently downgraded to a warning.
     mipJsonPath = fullfile(packageDir, 'mip.json');
+    mipConfig = [];
     if exist(mipJsonPath, 'file')
         try
             fid = fopen(mipJsonPath, 'r');
             jsonText = fread(fid, '*char')';
             fclose(fid);
             mipConfig = jsondecode(jsonText);
-
-            % Load dependencies first
-            if isfield(mipConfig, 'dependencies') && ~isempty(mipConfig.dependencies)
-                deps = mipConfig.dependencies;
-                if ~iscell(deps)
-                    deps = {deps};
-                end
-                fprintf('Loading dependencies for "%s": %s\n', ...
-                        fqn, strjoin(deps, ', '));
-                for i = 1:length(deps)
-                    dep = deps{i};
-                    % Resolve dependency: same channel first, then core
-                    depFqn = resolveDependency(dep, result.org, result.channel);
-                    if ~mip.utils.is_loaded(depFqn)
-                        loadSingle(depFqn, installIfMissing, false, channel, false, loadingStack);
-                    else
-                        fprintf('  Dependency "%s" is already loaded\n', depFqn);
-                    end
-                end
-            end
         catch ME
             warning('mip:jsonParseError', ...
                     'Could not parse mip.json for package "%s": %s', ...
                     fqn, ME.message);
+            mipConfig = [];
+        end
+    end
+
+    if ~isempty(mipConfig) && isfield(mipConfig, 'dependencies') && ~isempty(mipConfig.dependencies)
+        deps = mipConfig.dependencies;
+        if ~iscell(deps)
+            deps = {deps};
+        end
+        fprintf('Loading dependencies for "%s": %s\n', ...
+                fqn, strjoin(deps, ', '));
+        for i = 1:length(deps)
+            dep = deps{i};
+            % Resolve dependency: same channel first, then core
+            depFqn = resolveDependency(dep, result.org, result.channel);
+            if ~mip.utils.is_loaded(depFqn)
+                loadSingle(depFqn, installIfMissing, false, channel, false, loadingStack);
+            else
+                fprintf('  Dependency "%s" is already loaded\n', depFqn);
+            end
         end
     end
 
@@ -163,18 +166,24 @@ function loadSingle(packageArg, installIfMissing, stickyPackage, channel, isDire
               'Package "%s" does not have a load_package.m file', fqn);
     end
 
-    % Execute the load_package.m file
+    % Execute the load_package.m file. If it errors, the package is NOT
+    % marked as loaded, so the user can fix the issue and retry. We do not
+    % attempt to roll back any path or state changes that load_package.m
+    % may have made before failing -- doing so reliably is not possible.
     originalDir = pwd;
+    restoreDir = onCleanup(@() cd(originalDir));
     cd(packageDir);
     try
         run(loadFile);
-        fprintf('Loaded package "%s"\n', fqn);
     catch ME
-        warning('mip:loadError', ...
-                'Error executing load_package.m for package "%s": %s', ...
-                fqn, ME.message);
+        loadErr = MException('mip:loadError', ...
+            'Error executing load_package.m for package "%s": %s', ...
+            fqn, ME.message);
+        loadErr = addCause(loadErr, ME);
+        throw(loadErr);
     end
-    cd(originalDir);
+    clear restoreDir;
+    fprintf('Loaded package "%s"\n', fqn);
 
     % Mark package as loaded
     mip.utils.key_value_append('MIP_LOADED_PACKAGES', fqn);

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -341,7 +341,7 @@ After installation, a hint is printed showing how to load the package:
    - If `--sticky` is specified, add to sticky packages.
    - Return early.
 6. Read `mip.json` and load dependencies first (recursively, as non-direct loads).
-7. Execute `load_package.m` in the package directory (changes `pwd` temporarily).
+7. Execute `load_package.m` in the package directory (changes `pwd` temporarily). If it errors, raise `mip:loadError` and stop -- the package is **not** marked as loaded (see [§4.7](#47-load_packagem-execution)).
 8. Add to `MIP_LOADED_PACKAGES`.
 9. If this is a direct load, add to `MIP_DIRECTLY_LOADED_PACKAGES`.
 10. If `--sticky`, add to `MIP_STICKY_PACKAGES`.
@@ -377,7 +377,7 @@ A loading stack tracks the current dependency chain. If a package appears in its
 
 ### 4.6 Multiple Packages
 
-`mip load pkg1 pkg2 --sticky` loads all listed packages. Each is marked as directly loaded. The `--sticky` flag applies to all of them.
+`mip load pkg1 pkg2 --sticky` loads all listed packages. Each is marked as directly loaded. The `--sticky` flag applies to all of them. Packages are loaded in argument order; if any package errors, loading stops and remaining packages on the command line are not attempted.
 
 ### 4.7 `load_package.m` Execution
 
@@ -386,6 +386,8 @@ The load script is executed by `cd`-ing to the package directory and calling `ru
 - **Editable installs**: paths are absolute, pointing to the source directory.
 
 If `load_package.m` doesn't exist, raises `mip:loadNotFound`.
+
+If `load_package.m` throws during execution, the working directory is restored and `mip:loadError` is raised (with the original error attached as a cause). The package is **not** added to `MIP_LOADED_PACKAGES` or `MIP_DIRECTLY_LOADED_PACKAGES`, so the user can fix the issue and retry without first having to run `mip unload`. The error propagates up through dependency recursion, so a parent package whose dependency failed to load is also not marked as loaded. mip does **not** attempt to undo whatever the partially-executed `load_package.m` did to the path -- recovering arbitrary path or workspace mutations is not generally possible. Users should treat a `mip:loadError` as a signal that the path may be in a partial state and restart MATLAB if anything looks wrong.
 
 ---
 
@@ -763,6 +765,7 @@ The `numbl_wasm` tag serves as a fallback architecture for all `numbl_*` platfor
 | `mip:dependencyNotFound` | A dependency is not installed |
 | `mip:cannotUnloadMip` | Attempt to unload `mip-org/core/mip` |
 | `mip:loadNotFound` | `load_package.m` missing |
+| `mip:loadError` | `load_package.m` threw an error during execution |
 | `mip:mipYamlNotFound` | `mip.yaml` missing in source directory |
 | `mip:invalidMipYaml` | `mip.yaml` missing required `name` field |
 | `mip:mipJsonNotFound` | `mip.json` missing in package directory |
@@ -921,9 +924,7 @@ This behavior is intentional and was confirmed in [#103](https://github.com/mip-
 
 ### 14.17 `load_package.m` Error Handling
 
-**Current behavior**: If `load_package.m` throws an error during execution, a warning is printed (`mip:loadError`) but the package is still marked as loaded. This could leave the system in an inconsistent state where a package is "loaded" but its paths aren't actually on the MATLAB path.
-
-**Suggestion**: If `load_package.m` fails, the package should **not** be marked as loaded. Or at minimum, the error should be surfaced more prominently.
+**Resolved in [#104](https://github.com/mip-org/mip/issues/104)**: A failing `load_package.m` now raises `mip:loadError` and the package is **not** marked as loaded, so the user can fix the script and retry. See [§4.7](#47-load_packagem-execution) for the full semantics. mip does not attempt to roll back any path mutations the partial run may have made -- recovering them in general is not feasible. The original error is attached as a cause on the `mip:loadError` MException.
 
 ### 14.18 `--channel` Flag Interaction with FQN
 

--- a/tests/TestLoadPackage.m
+++ b/tests/TestLoadPackage.m
@@ -169,5 +169,79 @@ classdef TestLoadPackage < matlab.unittest.TestCase
             testCase.verifyTrue(mip.utils.is_loaded('mip-org/core/pkgB'));
         end
 
+        function testLoadPackage_LoadScriptError_Throws(testCase)
+            % If load_package.m errors, mip.load should throw mip:loadError.
+            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'badpkg');
+            writeFailingLoadScript(fullfile(pkgDir, 'load_package.m'));
+            testCase.verifyError(@() mip.load('mip-org/core/badpkg'), 'mip:loadError');
+        end
+
+        function testLoadPackage_LoadScriptError_NotMarkedLoaded(testCase)
+            % After a failed load, the package must not be marked as loaded.
+            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'badpkg');
+            writeFailingLoadScript(fullfile(pkgDir, 'load_package.m'));
+            try
+                mip.load('mip-org/core/badpkg');
+            catch
+                % expected
+            end
+            testCase.verifyFalse(mip.utils.is_loaded('mip-org/core/badpkg'));
+            testCase.verifyFalse(mip.utils.is_directly_loaded('mip-org/core/badpkg'));
+        end
+
+        function testLoadPackage_LoadScriptError_CanRetry(testCase)
+            % After a failed load, fixing the script and reloading should work.
+            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'badpkg');
+            loadScript = fullfile(pkgDir, 'load_package.m');
+            writeFailingLoadScript(loadScript);
+            try
+                mip.load('mip-org/core/badpkg');
+            catch
+                % expected
+            end
+            % Replace with a working load_package.m and retry
+            fid = fopen(loadScript, 'w');
+            fprintf(fid, 'function load_package()\n');
+            fprintf(fid, '    pkg_dir = fileparts(mfilename(''fullpath''));\n');
+            fprintf(fid, '    addpath(pkg_dir);\n');
+            fprintf(fid, 'end\n');
+            fclose(fid);
+            mip.load('mip-org/core/badpkg');
+            testCase.verifyTrue(mip.utils.is_loaded('mip-org/core/badpkg'));
+        end
+
+        function testLoadPackage_LoadScriptError_RestoresWorkingDir(testCase)
+            % A failing load_package.m must not leave pwd inside the package dir.
+            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'badpkg');
+            writeFailingLoadScript(fullfile(pkgDir, 'load_package.m'));
+            origDir = pwd;
+            try
+                mip.load('mip-org/core/badpkg');
+            catch
+                % expected
+            end
+            testCase.verifyEqual(pwd, origDir);
+        end
+
+        function testLoadPackage_DependencyLoadError_ParentNotLoaded(testCase)
+            % If a dependency fails to load, the parent must also not be marked loaded.
+            depDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'baddep');
+            writeFailingLoadScript(fullfile(depDir, 'load_package.m'));
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'mainpkg', ...
+                'dependencies', {'baddep'});
+            testCase.verifyError(@() mip.load('mip-org/core/mainpkg'), 'mip:loadError');
+            testCase.verifyFalse(mip.utils.is_loaded('mip-org/core/mainpkg'));
+            testCase.verifyFalse(mip.utils.is_loaded('mip-org/core/baddep'));
+        end
+
     end
+end
+
+function writeFailingLoadScript(scriptPath)
+%WRITEFAILINGLOADSCRIPT   Overwrite a load_package.m so that it errors.
+    fid = fopen(scriptPath, 'w');
+    fprintf(fid, 'function load_package()\n');
+    fprintf(fid, '    error(''test:loadFailed'', ''intentional load failure'');\n');
+    fprintf(fid, 'end\n');
+    fclose(fid);
 end


### PR DESCRIPTION
## Summary

- If `load_package.m` errors, `mip.load` now raises `mip:loadError` (original error attached as cause) and the package is **not** added to `MIP_LOADED_PACKAGES` / `MIP_DIRECTLY_LOADED_PACKAGES`, so the user can fix the script and retry without first running `mip unload`.
- The error propagates through dependency recursion: a parent whose dependency failed to load is also not marked as loaded.
- The `mip.json` read is now wrapped in its own narrow try/catch so a parse failure still degrades to a warning, but recursive `loadSingle` calls are no longer silently swallowed by that catch.
- We do **not** attempt to roll back path mutations a partially-executed `load_package.m` may have made -- that is not generally feasible. The new docs call this out explicitly.

Behavior reference updated in §4.1, §4.6, §4.7, §13, and §14.17 (resolved). New tests in `TestLoadPackage` cover: error is thrown, package is not marked loaded, retry works, working directory is restored, and parent-not-loaded when a dependency fails.

Closes #104.