### PR TITLE
mip update uses uninstall+install for remote packages

### DIFF
--- a/+mip/update.m
+++ b/+mip/update.m
@@ -11,12 +11,23 @@ function update(varargin)
 % Options:
 %   --force           Force update even if already up to date
 %
-% For remote packages, checks whether the installed version (and commit
-% hash) matches the latest in the channel index. If already up to date,
-% does nothing (unless --force is used).
+% For each requested package, checks whether an update is needed. For
+% remote packages, the installed version (and commit hash) is compared
+% against the latest in the channel index. Local packages are always
+% considered to need an update. If a package does not need updating,
+% nothing happens for that package (unless --force is specified).
 %
-% For local packages (installed from a local directory), always reinstalls
-% from the original source directory.
+% For the remote packages that need updating, `mip update X Y Z` is
+% equivalent to `mip uninstall X Y Z` followed by `mip install X Y Z`.
+% This re-resolves each package's dependency graph against the current
+% channel index, so dependencies are effectively updated as well.
+%
+% Local packages are reinstalled directly from their source path without
+% going through uninstall (since install_local cannot re-fetch deps from
+% a channel).
+%
+% Any packages that were loaded before the update are reloaded afterward,
+% even if they were pruned as unused during the uninstall step.
 %
 % Accepts both bare package names and fully qualified names.
 
@@ -40,14 +51,110 @@ function update(varargin)
         error('mip:update:noPackage', 'At least one package name is required for update command.');
     end
 
+    % Resolve and validate each argument. Any error here (not installed,
+    % missing source_path, missing source dir) is raised before we touch
+    % anything on disk.
+    toProcess = cell(1, length(args));
     for i = 1:length(args)
-        updateSinglePackage(args{i}, force);
+        toProcess{i} = resolvePackage(args{i});
     end
+
+    % Handle self-update (`mip-org/core/mip`) separately and remove it
+    % from the batch. mip cannot be uninstalled through the normal flow.
+    keepMask = true(1, length(toProcess));
+    for i = 1:length(toProcess)
+        if strcmp(toProcess{i}.fqn, 'mip-org/core/mip')
+            updateSelf(toProcess{i}, force);
+            keepMask(i) = false;
+        end
+    end
+    toProcess = toProcess(keepMask);
+    if isempty(toProcess)
+        return
+    end
+
+    % Determine which of the remaining packages actually need updating.
+    needsUpdate = false(1, length(toProcess));
+    for i = 1:length(toProcess)
+        p = toProcess{i};
+        if force
+            fprintf('Force updating "%s" (%s)\n', p.fqn, p.pkgInfo.version);
+            needsUpdate(i) = true;
+        elseif p.isLocal
+            % Local packages are always reinstalled from source.
+            needsUpdate(i) = true;
+        else
+            needsUpdate(i) = checkRemoteNeedsUpdate(p);
+        end
+    end
+    toProcess = toProcess(needsUpdate);
+
+    if isempty(toProcess)
+        return
+    end
+
+    % Split into local and remote sets
+    localPkgs = {};
+    remotePkgs = {};
+    for i = 1:length(toProcess)
+        if toProcess{i}.isLocal
+            localPkgs{end+1} = toProcess{i}; %#ok<AGROW>
+        else
+            remotePkgs{end+1} = toProcess{i}; %#ok<AGROW>
+        end
+    end
+
+    % Snapshot currently-loaded state so we can restore it after the
+    % update cycle. We remember both the full loaded list (so transitive
+    % deps that get pruned can be re-loaded) and the directly-loaded
+    % list (so we can preserve the direct-vs-transitive distinction).
+    loadedBefore = mip.utils.key_value_get('MIP_LOADED_PACKAGES');
+    directlyLoadedBefore = mip.utils.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
+
+    % --- Local packages: rmdir + install_local (no mip.uninstall) ---
+    % Local packages cannot go through mip.uninstall because that prunes
+    % orphaned deps, and install_local cannot re-fetch them from a channel.
+    for i = 1:length(localPkgs)
+        p = localPkgs{i};
+        fprintf('Updating local package "%s"...\n', p.fqn);
+
+        if mip.utils.is_loaded(p.fqn)
+            fprintf('Unloading "%s" before update...\n', p.fqn);
+            mip.unload(p.fqn);
+        end
+
+        rmdir(p.pkgDir, 's');
+        mip.utils.remove_directly_installed(p.fqn);
+        packagesDir = mip.utils.get_packages_dir();
+        cleanupEmptyDirs(fullfile(packagesDir, 'local', 'local'));
+        cleanupEmptyDirs(fullfile(packagesDir, 'local'));
+
+        fprintf('Reinstalling "%s" from %s...\n', p.fqn, p.sourcePath);
+        mip.utils.install_local(p.sourcePath, p.editable);
+    end
+
+    % --- Remote packages: mip.uninstall + mip.install ---
+    % The uninstall prunes orphaned deps; the install re-resolves the
+    % full dependency graph from the current channel index.
+    if ~isempty(remotePkgs)
+        remoteFqns = cellfun(@(p) p.fqn, remotePkgs, 'UniformOutput', false);
+        fprintf('\nUninstalling %d remote package(s) to update: %s\n', ...
+                length(remoteFqns), strjoin(remoteFqns, ', '));
+        mip.uninstall(remoteFqns{:});
+
+        fprintf('\nReinstalling remote package(s): %s\n', strjoin(remoteFqns, ', '));
+        mip.install(remoteFqns{:});
+    end
+
+    % Reload anything that was loaded before update but isn't now.
+    reloadPreviouslyLoaded(loadedBefore, directlyLoadedBefore);
 end
 
