### PR TITLE
Simplify load-state management across load, unload, and update

### DIFF
--- a/+mip/+state/check_needs_update.m
+++ b/+mip/+state/check_needs_update.m
@@ -1,0 +1,25 @@
+function tf = check_needs_update(installedInfo, latestInfo)
+%CHECK_NEEDS_UPDATE   Compare installed vs latest version and commit hash.
+%
+% Returns true if the latest version differs from installed, or if the
+% versions match but the commit hash has changed.
+
+    installedVersion = installedInfo.version;
+    latestVersion = latestInfo.version;
+
+    if ~strcmp(installedVersion, latestVersion)
+        tf = true;
+        return
+    end
+
+    installedHash = '';
+    if isfield(installedInfo, 'commit_hash')
+        installedHash = installedInfo.commit_hash;
+    end
+    latestHash = '';
+    if isfield(latestInfo, 'commit_hash')
+        latestHash = latestInfo.commit_hash;
+    end
+
+    tf = ~isempty(latestHash) && ~strcmp(installedHash, latestHash);
+end

--- a/+mip/+state/set_unloaded.m
+++ b/+mip/+state/set_unloaded.m
@@ -1,0 +1,10 @@
+function set_unloaded(fqn)
+%SET_UNLOADED   Remove a package from all load-state lists atomically.
+%
+% Removes fqn from MIP_LOADED_PACKAGES, MIP_DIRECTLY_LOADED_PACKAGES,
+% and MIP_STICKY_PACKAGES in a single call.
+
+    mip.state.key_value_remove('MIP_STICKY_PACKAGES', fqn);
+    mip.state.key_value_remove('MIP_DIRECTLY_LOADED_PACKAGES', fqn);
+    mip.state.key_value_remove('MIP_LOADED_PACKAGES', fqn);
+end

--- a/+mip/load.m
+++ b/+mip/load.m
@@ -18,10 +18,12 @@ function load(varargin)
 %   --sticky      Mark the package(s) as sticky (prevents unload with 'mip unload --all')
 %   --install     Automatically install the package(s) if not already installed
 %   --channel <c> Channel to install from when using --install (e.g. 'mip-org/staging')
+%   --transitive  (internal) Load as a transitive dependency, not a direct load
 
     % Parse flags and package names from arguments
     installIfMissing = false;
     stickyPackage = false;
+    isDirect = true;
     channel = '';
     packageArgs = {};
     i = 1;
@@ -31,6 +33,8 @@ function load(varargin)
             installIfMissing = true;
         elseif ischar(arg) && strcmp(arg, '--sticky')
             stickyPackage = true;
+        elseif ischar(arg) && strcmp(arg, '--transitive')
+            isDirect = false;
         elseif ischar(arg) && strcmp(arg, '--channel')
             if i < length(varargin)
                 i = i + 1;
@@ -50,7 +54,7 @@ function load(varargin)
 
     % Load each package
     for i = 1:length(packageArgs)
-        loadSingle(packageArgs{i}, installIfMissing, stickyPackage, channel, true, {});
+        loadSingle(packageArgs{i}, installIfMissing, stickyPackage, channel, isDirect, {});
     end
 end
 

--- a/+mip/unload.m
+++ b/+mip/unload.m
@@ -59,14 +59,8 @@ function unload(varargin)
         % Execute unload_package.m if it exists
         executeUnload(packageDir, fqn);
 
-        % Remove from sticky packages
-        mip.state.key_value_remove('MIP_STICKY_PACKAGES', fqn);
-
-        % Remove from directly loaded packages
-        mip.state.key_value_remove('MIP_DIRECTLY_LOADED_PACKAGES', fqn);
-
-        % Remove from loaded packages
-        mip.state.key_value_remove('MIP_LOADED_PACKAGES', fqn);
+        % Remove from all load-state lists
+        mip.state.set_unloaded(fqn);
 
         fprintf('Unloaded package "%s"\n', fqn);
     end

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -105,9 +105,7 @@ function update(varargin)
     end
 
     % Snapshot currently-loaded state so we can restore it after the
-    % update cycle. We remember both the full loaded list (so transitive
-    % deps that get pruned can be re-loaded) and the directly-loaded
-    % list (so we can preserve the direct-vs-transitive distinction).
+    % update cycle.
     loadedBefore = mip.state.key_value_get('MIP_LOADED_PACKAGES');
     directlyLoadedBefore = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
 
@@ -225,37 +223,22 @@ function tf = checkRemoteNeedsUpdate(p)
     end
 
     latestInfo = packageInfoMap(fqn);
-    latestVersion = latestInfo.version;
 
