### PR TITLE
Extract duplicated logic into shared utilities

### DIFF
--- a/+mip/+utils/check_broken_dependencies.m
+++ b/+mip/+utils/check_broken_dependencies.m
@@ -1,0 +1,91 @@
+function check_broken_dependencies(mode)
+%CHECK_BROKEN_DEPENDENCIES   Warn about packages with missing dependencies.
+%
+% Args:
+%   mode - 'installed' to check installed packages for uninstalled deps,
+%          'loaded' to check loaded packages for unloaded deps.
+
+if strcmp(mode, 'installed')
+    packages = mip.utils.list_installed_packages();
+    missingVerb = 'not installed';
+    contextNoun = 'installed';
+else
+    packages = mip.utils.key_value_get('MIP_LOADED_PACKAGES');
+    missingVerb = 'no longer loaded';
+    contextNoun = 'loaded';
+end
+
+if isempty(packages)
+    return
+end
+
+brokenDeps = {};
+for i = 1:length(packages)
+    pkg = packages{i};
+    r = mip.utils.parse_package_arg(pkg);
+    if ~r.is_fqn
+        continue
+    end
+
+    packageDir = mip.utils.get_package_dir(r.org, r.channel, r.name);
+    mipJsonPath = fullfile(packageDir, 'mip.json');
+
+    if ~exist(mipJsonPath, 'file')
+        continue
+    end
+
+    try
+        pkgInfo = mip.utils.read_package_json(packageDir);
+
+        if isempty(pkgInfo.dependencies)
+            continue
+        end
+
+        depNames = pkgInfo.dependencies;
+        if ~iscell(depNames)
+            depNames = {depNames};
+        end
+        for j = 1:length(depNames)
+            dep = depNames{j};
+            if strcmp(mode, 'installed')
+                depMissing = isDependencyUninstalled(dep);
+            else
+                depMissing = isDependencyUnloaded(dep);
+            end
+            if depMissing
+                brokenDeps{end+1} = sprintf('Package "%s" depends on "%s" which is %s', pkg, dep, missingVerb); %#ok<AGROW>
+            end
+        end
+    catch
+        % Silently ignore parse errors
+    end
+end
+
+if ~isempty(brokenDeps)
+    warning('mip:brokenDependencies', ...
+            'Warning: Some %s packages have missing dependencies:\n  %s', ...
+            contextNoun, strjoin(brokenDeps, '\n  '));
+end
+
+end
+
+function tf = isDependencyUninstalled(dep)
+    depResult = mip.utils.parse_package_arg(dep);
+    if depResult.is_fqn
+        depDir = mip.utils.get_package_dir(depResult.org, depResult.channel, depResult.name);
+        tf = ~exist(depDir, 'dir');
+    else
+        resolved = mip.utils.resolve_bare_name(dep);
+        tf = isempty(resolved);
+    end
+end
+
+function tf = isDependencyUnloaded(dep)
+    depResult = mip.utils.parse_package_arg(dep);
+    if depResult.is_fqn
+        depFqn = dep;
+    else
+        depFqn = mip.utils.resolve_bare_name(dep);
+    end
+    tf = isempty(depFqn) || ~mip.utils.is_loaded(depFqn);
+end

--- a/+mip/+utils/cleanup_empty_dirs.m
+++ b/+mip/+utils/cleanup_empty_dirs.m
@@ -1,0 +1,14 @@
+function cleanup_empty_dirs(dirPath)
+%CLEANUP_EMPTY_DIRS   Remove directory if it is empty (no subdirectories or files).
+
+if ~exist(dirPath, 'dir')
+    return
+end
+contents = dir(dirPath);
+% Filter out . and ..
+contents = contents(~ismember({contents.name}, {'.', '..'}));
+if isempty(contents)
+    rmdir(dirPath);
+end
+
+end