-function updateSinglePackage(packageArg, force)
+function p = resolvePackage(packageArg)
+% Resolve a package argument to a struct with everything needed to
+% update it. Validates that the package is installed and, for local
+% packages, that the original source directory is still available.
 
-    % Resolve the package to its FQN
     result = mip.utils.parse_package_arg(packageArg);
 
     if result.is_fqn
@@ -56,7 +163,6 @@ function updateSinglePackage(packageArg, force)
         packageName = result.name;
         fqn = packageArg;
     else
-        % Bare name: find it among installed packages
         fqn = mip.utils.resolve_bare_name(result.name);
         if isempty(fqn)
             error('mip:update:notInstalled', ...
@@ -70,161 +176,155 @@ function updateSinglePackage(packageArg, force)
     end
 
     pkgDir = mip.utils.get_package_dir(org, channelName, packageName);
-
-    % Check if package is installed
     if ~exist(pkgDir, 'dir')
         error('mip:update:notInstalled', ...
               'Package "%s" is not installed. Run "mip install %s" first.', ...
               fqn, fqn);
     end
 
-    % Read installed package info
     try
         pkgInfo = mip.utils.read_package_json(pkgDir);
     catch
         pkgInfo = struct('version', 'unknown', 'name', packageName);
     end
 
-    % Determine if this is a local package
     isLocal = strcmp(org, 'local') && strcmp(channelName, 'local');
-
-    % Self-update: keep special handling (cannot uninstall mip)
-    if strcmp(fqn, 'mip-org/core/mip')
-        updateSelf(fqn, pkgDir, pkgInfo, force);
-        return
-    end
-
+    sourcePath = '';
+    editable = false;
     if isLocal
-        updateLocalPackage(fqn, pkgDir, pkgInfo);
-    else
-        updateRemotePackage(fqn, org, channelName, packageName, pkgDir, pkgInfo, force);
+        % Validate local requirements up front so we fail before any
+        % destructive action.
+        if ~isfield(pkgInfo, 'source_path')
+            error('mip:update:noSourcePath', ...
+                  'Local package "%s" does not have a source_path in mip.json. Cannot update.', fqn);
+        end
+        sourcePath = pkgInfo.source_path;
+        if ~isfolder(sourcePath)
+            error('mip:update:sourceNotFound', ...
+                  'Source directory "%s" for package "%s" no longer exists.', sourcePath, fqn);
+        end
+        editable = isfield(pkgInfo, 'editable') && pkgInfo.editable;
     end
+
+    p = struct( ...
+        'fqn', fqn, ...
+        'org', org, ...
+        'channel', channelName, ...
+        'name', packageName, ...
+        'pkgDir', pkgDir, ...
+        'pkgInfo', pkgInfo, ...
+        'isLocal', isLocal, ...
+        'sourcePath', sourcePath, ...
+        'editable', editable ...
+    );
 end
 
-function updateRemotePackage(fqn, org, channelName, packageName, pkgDir, pkgInfo, force)
-    installedVersion = pkgInfo.version;
-    channelStr = [org '/' channelName];
+function tf = checkRemoteNeedsUpdate(p)
+% Fetch the channel index and decide whether p needs updating.
+
+    fqn = p.fqn;
+    installedVersion = p.pkgInfo.version;
+    channelStr = [p.org '/' p.channel];
 
     fprintf('Checking for updates to "%s" (installed: %s, channel: %s)...\n', ...
             fqn, installedVersion, channelStr);
 
-    % Fetch the index
     index = mip.utils.fetch_index(channelStr);
-    [packageInfoMap, unavailablePackages] = mip.utils.build_package_info_map(index, org, channelName);
+    [packageInfoMap, unavailablePackages] = mip.utils.build_package_info_map(index, p.org, p.channel);
 
-    % Find the package in the index
     currentArch = mip.arch();
     if ~packageInfoMap.isKey(fqn)
         if unavailablePackages.isKey(fqn)
             archs = unavailablePackages(fqn);
             error('mip:update:unavailable', ...
                   'Package "%s" is not available for architecture "%s". Available: %s', ...
-                  packageName, currentArch, strjoin(archs, ', '));
+                  p.name, currentArch, strjoin(archs, ', '));
         else
             error('mip:update:notInIndex', ...
                   'Package "%s" not found in the %s channel index.', ...
-                  packageName, channelStr);
+                  p.name, channelStr);
         end
     end
 
     latestInfo = packageInfoMap(fqn);
     latestVersion = latestInfo.version;
 