-    if strcmp(installedVersion, latestVersion)
-        installedHash = '';
-        if isfield(p.pkgInfo, 'commit_hash')
-            installedHash = p.pkgInfo.commit_hash;
-        end
-        latestHash = '';
-        if isfield(latestInfo, 'commit_hash')
-            latestHash = latestInfo.commit_hash;
-        end
-
-        if isempty(latestHash) || strcmp(installedHash, latestHash)
-            fprintf('Package "%s" is already up to date (%s)\n', fqn, installedVersion);
-            tf = false;
-            return
-        end
-
-        fprintf('Version is "%s" but commit hash has changed (%s -> %s)\n', ...
-                installedVersion, installedHash, latestHash);
+    if ~mip.state.check_needs_update(p.pkgInfo, latestInfo)
+        fprintf('Package "%s" is already up to date (%s)\n', fqn, installedVersion);
+        tf = false;
+        return
     end
 
-    fprintf('Updating "%s": %s -> %s\n', fqn, installedVersion, latestVersion);
+    fprintf('Updating "%s": %s -> %s\n', fqn, installedVersion, latestInfo.version);
     tf = true;
 end
 
 function reloadPreviouslyLoaded(loadedBefore, directlyLoadedBefore)
 % Reload any packages that were loaded before the update but are no
-% longer loaded. Preserves the direct-vs-transitive loaded distinction
-% by resetting MIP_DIRECTLY_LOADED_PACKAGES to the pre-update snapshot
-% at the end (filtered to entries that are actually loaded now).
+% longer loaded. Uses --transitive for packages that were not directly
+% loaded, preserving the direct-vs-transitive distinction without
+% needing a post-fixup pass.
 
     if isempty(loadedBefore)
         return
@@ -276,23 +259,12 @@ function reloadPreviouslyLoaded(loadedBefore, directlyLoadedBefore)
             continue
         end
         fprintf('Reloading "%s"...\n', pkg);
-        mip.load(pkg);
-    end
-
-    % Restore the directly-loaded snapshot. The bulk reload above may
-    % have marked formerly-transitively-loaded packages as directly
-    % loaded (since mip.load is always a direct call). Reset the state
-    % so only the packages that were directly loaded before -- and that
-    % are still loaded now -- are marked as directly loaded.
-    currentlyLoaded = mip.state.key_value_get('MIP_LOADED_PACKAGES');
-    desiredDirectly = {};
-    for i = 1:length(directlyLoadedBefore)
-        pkg = directlyLoadedBefore{i};
-        if ismember(pkg, currentlyLoaded)
-            desiredDirectly{end+1} = pkg; %#ok<AGROW>
+        if ismember(pkg, directlyLoadedBefore)
+            mip.load(pkg);
+        else
+            mip.load(pkg, '--transitive');
         end
     end
-    mip.state.key_value_set('MIP_DIRECTLY_LOADED_PACKAGES', desiredDirectly);
 end
 
 function updateSelf(p, force)
@@ -316,27 +288,13 @@ function updateSelf(p, force)
     end
 
     latestInfo = packageInfoMap(fqn);
-    latestVersion = latestInfo.version;
 
-    if ~force
-        if strcmp(installedVersion, latestVersion)
-            installedHash = '';
-            if isfield(pkgInfo, 'commit_hash')
-                installedHash = pkgInfo.commit_hash;
-            end
-            latestHash = '';
-            if isfield(latestInfo, 'commit_hash')
-                latestHash = latestInfo.commit_hash;
-            end
-
-            if isempty(latestHash) || strcmp(installedHash, latestHash)
-                fprintf('mip is already up to date (%s)\n', installedVersion);
-                return
-            end
-        end
+    if ~force && ~mip.state.check_needs_update(pkgInfo, latestInfo)
+        fprintf('mip is already up to date (%s)\n', installedVersion);
+        return
     end
 
-    fprintf('Updating mip: %s -> %s\n', installedVersion, latestVersion);
+    fprintf('Updating mip: %s -> %s\n', installedVersion, latestInfo.version);
 
     tempDir = tempname;
     mkdir(tempDir);


### PR DESCRIPTION
## Summary

- Extract duplicated version+commit_hash comparison into `mip.state.check_needs_update`, used by both `checkRemoteNeedsUpdate` and `updateSelf` in update.m
- Add `mip.state.set_unloaded` to remove a package from all three load-state lists in one call, replacing sequential `key_value_remove` calls in unload.m
- Add `--transitive` flag to `mip.load` so update.m can reload transitive deps without marking them as directly loaded, eliminating the post-fixup pass in `reloadPreviouslyLoaded`

All 284 tests pass.