--- a/+mip/+utils/get_all_dependencies.m
+++ b/+mip/+utils/get_all_dependencies.m
@@ -1,0 +1,58 @@
+function deps = get_all_dependencies(fqn)
+%GET_ALL_DEPENDENCIES   Recursively collect all transitive dependencies of an installed package.
+%
+% Reads mip.json from the installed package directory and resolves bare
+% dependency names using same-channel-first, then mip-org/core, then
+% general resolution.
+%
+% Args:
+%   fqn - Fully qualified package name (org/channel/name)
+%
+% Returns:
+%   deps - Cell array of dependency FQNs (transitive closure, not including fqn itself)
+
+deps = {};
+
+result = mip.utils.parse_package_arg(fqn);
+if ~result.is_fqn
+    return
+end
+
+packageDir = mip.utils.get_package_dir(result.org, result.channel, result.name);
+mipJsonPath = fullfile(packageDir, 'mip.json');
+
+if ~exist(mipJsonPath, 'file')
+    return
+end
+
+try
+    pkgInfo = mip.utils.read_package_json(packageDir);
+
+    if isempty(pkgInfo.dependencies)
+        return
+    end
+
+    depNames = pkgInfo.dependencies;
+    if ~iscell(depNames)
+        depNames = {depNames};
+    end
+    for i = 1:length(depNames)
+        dep = depNames{i};
+        try
+            depFqn = mip.utils.resolve_dependency(dep, result.org, result.channel);
+        catch
+            continue
+        end
+        if ~ismember(depFqn, deps)
+            deps{end+1} = depFqn; %#ok<AGROW>
+            transitiveDeps = mip.utils.get_all_dependencies(depFqn);
+            deps = unique([deps, transitiveDeps]);
+        end
+    end
+catch ME
+    warning('mip:jsonParseError', ...
+            'Could not parse mip.json for package "%s": %s', ...
+            fqn, ME.message);
+end
+
+end

--- a/+mip/+utils/prune_unused_packages.m
+++ b/+mip/+utils/prune_unused_packages.m
@@ -24,7 +24,7 @@ function prune_unused_packages()
     for i = 1:length(directlyInstalled)
         directPkg = directlyInstalled{i};
         if ismember(directPkg, allInstalled)
-            neededPackages = [neededPackages, getAllDependencies(directPkg)]; %#ok<AGROW>
+            neededPackages = [neededPackages, mip.utils.get_all_dependencies(directPkg)]; %#ok<AGROW>
         end
     end
 
@@ -51,82 +51,12 @@ function prune_unused_packages()
             try
                 rmdir(pkgDir, 's');
                 fprintf('  Pruned package "%s"\n', fqn);
-                cleanupEmptyDirs(fullfile(mip.utils.get_packages_dir(), r.org, r.channel));
-                cleanupEmptyDirs(fullfile(mip.utils.get_packages_dir(), r.org));
+                mip.utils.cleanup_empty_dirs(fullfile(mip.utils.get_packages_dir(), r.org, r.channel));
+                mip.utils.cleanup_empty_dirs(fullfile(mip.utils.get_packages_dir(), r.org));
             catch ME
                 warning('mip:pruneFailed', ...
                         'Failed to prune package "%s": %s', fqn, ME.message);
             end
         end