-    % Check if up to date (version + commit hash)
-    if ~force
-        if strcmp(installedVersion, latestVersion)
-            installedHash = '';
-            if isfield(pkgInfo, 'commit_hash')
-                installedHash = pkgInfo.commit_hash;
-            end
-            latestHash = '';
-            if isfield(latestInfo, 'commit_hash')
-                latestHash = latestInfo.commit_hash;
-            end
-
-            if isempty(latestHash) || strcmp(installedHash, latestHash)
-                fprintf('Package "%s" is already up to date (%s)\n', fqn, installedVersion);
-                return
-            end
-
-            fprintf('Version is "%s" but commit hash has changed (%s -> %s)\n', ...
-                    installedVersion, installedHash, latestHash);
+    if strcmp(installedVersion, latestVersion)
+        installedHash = '';
+        if isfield(p.pkgInfo, 'commit_hash')
+            installedHash = p.pkgInfo.commit_hash;
         end
-    else
-        fprintf('Force updating "%s" (%s)\n', fqn, installedVersion);
+        latestHash = '';
+        if isfield(latestInfo, 'commit_hash')
+            latestHash = latestInfo.commit_hash;
+        end
+
+        if isempty(latestHash) || strcmp(installedHash, latestHash)
+            fprintf('Package "%s" is already up to date (%s)\n', fqn, installedVersion);
+            tf = false;
+            return
+        end
+
+        fprintf('Version is "%s" but commit hash has changed (%s -> %s)\n', ...
+                installedVersion, installedHash, latestHash);
     end
 
     fprintf('Updating "%s": %s -> %s\n', fqn, installedVersion, latestVersion);
-
-    % Note if loaded, then unload
-    wasLoaded = mip.utils.is_loaded(fqn);
-    if wasLoaded
-        fprintf('Unloading "%s" before update...\n', fqn);
-        mip.unload(fqn);
-    end
-
-    % Remove old package
-    rmdir(pkgDir, 's');
-    mip.utils.remove_directly_installed(fqn);
-    cleanupEmptyDirs(fullfile(mip.utils.get_packages_dir(), org, channelName));
-    cleanupEmptyDirs(fullfile(mip.utils.get_packages_dir(), org));
-
-    % Install fresh
-    fprintf('Reinstalling "%s"...\n', fqn);
-    mip.install(fqn);
-
-    % Reload if was loaded
-    if wasLoaded
-        fprintf('Reloading "%s"...\n', fqn);
-        mip.load(fqn);
-    end
+    tf = true;
 end
 
-function updateLocalPackage(fqn, pkgDir, pkgInfo)
-    % Local packages always reinstall from source
-    fprintf('Updating local package "%s"...\n', fqn);
+function reloadPreviouslyLoaded(loadedBefore, directlyLoadedBefore)
+% Reload any packages that were loaded before the update but are no
+% longer loaded. Preserves the direct-vs-transitive loaded distinction
+% by resetting MIP_DIRECTLY_LOADED_PACKAGES to the pre-update snapshot
+% at the end (filtered to entries that are actually loaded now).
 
-    % Get source path and editable flag from mip.json
-    if ~isfield(pkgInfo, 'source_path')
-        error('mip:update:noSourcePath', ...
-              'Local package "%s" does not have a source_path in mip.json. Cannot update.', fqn);
-    end
-    sourcePath = pkgInfo.source_path;
-    isEditable = isfield(pkgInfo, 'editable') && pkgInfo.editable;
-
-    % Check source directory still exists
-    if ~isfolder(sourcePath)
-        error('mip:update:sourceNotFound', ...
-              'Source directory "%s" for package "%s" no longer exists.', sourcePath, fqn);
+    if isempty(loadedBefore)
+        return
     end
 
