### PR TITLE
Replace exception-driven retry loop with structured data flow

### DIFF
--- a/+mip/+dependency/build_dependency_graph.m
+++ b/+mip/+dependency/build_dependency_graph.m
@@ -1,4 +1,4 @@
-function depList = build_dependency_graph(packageFqn, packageInfoMap, visited, path)
+function [depList, missingFqns] = build_dependency_graph(packageFqn, packageInfoMap, visited, path)
 %BUILD_DEPENDENCY_GRAPH   Recursively build dependency graph for a package.
 %
 % Args:
@@ -8,12 +8,15 @@ function depList = build_dependency_graph(packageFqn, packageInfoMap, visited, p
 %   path           - (Optional) Cell array representing current dependency path
 %
 % Returns:
-%   depList - Cell array of FQNs in dependency order (dependencies first)
+%   depList     - Cell array of FQNs in dependency order (dependencies first)
+%   missingFqns - Cell array of FQNs that were not found in packageInfoMap.
+%                 When non-empty, depList is incomplete. The caller should
+%                 fetch the channels for the missing packages and retry.
 %
 % Bare-name dependencies are always resolved to mip-org/core/<name>.
 %
 % Example:
-%   deps = mip.dependency.build_dependency_graph('mip-org/core/mypackage', pkgMap);
+%   [deps, missing] = mip.dependency.build_dependency_graph('mip-org/core/mypackage', pkgMap);
 
 if nargin < 3
     visited = {};
@@ -21,6 +24,8 @@ end
 if nargin < 4
     path = {};
 end
+
+missingFqns = {};
 
 % Check for circular dependency
 if ismember(packageFqn, path)
@@ -37,8 +42,9 @@ end
 
 % Find package info
 if ~isKey(packageInfoMap, packageFqn)
-    error('mip:packageNotFound', ...
-          'Package "%s" not found in repository', packageFqn);
+    depList = {};
+    missingFqns = {packageFqn};
+    return
 end
 pkgInfo = packageInfoMap(packageFqn);
 
@@ -65,8 +71,9 @@ for i = 1:length(dependencies)
         depFqn = mip.parse.make_fqn('mip-org', 'core', depResult.name);
     end
 
-    subDeps = mip.dependency.build_dependency_graph(depFqn, packageInfoMap, visited, path);
+    [subDeps, subMissing] = mip.dependency.build_dependency_graph(depFqn, packageInfoMap, visited, path);
     depList = [depList, subDeps]; %#ok<*AGROW>
+    missingFqns = [missingFqns, subMissing];
 end
 
 % Then add this package

--- a/+mip/install.m
+++ b/+mip/install.m
@@ -234,23 +234,39 @@ function installedFqns = installFromRepository(repoPackages, channel)
     % If a cross-channel FQN dep is not in the map, fetch its channel and retry.
     allRequiredFqns = {};
     for attempt = 1:10
-        try
-            allRequiredFqns = {};
-            for i = 1:length(resolvedPackages)
-                installOrder = mip.dependency.build_dependency_graph(resolvedPackages{i}.fqn, packageInfoMap);
-                allRequiredFqns = [allRequiredFqns, installOrder]; %#ok<AGROW>
+        allRequiredFqns = {};
+        allMissing = {};
+        for i = 1:length(resolvedPackages)
+            [installOrder, missing] = mip.dependency.build_dependency_graph(resolvedPackages{i}.fqn, packageInfoMap);
+            allRequiredFqns = [allRequiredFqns, installOrder]; %#ok<AGROW>
+            allMissing = [allMissing, missing]; %#ok<AGROW>
+        end
+        allMissing = unique(allMissing, 'stable');
+
+        if isempty(allMissing)
+            break
+        end
+
+        % Fetch channels for missing cross-channel dependencies
+        fetchedNew = false;
+        for i = 1:length(allMissing)
+            parsed = mip.parse.parse_package_arg(allMissing{i});
+            if ~parsed.is_fqn
+                error('mip:packageNotFound', 'Package "%s" not found in repository', allMissing{i});
             end
-            break  % success
-        catch ME
-            if ~strcmp(ME.identifier, 'mip:packageNotFound'), rethrow(ME); end
-            tokens = regexp(ME.message, '"([^"]+)"', 'tokens');
-            if isempty(tokens), rethrow(ME); end
-            parsed = mip.parse.parse_package_arg(tokens{1}{1});
-            if ~parsed.is_fqn, rethrow(ME); end
             missingChannel = [parsed.org '/' parsed.channel];
-            if fetchedChannels.isKey(missingChannel), rethrow(ME); end
+            if fetchedChannels.isKey(missingChannel)
+                continue
+            end
             fprintf('Fetching %s index for cross-channel dependency...\n', missingChannel);
             fetchChannelIndex(missingChannel, packageInfoMap, unavailablePackages, fetchedChannels, requestedVersions);
+            fetchedNew = true;
+        end
+
+        if ~fetchedNew
+            % All channels already fetched but packages still missing
+            error('mip:packageNotFound', ...
+                  'Package(s) not found in repository: %s', strjoin(allMissing, ', '));
         end
     end
     allRequiredFqns = unique(allRequiredFqns, 'stable');


### PR DESCRIPTION
## Summary

- `build_dependency_graph` now returns missing FQNs as a second output instead of throwing `mip:packageNotFound`
- The install retry loop in `installFromRepository` uses this structured list to fetch missing channel indexes directly, removing the regex parsing of error message strings

All 284 tests pass.