-    end
-end
-
-function deps = getAllDependencies(fqn)
-    deps = {};
-
-    result = mip.utils.parse_package_arg(fqn);
-    if ~result.is_fqn
-        return
-    end
-
-    pkgDir = mip.utils.get_package_dir(result.org, result.channel, result.name);
-    mipJsonPath = fullfile(pkgDir, 'mip.json');
-
-    if ~exist(mipJsonPath, 'file')
-        return
-    end
-
-    try
-        fid = fopen(mipJsonPath, 'r');
-        jsonText = fread(fid, '*char')';
-        fclose(fid);
-        mipConfig = jsondecode(jsonText);
-
-        if isfield(mipConfig, 'dependencies') && ~isempty(mipConfig.dependencies)
-            depNames = mipConfig.dependencies;
-            if ~iscell(depNames)
-                depNames = {depNames};
-            end
-            for i = 1:length(depNames)
-                dep = depNames{i};
-                depResult = mip.utils.parse_package_arg(dep);
-                if depResult.is_fqn
-                    depFqn = dep;
-                else
-                    % Same channel first, then resolve
-                    sameDir = mip.utils.get_package_dir(result.org, result.channel, dep);
-                    if exist(sameDir, 'dir')
-                        depFqn = mip.utils.make_fqn(result.org, result.channel, dep);
-                    else
-                        depFqn = mip.utils.resolve_bare_name(dep);
-                        if isempty(depFqn)
-                            continue
-                        end
-                    end
-                end
-                if ~ismember(depFqn, deps)
-                    deps{end+1} = depFqn; %#ok<AGROW>
-                    transitiveDeps = getAllDependencies(depFqn);
-                    deps = unique([deps, transitiveDeps]);
-                end
-            end
-        end
-    catch ME
-        warning('mip:jsonParseError', ...
-                'Could not parse mip.json for package "%s": %s', ...
-                fqn, ME.message);
-    end
-end
-
-function cleanupEmptyDirs(dirPath)
-% Remove directory if it is empty (no subdirectories or files)
-    if ~exist(dirPath, 'dir')
-        return
-    end
-    contents = dir(dirPath);
-    % Filter out . and ..
-    contents = contents(~ismember({contents.name}, {'.', '..'}));
-    if isempty(contents)
-        rmdir(dirPath);
     end
 end

--- a/+mip/+utils/resolve_dependency.m
+++ b/+mip/+utils/resolve_dependency.m
@@ -1,0 +1,43 @@
+function depFqn = resolve_dependency(depName, contextOrg, contextChannel)
+%RESOLVE_DEPENDENCY   Resolve a dependency name to a fully qualified name.
+%
+% If depName is already a FQN, return as-is.
+% If bare, try same channel first, then mip-org/core, then general resolution.
+%
+% Args:
+%   depName        - Dependency name (bare or FQN)
+%   contextOrg     - Org of the parent package
+%   contextChannel - Channel of the parent package
+%
+% Returns:
+%   depFqn - Fully qualified name, or error if not found
+
+result = mip.utils.parse_package_arg(depName);
+
+if result.is_fqn
+    depFqn = depName;
+    return
+end
+
+% Try same channel first
+sameChannelDir = mip.utils.get_package_dir(contextOrg, contextChannel, result.name);
+if exist(sameChannelDir, 'dir')
+    depFqn = mip.utils.make_fqn(contextOrg, contextChannel, result.name);
+    return
+end
+
+% Try mip-org/core
+coreDir = mip.utils.get_package_dir('mip-org', 'core', result.name);
+if exist(coreDir, 'dir')
+    depFqn = mip.utils.make_fqn('mip-org', 'core', result.name);
+    return
+end
+
+% Fall back to general resolution
+depFqn = mip.utils.resolve_bare_name(result.name);
+if isempty(depFqn)
+    error('mip:dependencyNotFound', ...
+          'Dependency "%s" is not installed.', result.name);
+end
+
+end