-    % Note if loaded, then unload
-    wasLoaded = mip.utils.is_loaded(fqn);
-    if wasLoaded
-        fprintf('Unloading "%s" before update...\n', fqn);
-        mip.unload(fqn);
+    for i = 1:length(loadedBefore)
+        pkg = loadedBefore{i};
+        if mip.utils.is_loaded(pkg)
+            continue
+        end
+        r = mip.utils.parse_package_arg(pkg);
+        if ~r.is_fqn
+            continue
+        end
+        pkgDir = mip.utils.get_package_dir(r.org, r.channel, r.name);
+        if ~exist(pkgDir, 'dir')
+            fprintf('Warning: "%s" was loaded before update but is no longer installed; skipping reload.\n', pkg);
+            continue
+        end
+        fprintf('Reloading "%s"...\n', pkg);
+        mip.load(pkg);
     end
 
-    % Remove old package
-    rmdir(pkgDir, 's');
-    mip.utils.remove_directly_installed(fqn);
-    packagesDir = mip.utils.get_packages_dir();
-    cleanupEmptyDirs(fullfile(packagesDir, 'local', 'local'));
-    cleanupEmptyDirs(fullfile(packagesDir, 'local'));
-
-    % Reinstall from source
-    mip.utils.install_local(sourcePath, isEditable);
-
-    % Reload if was loaded
-    if wasLoaded
-        fprintf('Reloading "%s"...\n', fqn);
-        mip.load(fqn);
+    % Restore the directly-loaded snapshot. The bulk reload above may
+    % have marked formerly-transitively-loaded packages as directly
+    % loaded (since mip.load is always a direct call). Reset the state
+    % so only the packages that were directly loaded before -- and that
+    % are still loaded now -- are marked as directly loaded.
+    currentlyLoaded = mip.utils.key_value_get('MIP_LOADED_PACKAGES');
+    desiredDirectly = {};
+    for i = 1:length(directlyLoadedBefore)
+        pkg = directlyLoadedBefore{i};
+        if ismember(pkg, currentlyLoaded)
+            desiredDirectly{end+1} = pkg; %#ok<AGROW>
+        end
     end
+    mip.utils.key_value_set('MIP_DIRECTLY_LOADED_PACKAGES', desiredDirectly);
 end
 
-function updateSelf(fqn, pkgDir, pkgInfo, force)
-    % Self-update for mip-org/core/mip
-    % Special handling: download and swap in place, then reload.
+function updateSelf(p, force)
+% Self-update for mip-org/core/mip. mip cannot be uninstalled through
+% the normal flow, so we download and swap in place.
+
+    fqn = p.fqn;
+    pkgDir = p.pkgDir;
+    pkgInfo = p.pkgInfo;
+
     installedVersion = pkgInfo.version;
     channelStr = 'mip-org/core';
 
@@ -240,7 +340,6 @@ function updateSelf(fqn, pkgDir, pkgInfo, force)
     latestInfo = packageInfoMap(fqn);
     latestVersion = latestInfo.version;
 
-    % Check if up to date
     if ~force
         if strcmp(installedVersion, latestVersion)
             installedHash = '';

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -26,11 +26,13 @@ Versions are either **numeric** (e.g., `1.2.3`) or **non-numeric** (e.g., `main`
 
 ### 1.4 The `@version` Suffix
 
-Any package argument (bare or FQN) can include `@version` to pin a specific version:
+Any package argument passed to a `mip` command (bare or FQN) can include `@version` to pin a specific version:
 - `chebfun@1.2.0`
 - `mip-org/core/mip@main`
 
 The `@` is parsed from the last occurrence in the string. The version suffix is stripped before resolving the package identity.
+
+The `@version` suffix applies **only** to command-line package arguments. It is not supported inside the `dependencies` field of `mip.yaml` -- dependency entries are plain package names (bare or FQN) with no version or version-constraint grammar. See [§14.2](#142-no-version-constraints-on-dependencies).
 
 ### 1.5 Channels
 
@@ -493,38 +495,40 @@ Using an FQN bypasses this check entirely.
 
 ## 7. Updating
 
-### 7.1 Remote Package Update (`mip update <package>`)
+`mip update X Y Z` is, for the packages that actually need updating, equivalent to `mip uninstall X Y Z` followed by `mip install X Y Z`, with the set of previously-loaded packages reloaded at the end. This means each updated package's dependency graph is re-resolved against the current channel index, so dependencies are effectively updated as a side-effect of updating the packages that depend on them. Packages that do **not** need updating are left entirely alone (their dependencies are **not** revisited) unless `--force` is specified.
 
-1. Resolve to FQN (bare name uses `resolve_bare_name`).
-2. Check the package is installed. If not, raises `mip:update:notInstalled`.
-3. Fetch the channel index.
-4. Compare installed version + commit hash with latest in index:
-   - Same version **and** same commit hash (or no hash available): "already up to date", return.
-   - Same version but different commit hash: update (content changed within the same version).
-   - Different version: update.
-5. If updating:
-   - Note whether the package is currently loaded.
-   - Unload if loaded.
-   - Delete the old package directory.
-   - Remove from `directly_installed.txt`.
-   - Clean up empty parent directories.
-   - Reinstall via `mip install <fqn>`.
-   - Reload if it was previously loaded.
+### 7.1 Update Flow (`mip update X Y Z`)
+
+1. Parse `--force` flag.
+2. Resolve each argument to a `(fqn, org, channel, name, pkgDir, pkgInfo, isLocal, sourcePath, editable)` tuple. Validation errors are raised **before** any destructive action:
+   - Not installed → `mip:update:notInstalled`.
+   - Local package without `source_path` in `mip.json` → `mip:update:noSourcePath`.
+   - Local package whose source directory is missing → `mip:update:sourceNotFound`.
+3. If `mip-org/core/mip` is among the arguments, handle it via the self-update flow ([§7.4](#74-self-update-mip-update-mip)) and remove it from the batch.
+4. For each remaining package, decide whether it needs updating:
+   - `--force`: always yes.
+   - Local package: always yes (no up-to-date check).
+   - Remote package: fetch the channel index and compare installed version + commit hash with latest:
+     - Same version **and** same commit hash (or no hash available): "already up to date", skip.
+     - Same version but different commit hash: update (content changed within the same version).
+     - Different version: update.
+5. If no packages need updating, return. Otherwise:
+   - Snapshot `MIP_LOADED_PACKAGES` and `MIP_DIRECTLY_LOADED_PACKAGES`.
+   - **Local packages** are updated in-place: unload if loaded, `rmdir` the old directory, `remove_directly_installed`, then `mip.utils.install_local(sourcePath, editable)`. They do **not** go through `mip.uninstall` because the prune step would remove their deps, which `install_local` cannot re-fetch from a channel.
+   - **Remote packages** go through `mip.uninstall(fqn1, fqn2, ...)` which unloads them, removes them from disk, removes them from `directly_installed.txt`, and prunes any orphaned transitive dependencies. Then `mip.install(remoteFqn1, remoteFqn2, ...)` reinstalls them with freshly-resolved dependency graphs.
+   - Reload every package in the pre-update `MIP_LOADED_PACKAGES` snapshot that is not currently loaded and whose directory exists. Packages that were in the snapshot but are no longer installed are skipped with a warning.
+   - Restore `MIP_DIRECTLY_LOADED_PACKAGES` to the pre-update snapshot (filtered to entries that are actually loaded now) so that packages which were only transitively loaded before the update remain only transitively loaded after.
 
 ### 7.2 Local Package Update
 
-1. Read `source_path` from `mip.json`. If absent, raises `mip:update:noSourcePath`.
-2. Check the source directory still exists. If not, raises `mip:update:sourceNotFound`.
-3. Note whether loaded.
-4. Remove old package directory.
-5. Reinstall from source (preserving editable/non-editable mode).
-6. Reload if it was previously loaded.
+Local packages do **not** go through `mip.uninstall` + `mip.install`. Instead, the old package directory is removed directly and `mip.utils.install_local` is called with the original `source_path` and `editable` flag from `mip.json`. This avoids pruning transitive dependencies that `install_local` cannot re-fetch.
 
-Local updates **always** reinstall (no up-to-date check). Timestamps change on every update. For editable installs the `compile_script` runs again on every update; the `--no-compile` flag from the original install is **not** preserved. See [§14.16](#1416-mip-update-on-local-package-always-reinstalls).
+- The up-to-date check is skipped -- local packages are always reinstalled.
+- Timestamps change on every update. For editable installs the `compile_script` runs again on every update; the `--no-compile` flag from the original install is **not** preserved. See [§14.16](#1416-mip-update-on-local-package-always-reinstalls).
 
 ### 7.3 Force Update (`--force`)
 
-Skips the up-to-date check. For remote packages, this causes a full re-download and reinstall even when version and commit hash match.
+Skips the up-to-date check. For remote packages, this forces the full `mip.uninstall` + `mip.install` cycle even when version and commit hash match, causing a fresh dependency resolution against the channel index. This is the way to "update the dependencies" of a package that is itself already up to date (see [§7.6](#76-dependency-updates)). Local packages are always reinstalled regardless of `--force`.
 
 ### 7.4 Self-Update (`mip update mip`)
 
@@ -534,16 +538,22 @@ Special flow for `mip-org/core/mip`:
 3. Replace the installed package in-place.
 4. Re-run `load_package.m` to reload.
 
-Does not go through the normal unload/reinstall flow since mip cannot be unloaded.
+Does not go through the normal uninstall/reinstall flow since mip cannot be uninstalled. Self-update runs before the batch uninstall/install so it is safe to pass `mip` in the same call as other packages.
 
 ### 7.5 Load State Preservation
 
-- If the package was loaded before update, it is unloaded, updated, then reloaded.
-- If it was not loaded, it stays unloaded after update.
+- Packages that were loaded before the update are reloaded afterward, including transitive dependencies that got pruned as unused during the uninstall step and then brought back by the reinstall.
+- Packages that were not loaded before the update remain unloaded afterward.
+- The directly-vs-transitively loaded distinction is preserved: a package that was only transitively loaded before the update is not promoted to directly loaded, even if it needed an explicit `mip.load` call during the reload pass.
+- If a previously-loaded package ends up uninstalled after the update (e.g. it was a transitive dep of the old version but not the new one), it is skipped with a warning; its entry is effectively dropped from the loaded set.
 
-### 7.6 Directly Installed Tracking
+### 7.6 Dependency Updates
 
-The `directly_installed.txt` status is preserved across updates. The package is removed during cleanup and re-added during reinstall.
+Dependencies are updated only as a side-effect of updating a package that depends on them. `mip update foo` does **not** check whether `foo`'s dependencies have newer versions in the channel index. If `foo` itself is up to date, nothing happens; its dependencies are left alone. If `foo` needs an update, the uninstall+install cycle re-resolves the full dependency graph and pulls in whatever the channel currently has. `mip update --force foo` forces the uninstall+install cycle even when `foo` is up to date, which is the way to refresh `foo`'s dependencies from the channel index.
+
+### 7.7 Directly Installed Tracking
+
+The `directly_installed.txt` entry for each updated package is preserved across the update: `mip.uninstall` removes it and `mip.install` adds it back. Packages that were only transitive dependencies (not directly installed) before the update remain transitive dependencies after the update.
 
 ---
 
@@ -683,7 +693,7 @@ This tracking is critical for dependency pruning: only directly installed packag
   "version": "1.0.0",
   "description": "...",
   "architecture": "linux_x86_64",
-  "dependencies": ["dep1", "org/chan/dep2"],
+  "dependencies": ["dep1", "org/chan/dep2"],   // bare or FQN names only; no @version or constraints
   "editable": false,
   "source_path": "/path/to/source",
   "compile_script": "do_compile.m",
@@ -704,7 +714,7 @@ description: "..."              # Optional
 license: MIT                    # Optional
 homepage: "https://..."         # Optional
 repository: "https://..."       # Optional
-dependencies: [dep1, dep2]      # Optional (defaults to [])
+dependencies: [dep1, dep2]      # Optional (defaults to []); bare or FQN names only, no @version or constraints
 addpaths:                       # Optional (defaults to [])
   - path: "src"
   - path: "lib"
@@ -816,14 +826,13 @@ This means a package could be installed with dependencies resolved one way, but 
 
 A potential middle ground: at install time, resolve bare-name deps using same-channel-first logic and **store the resolved FQN** in `mip.json`. Then at load time, always use the resolved FQN. This would make behavior consistent and explicit.
 
-### 14.2 No Version Constraint System
+### 14.2 No Version Constraints on Dependencies
 
-**Current behavior**: Dependencies are by name only, with no version constraints. `mip install` always gets the latest version. There's no way to say "depends on chebfun >= 2.0".
+**Current behavior**: Dependencies in `mip.yaml` are by name only (bare or FQN). Entries have no version field, no `@version` suffix, and no constraint grammar (`>=`, `~`, ranges). `mip install` always picks the version chosen by `select_best_version` ([§3.1.3](#313-version-selection-select_best_version)). If a dependency is already installed at any version, it is treated as satisfied -- no version comparison, no upgrade, no warning.
 
-**Questions**:
-- Should there be a minimum version constraint system?
-- What happens if a dependency is already installed at an older version? Currently it's just skipped (already installed).
-- Should `mip install` warn if a dependency is installed but at a potentially incompatible version?
+**Resolved in [#95](https://github.com/mip-org/mip/issues/95)**: dependency version constraints are **out of scope**. A constraint system would add significant implementation and UX complexity (resolution, conflict reporting, already-installed reconciliation, lock-file interaction) that is not justified for current use cases. Packages pinning an explicit dependency version should do so by listing the FQN of a version-locked package in an appropriate channel, not via a constraint in `mip.yaml`.
+
+This decision may be revisited if a concrete need arises. Related: lock files ([§14.5](#145-no-lock-file-or-dependency-snapshot), [#96](https://github.com/mip-org/mip/issues/96)).
 
 ### 14.3 Local Install Dependency Check Is Incomplete
 
@@ -874,11 +883,11 @@ A potential middle ground: at install time, resolve bare-name deps using same-ch
 - Can concurrent sessions corrupt `directly_installed.txt` (no file locking)?
 - Should `mip list` or `mip info` warn if file state and memory state are inconsistent?
 
-### 14.10 Update Doesn't Update Dependencies
+### 14.10 Update Doesn't Explicitly Check Dependencies
 
-**Current behavior**: `mip update <pkg>` only updates the specified package. It does not check whether dependencies also have newer versions available.
+**Current behavior**: `mip update <pkg>` only checks whether `<pkg>` itself needs updating. If it does, the uninstall+install cycle ([§7.1](#71-update-flow-mip-update-x-y-z)) re-resolves the full dependency graph and effectively updates the deps as a side-effect. If `<pkg>` is already up to date, its dependencies are **not** revisited -- use `mip update --force <pkg>` to force the uninstall+install cycle and pick up fresh deps.
 
-**Question**: Should there be a `mip update --recursive` or `mip update --all` that updates a package and all its dependencies?
+**Resolved in [#99](https://github.com/mip-org/mip/issues/99)**: there is no `mip update --recursive` or `mip update --all`. The user-facing semantics are deliberately "`mip update X Y Z` ≡ `mip uninstall X Y Z` + `mip install X Y Z` + reload previously-loaded packages" -- anything that wants broader dep refresh should pass the right package list or use `--force`.
 
 ### 14.11 Rollback on Failed Install
 
@@ -929,7 +938,7 @@ The following behaviors are specified in this document but not fully covered by 
 This behavior is intentional and was confirmed in [#103](https://github.com/mip-org/mip/issues/103):
 - Unconditional uninstall + reinstall is the expected semantics for `mip update` on a local package — `mip update` is the user's "rebuild from source" hammer.
 - For editable installs, recompiling is wanted: the user almost certainly edited source that needs rebuilding.
-- A future `mip update --all` should **not** include local packages.
+- There is no `mip update --all`; see [§14.10](#1410-update-doesnt-explicitly-check-dependencies).
 
 ### 14.17 `load_package.m` Error Handling
 

--- a/tests/TestUpdateLocal.m
+++ b/tests/TestUpdateLocal.m
@@ -225,5 +225,92 @@ classdef TestUpdateLocal < matlab.unittest.TestCase
                 'Package should still be directly installed after update');
         end
 
+        %% --- Dependency + load state preservation ---
+
+        function testUpdate_ReloadsDependencyAfterUpdate(testCase)
+            % Install a dependency (fake installed package), then a local
+            % source package that depends on it. Load the main package
+            % (which transitively loads the dep). Update the main package
+            % and verify both are still loaded afterward.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'depA');
+            mip.utils.add_directly_installed('mip-org/core/depA');
+
+            srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg', ...
+                'dependencies', {'depA'});
+            mip.install(srcDir);
+
+            mip.load('local/local/mypkg');
+            testCase.verifyTrue(mip.utils.is_loaded('local/local/mypkg'));
+            testCase.verifyTrue(mip.utils.is_loaded('mip-org/core/depA'), ...
+                'depA should be transitively loaded');
+
+            mip.update('local/local/mypkg');
+
+            testCase.verifyTrue(mip.utils.is_loaded('local/local/mypkg'), ...
+                'Main package should be reloaded after update');
+            testCase.verifyTrue(mip.utils.is_loaded('mip-org/core/depA'), ...
+                'Dependency should still be loaded after update');
+        end
+
+        function testUpdate_PreservesDirectlyLoadedDistinction(testCase)
+            % A package loaded only as a transitive dep should not be
+            % promoted to directly loaded after update.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'depA');
+            mip.utils.add_directly_installed('mip-org/core/depA');
+
+            srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg', ...
+                'dependencies', {'depA'});
+            mip.install(srcDir);
+
+            mip.load('local/local/mypkg');
+
+            % depA should be transitively loaded (not directly loaded)
+            testCase.verifyTrue(mip.utils.is_loaded('mip-org/core/depA'));
+            testCase.verifyFalse(mip.utils.is_directly_loaded('mip-org/core/depA'), ...
+                'depA should only be transitively loaded before update');
+
+            mip.update('local/local/mypkg');
+
+            testCase.verifyTrue(mip.utils.is_loaded('mip-org/core/depA'));
+            testCase.verifyFalse(mip.utils.is_directly_loaded('mip-org/core/depA'), ...
+                'depA should remain transitively loaded (not promoted to directly loaded)');
+            testCase.verifyTrue(mip.utils.is_directly_loaded('local/local/mypkg'), ...
+                'Main package should remain directly loaded');
+        end
+
+        function testUpdate_MultiplePackages(testCase)
+            % Updating multiple local packages at once should work.
+            srcA = createTestSourcePackage(testCase.SourceDir, 'pkgA');
+            srcB = createTestSourcePackage(testCase.SourceDir, 'pkgB');
+            mip.install(srcA);
+            mip.install(srcB);
+
+            mip.load('local/local/pkgA');
+            mip.load('local/local/pkgB');
+            testCase.verifyTrue(mip.utils.is_loaded('local/local/pkgA'));
+            testCase.verifyTrue(mip.utils.is_loaded('local/local/pkgB'));
+
+            pkgDirA = fullfile(testCase.TestRoot, 'packages', 'local', 'local', 'pkgA');
+            pkgDirB = fullfile(testCase.TestRoot, 'packages', 'local', 'local', 'pkgB');
+            infoA1 = mip.utils.read_package_json(pkgDirA);
+            infoB1 = mip.utils.read_package_json(pkgDirB);
+
+            pause(1.1);
+
+            mip.update('local/local/pkgA', 'local/local/pkgB');
+
+            testCase.verifyTrue(mip.utils.is_loaded('local/local/pkgA'), ...
+                'pkgA should be reloaded');
+            testCase.verifyTrue(mip.utils.is_loaded('local/local/pkgB'), ...
+                'pkgB should be reloaded');
+
+            infoA2 = mip.utils.read_package_json(pkgDirA);
+            infoB2 = mip.utils.read_package_json(pkgDirB);
+            testCase.verifyFalse(strcmp(infoA2.timestamp, infoA1.timestamp), ...
+                'pkgA should have been reinstalled');
+            testCase.verifyFalse(strcmp(infoB2.timestamp, infoB1.timestamp), ...
+                'pkgB should have been reinstalled');
+        end
+
     end
 end

--- a/tests/TestUpdateRemote.m
+++ b/tests/TestUpdateRemote.m
@@ -129,5 +129,54 @@ classdef TestUpdateRemote < matlab.unittest.TestCase
                 'Should be upgraded to latest version');
         end
 
+        %% --- Dependency re-resolution ---
+
+        function testUpdate_ForceReresolveDeps(testCase)
+            % Install gamma (depends on alpha). Force-update gamma.
+            % The uninstall+install cycle should prune alpha (orphaned)
+            % and re-install it alongside gamma.
+            mip.install('--channel', 'mip-org/test-channel1', 'gamma');
+
+            gammaDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'gamma');
+            alphaDir = fullfile(testCase.TestRoot, 'packages', ...
+                'mip-org', 'test-channel1', 'alpha');
+
+            testCase.verifyTrue(exist(gammaDir, 'dir') > 0);
+            testCase.verifyTrue(exist(alphaDir, 'dir') > 0);
+
+            % Drop a marker in alpha to prove it was reinstalled
+            marker = fullfile(alphaDir, '.test_marker');
+            fid = fopen(marker, 'w'); fclose(fid);
+            testCase.verifyTrue(exist(marker, 'file') > 0);
+
+            mip.update('--force', 'mip-org/test-channel1/gamma');
+
+            testCase.verifyTrue(exist(gammaDir, 'dir') > 0, ...
+                'gamma should be reinstalled');
+            testCase.verifyTrue(exist(alphaDir, 'dir') > 0, ...
+                'alpha should be re-installed as dependency of gamma');
+            testCase.verifyFalse(exist(marker, 'file') > 0, ...
+                'alpha marker should be gone (dep was pruned and re-installed)');
+        end
+
+        function testUpdate_ForcePreservesLoadedDeps(testCase)
+            % Install gamma (depends on alpha), load gamma, force-update.
+            % Both gamma and alpha should be reloaded afterward.
+            mip.install('--channel', 'mip-org/test-channel1', 'gamma');
+            mip.load('mip-org/test-channel1/gamma');
+
+            testCase.verifyTrue(mip.utils.is_loaded('mip-org/test-channel1/gamma'));
+            testCase.verifyTrue(mip.utils.is_loaded('mip-org/test-channel1/alpha'), ...
+                'alpha should be transitively loaded');
+
+            mip.update('--force', 'mip-org/test-channel1/gamma');
+
+            testCase.verifyTrue(mip.utils.is_loaded('mip-org/test-channel1/gamma'), ...
+                'gamma should be reloaded after force update');
+            testCase.verifyTrue(mip.utils.is_loaded('mip-org/test-channel1/alpha'), ...
+                'alpha should be reloaded as transitive dependency');
+        end
+
     end
 end


### PR DESCRIPTION
## Summary

- Remote packages: `mip update X Y Z` now runs `mip.uninstall(X,Y,Z)` then `mip.install(X,Y,Z)`, re-resolving deps from the channel index
- Local packages: direct rmdir + `install_local` (avoids pruning deps that can't be re-fetched)
- Snapshots loaded packages before update, reloads afterward (preserves directly-vs-transitively-loaded distinction)
- All validation runs before any destructive action

Closes #99