--- a/+mip/load.m
+++ b/+mip/load.m
@@ -121,36 +121,32 @@ function loadSingle(packageArg, installIfMissing, stickyPackage, channel, isDire
         return
     end
 
-    % Check for mip.json and process dependencies. Only the parse step is
+    % Load dependencies listed in mip.json. Only the parse step is
     % wrapped in try/catch so that recursive dependency-load errors propagate
     % instead of being silently downgraded to a warning.
     mipJsonPath = fullfile(packageDir, 'mip.json');
-    mipConfig = [];
+    deps = {};
     if exist(mipJsonPath, 'file')
         try
-            fid = fopen(mipJsonPath, 'r');
-            jsonText = fread(fid, '*char')';
-            fclose(fid);
-            mipConfig = jsondecode(jsonText);
+            mipConfig = mip.utils.read_package_json(packageDir);
+            deps = mipConfig.dependencies;
+            if ~iscell(deps)
+                deps = {deps};
+            end
         catch ME
             warning('mip:jsonParseError', ...
                     'Could not parse mip.json for package "%s": %s', ...
                     fqn, ME.message);
-            mipConfig = [];
         end
     end
 
-    if ~isempty(mipConfig) && isfield(mipConfig, 'dependencies') && ~isempty(mipConfig.dependencies)
-        deps = mipConfig.dependencies;
-        if ~iscell(deps)
-            deps = {deps};
-        end
+    if ~isempty(deps)
         fprintf('Loading dependencies for "%s": %s\n', ...
                 fqn, strjoin(deps, ', '));
         for i = 1:length(deps)
             dep = deps{i};
             % Resolve dependency: same channel first, then core
-            depFqn = resolveDependency(dep, result.org, result.channel);
+            depFqn = mip.utils.resolve_dependency(dep, result.org, result.channel);
             if ~mip.utils.is_loaded(depFqn)
                 loadSingle(depFqn, installIfMissing, false, channel, false, loadingStack);
             else
@@ -219,35 +215,3 @@ function fqn = resolveToFqn(packageArg)
     end
 end
 
-function depFqn = resolveDependency(depName, contextOrg, contextChannel)
-% Resolve a dependency name. If it's a FQN, use as-is.
-% If bare, try same channel first, then mip-org/core.
-
-    result = mip.utils.parse_package_arg(depName);
-
-    if result.is_fqn
-        depFqn = depName;
-        return
-    end
-
-    % Try same channel first
-    sameChannelDir = mip.utils.get_package_dir(contextOrg, contextChannel, result.name);
-    if exist(sameChannelDir, 'dir')
-        depFqn = mip.utils.make_fqn(contextOrg, contextChannel, result.name);
-        return
-    end
-
-    % Try mip-org/core
-    coreDir = mip.utils.get_package_dir('mip-org', 'core', result.name);
-    if exist(coreDir, 'dir')
-        depFqn = mip.utils.make_fqn('mip-org', 'core', result.name);
-        return
-    end
-
-    % Fall back to general resolution
-    depFqn = mip.utils.resolve_bare_name(result.name);
-    if isempty(depFqn)
-        error('mip:dependencyNotFound', ...
-              'Dependency "%s" is not installed.', result.name);
-    end
-end

--- a/+mip/uninstall.m
+++ b/+mip/uninstall.m
@@ -100,83 +100,13 @@ function uninstall(varargin)
         mip.utils.remove_directly_installed(fqn);
 
         % Clean up empty parent directories
-        cleanupEmptyDirs(fullfile(mip.utils.get_packages_dir(), r.org, r.channel));
-        cleanupEmptyDirs(fullfile(mip.utils.get_packages_dir(), r.org));
+        mip.utils.cleanup_empty_dirs(fullfile(mip.utils.get_packages_dir(), r.org, r.channel));
+        mip.utils.cleanup_empty_dirs(fullfile(mip.utils.get_packages_dir(), r.org));
     end
 
     % Prune packages that are no longer needed
     mip.utils.prune_unused_packages();
 
     % After pruning, check for broken dependencies
-    checkForBrokenDependencies();
-end
-
-function cleanupEmptyDirs(dirPath)
-% Remove directory if it is empty (no subdirectories or files)
-    if ~exist(dirPath, 'dir')
-        return
-    end
-    contents = dir(dirPath);
-    % Filter out . and ..
-    contents = contents(~ismember({contents.name}, {'.', '..'}));
-    if isempty(contents)
-        rmdir(dirPath);
-    end
-end
-
-function checkForBrokenDependencies()
-    allInstalled = mip.utils.list_installed_packages();
-
-    if isempty(allInstalled)
-        return
-    end
-
-    brokenDeps = {};
-    for i = 1:length(allInstalled)
-        fqn = allInstalled{i};
-        r = mip.utils.parse_package_arg(fqn);
-        pkgDir = mip.utils.get_package_dir(r.org, r.channel, r.name);
-        mipJsonPath = fullfile(pkgDir, 'mip.json');
-
-        if ~exist(mipJsonPath, 'file')
-            continue
-        end
-
-        try
-            fid = fopen(mipJsonPath, 'r');
-            jsonText = fread(fid, '*char')';
-            fclose(fid);
-            mipConfig = jsondecode(jsonText);
-
-            if isfield(mipConfig, 'dependencies') && ~isempty(mipConfig.dependencies)
-                depNames = mipConfig.dependencies;
-                if ~iscell(depNames)
-                    depNames = {depNames};
-                end
-                for j = 1:length(depNames)
-                    dep = depNames{j};
-                    depResult = mip.utils.parse_package_arg(dep);
-                    if depResult.is_fqn
-                        depR = mip.utils.parse_package_arg(dep);
-                        depDir = mip.utils.get_package_dir(depR.org, depR.channel, depR.name);
-                        if ~exist(depDir, 'dir')
-                            brokenDeps{end+1} = sprintf('Package "%s" depends on "%s" which is not installed', fqn, dep); %#ok<AGROW>
-                        end
-                    else
-                        resolved = mip.utils.resolve_bare_name(dep);
-                        if isempty(resolved)
-                            brokenDeps{end+1} = sprintf('Package "%s" depends on "%s" which is not installed', fqn, dep); %#ok<AGROW>
-                        end
-                    end
-                end
-            end
-        catch
-        end
-    end
-
-    if ~isempty(brokenDeps)
-        warning('mip:brokenDependencies', ...
-                'Warning: Some installed packages have missing dependencies:\n  %s', ...
-                strjoin(brokenDeps, '\n  '));
-    end
+    mip.utils.check_broken_dependencies('installed');
 end

--- a/+mip/unload.m
+++ b/+mip/unload.m
@@ -154,7 +154,7 @@ function pruneUnusedPackages()
     neededPackages = {};
     for i = 1:length(MIP_DIRECTLY_LOADED_PACKAGES)
         directPkg = MIP_DIRECTLY_LOADED_PACKAGES{i};
-        neededPackages = [neededPackages, getAllDependencies(directPkg)]; %#ok<*AGROW>
+        neededPackages = [neededPackages, mip.utils.get_all_dependencies(directPkg)]; %#ok<*AGROW>
     end
 
     % Add directly loaded packages themselves
@@ -189,123 +189,7 @@ function pruneUnusedPackages()
     end
 
     % After pruning, check for broken dependencies
-    checkForBrokenDependencies();
-end
-
-function deps = getAllDependencies(fqn)
-    deps = {};
-
-    result = mip.utils.parse_package_arg(fqn);
-    if ~result.is_fqn
-        return
-    end
-
-    packageDir = mip.utils.get_package_dir(result.org, result.channel, result.name);
-    mipJsonPath = fullfile(packageDir, 'mip.json');
-
-    if ~exist(mipJsonPath, 'file')
-        return
-    end
-
-    try
-        fid = fopen(mipJsonPath, 'r');
-        jsonText = fread(fid, '*char')';
-        fclose(fid);
-        mipConfig = jsondecode(jsonText);
-
-        if isfield(mipConfig, 'dependencies') && ~isempty(mipConfig.dependencies)
-            depNames = mipConfig.dependencies;
-            if ~iscell(depNames)
-                depNames = {depNames};
-            end
-            for i = 1:length(depNames)
-                dep = depNames{i};
-                % Resolve bare dependency to FQN (same channel first, then core)
-                depResult = mip.utils.parse_package_arg(dep);
-                if depResult.is_fqn
-                    depFqn = dep;
-                else
-                    % Try same channel first
-                    sameDir = mip.utils.get_package_dir(result.org, result.channel, dep);
-                    if exist(sameDir, 'dir')
-                        depFqn = mip.utils.make_fqn(result.org, result.channel, dep);
-                    else
-                        depFqn = mip.utils.resolve_bare_name(dep);
-                        if isempty(depFqn)
-                            continue
-                        end
-                    end
-                end
-                if ~ismember(depFqn, deps)
-                    deps{end+1} = depFqn;
-                    transitiveDeps = getAllDependencies(depFqn);
-                    deps = unique([deps, transitiveDeps]);
-                end
-            end
-        end
-    catch ME
-        warning('mip:jsonParseError', ...
-                'Could not parse mip.json for package "%s": %s', ...
-                fqn, ME.message);
-    end
-end
-
-function checkForBrokenDependencies()
-    MIP_LOADED_PACKAGES = mip.utils.key_value_get('MIP_LOADED_PACKAGES');
-
-    if isempty(MIP_LOADED_PACKAGES)
-        return
-    end
-
-    brokenDeps = {};
-    for i = 1:length(MIP_LOADED_PACKAGES)
-        pkg = MIP_LOADED_PACKAGES{i};
-        r = mip.utils.parse_package_arg(pkg);
-        if ~r.is_fqn
-            continue
-        end
-
-        packageDir = mip.utils.get_package_dir(r.org, r.channel, r.name);
-        mipJsonPath = fullfile(packageDir, 'mip.json');
-
-        if ~exist(mipJsonPath, 'file')
-            continue
-        end
-
-        try
-            fid = fopen(mipJsonPath, 'r');
-            jsonText = fread(fid, '*char')';
-            fclose(fid);
-            mipConfig = jsondecode(jsonText);
-
-            if isfield(mipConfig, 'dependencies') && ~isempty(mipConfig.dependencies)
-                depNames = mipConfig.dependencies;
-                if ~iscell(depNames)
-                    depNames = {depNames};
-                end
-                for j = 1:length(depNames)
-                    dep = depNames{j};
-                    depResult = mip.utils.parse_package_arg(dep);
-                    if depResult.is_fqn
-                        depFqn = dep;
-                    else
-                        depFqn = mip.utils.resolve_bare_name(dep);
-                    end
-                    if isempty(depFqn) || ~mip.utils.is_loaded(depFqn)
-                        brokenDeps{end+1} = sprintf('Package "%s" depends on "%s" which is no longer loaded', pkg, dep); %#ok<AGROW>
-                    end
-                end
-            end
-        catch
-            % Silently ignore parse errors
-        end
-    end
-
-    if ~isempty(brokenDeps)
-        warning('mip:brokenDependencies', ...
-                'Warning: Some loaded packages have missing dependencies:\n  %s', ...
-                strjoin(brokenDeps, '\n  '));
-    end
+    mip.utils.check_broken_dependencies('loaded');
 end
 
 function unloadAll(forceUnload)
@@ -383,5 +267,5 @@ function unloadAll(forceUnload)
     mip.utils.key_value_set('MIP_DIRECTLY_LOADED_PACKAGES', MIP_DIRECTLY_LOADED_PACKAGES);
     mip.utils.key_value_set('MIP_STICKY_PACKAGES', MIP_STICKY_PACKAGES);
 
-    checkForBrokenDependencies();
+    mip.utils.check_broken_dependencies('loaded');
 end

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -126,8 +126,8 @@ function update(varargin)
         rmdir(p.pkgDir, 's');
         mip.utils.remove_directly_installed(p.fqn);
         packagesDir = mip.utils.get_packages_dir();
-        cleanupEmptyDirs(fullfile(packagesDir, 'local', 'local'));
-        cleanupEmptyDirs(fullfile(packagesDir, 'local'));
+        mip.utils.cleanup_empty_dirs(fullfile(packagesDir, 'local', 'local'));
+        mip.utils.cleanup_empty_dirs(fullfile(packagesDir, 'local'));
 
         fprintf('Reinstalling "%s" from %s...\n', p.fqn, p.sourcePath);
         mip.utils.install_local(p.sourcePath, p.editable);
@@ -389,13 +389,3 @@ function updateSelf(p, force)
     fprintf('\nmip has been updated to %s.\n', latestVersion);
 end
 
-function cleanupEmptyDirs(dirPath)
-    if ~exist(dirPath, 'dir')
-        return
-    end
-    contents = dir(dirPath);
-    contents = contents(~ismember({contents.name}, {'.', '..'}));
-    if isempty(contents)
-        rmdir(dirPath);
-    end
-end


### PR DESCRIPTION
## Summary
- Extract `cleanup_empty_dirs`, `get_all_dependencies`, `resolve_dependency`, and `check_broken_dependencies` into `+mip/+utils/` — these were duplicated across load, unload, uninstall, update, and prune_unused_packages
- Replace inline `fopen`/`fread`/`jsondecode` in `load.m` with existing `read_package_json` utility
- Net: ~300 lines removed, ~100 lines added in focused utilities; all 252 tests pass