### PR TITLE
Update packages in place instead of uninstall+install

### DIFF
--- a/+mip/update.m
+++ b/+mip/update.m
@@ -17,17 +17,17 @@ function update(varargin)
 % considered to need an update. If a package does not need updating,
 % nothing happens for that package (unless --force is specified).
 %
-% For the remote packages that need updating, `mip update X Y Z` is
-% equivalent to `mip uninstall X Y Z` followed by `mip install X Y Z`.
-% This re-resolves each package's dependency graph against the current
-% channel index, so dependencies are effectively updated as well.
+% Remote packages are updated in place: the old directory is removed and
+% the new version is downloaded. Existing dependencies are not updated.
+% After the update, any new dependencies that the updated package requires
+% are installed, and any orphaned packages (old dependencies no longer
+% needed by any directly installed package) are pruned.
 %
 % Local packages are reinstalled directly from their source path without
 % going through uninstall (since install_local cannot re-fetch deps from
 % a channel).
 %
-% Any packages that were loaded before the update are reloaded afterward,
-% even if they were pruned as unused during the uninstall step.
+% Any packages that were loaded before the update are reloaded afterward.
 %
 % Accepts both bare package names and fully qualified names.
 
@@ -74,17 +74,17 @@ function update(varargin)
     end
 
     % Determine which of the remaining packages actually need updating.
+    % For remote packages, also fetch the latest channel info (needed for
+    % downloading the new version).
     needsUpdate = false(1, length(toProcess));
     for i = 1:length(toProcess)
         p = toProcess{i};
-        if force
-            fprintf('Force updating "%s" (%s)\n', p.fqn, p.pkgInfo.version);
-            needsUpdate(i) = true;
-        elseif p.isLocal
+        if p.isLocal
             % Local packages are always reinstalled from source.
             needsUpdate(i) = true;
         else
-            needsUpdate(i) = checkRemoteNeedsUpdate(p);
+            [needsUpdate(i), latestInfo] = checkRemoteNeedsUpdate(p, force);
+            toProcess{i}.latestInfo = latestInfo;
         end
     end
     toProcess = toProcess(needsUpdate);
@@ -131,17 +131,27 @@ function update(varargin)
         mip.build.install_local(p.sourcePath, p.editable);
     end
 
-    % --- Remote packages: mip.uninstall + mip.install ---
-    % The uninstall prunes orphaned deps; the install re-resolves the
-    % full dependency graph from the current channel index.
+    % --- Remote packages: update in place, install new deps, prune ---
+    % Each package is replaced on disk with the latest version from the
+    % channel. Existing dependencies are left alone. After all packages are
+    % updated, any new dependencies are installed and orphaned packages are
+    % pruned.
     if ~isempty(remotePkgs)
-        remoteFqns = cellfun(@(p) p.fqn, remotePkgs, 'UniformOutput', false);
-        fprintf('\nUninstalling %d remote package(s) to update: %s\n', ...
-                length(remoteFqns), strjoin(remoteFqns, ', '));
-        mip.uninstall(remoteFqns{:});
+        for i = 1:length(remotePkgs)
+            p = remotePkgs{i};
+            if mip.state.is_loaded(p.fqn)
+                fprintf('Unloading "%s" before update...\n', p.fqn);
+                mip.unload(p.fqn);
+            end
+            downloadAndReplace(p);
+        end
 
-        fprintf('\nReinstalling remote package(s): %s\n', strjoin(remoteFqns, ', '));
-        mip.install(remoteFqns{:});
+        % Install any new dependencies that the updated packages require
+        remoteFqns = cellfun(@(p) p.fqn, remotePkgs, 'UniformOutput', false);
+        installMissingDeps(remoteFqns);
+
+        % Prune packages that are no longer needed
+        mip.state.prune_unused_packages();
     end
 
     % Reload anything that was loaded before update but isn't now.
@@ -195,8 +205,9 @@ function p = resolvePackage(packageArg)
     );
 end
 
-function tf = checkRemoteNeedsUpdate(p)
+function [tf, latestInfo] = checkRemoteNeedsUpdate(p, force)
 % Fetch the channel index and decide whether p needs updating.
+% Also returns the latestInfo struct (needed for downloading).
 
     fqn = p.fqn;
     installedVersion = p.pkgInfo.version;
@@ -224,6 +235,12 @@ function tf = checkRemoteNeedsUpdate(p)
 
     latestInfo = packageInfoMap(fqn);
 
+    if force
+        fprintf('Force updating "%s" (%s)\n', fqn, installedVersion);
+        tf = true;
+        return
+    end
+
     if ~mip.state.check_needs_update(p.pkgInfo, latestInfo)
         fprintf('Package "%s" is already up to date (%s)\n', fqn, installedVersion);
         tf = false;
@@ -232,6 +249,87 @@ function tf = checkRemoteNeedsUpdate(p)
 
     fprintf('Updating "%s": %s -> %s\n', fqn, installedVersion, latestInfo.version);
     tf = true;
+end
+
+function downloadAndReplace(p)
+% Remove the old package directory and download the new version.
+
+    fprintf('Downloading %s %s...\n', p.fqn, p.latestInfo.version);
+
+    rmdir(p.pkgDir, 's');
+
+    tempDir = tempname;
+    mkdir(tempDir);
+    try
+        mhlPath = mip.channel.download_mhl(p.latestInfo.mhl_url, tempDir);
+        parentDir = fileparts(p.pkgDir);
+        if ~exist(parentDir, 'dir')
+            mkdir(parentDir);
+        end
+        mip.channel.extract_mhl(mhlPath, p.pkgDir);
+        fprintf('Successfully updated "%s" to %s\n', p.fqn, p.latestInfo.version);
+    catch ME
+        if exist(tempDir, 'dir')
+            rmdir(tempDir, 's');
+        end
+        rethrow(ME);
+    end
+    if exist(tempDir, 'dir')
+        rmdir(tempDir, 's');
+    end
+end
+
+function installMissingDeps(remoteFqns)
+% Check the updated packages' dependencies and install any that are missing.
+
+    missingDeps = {};
+    for i = 1:length(remoteFqns)
+        fqn = remoteFqns{i};
+        r = mip.parse.parse_package_arg(fqn);
+        pkgDir = mip.paths.get_package_dir(r.org, r.channel, r.name);
+        if ~exist(pkgDir, 'dir')
+            continue
+        end
+        try
+            pkgInfo = mip.config.read_package_json(pkgDir);
+        catch
+            continue
+        end
+        deps = pkgInfo.dependencies;
+        if isempty(deps) || (isnumeric(deps) && isempty(deps))
+            continue
+        end
+        if ~iscell(deps)
+            deps = {deps};
+        end
+        for j = 1:length(deps)
+            depFqn = mip.resolve.resolve_dependency(deps{j});
+            depR = mip.parse.parse_package_arg(depFqn);
+            depDir = mip.paths.get_package_dir(depR.org, depR.channel, depR.name);
+            if ~exist(depDir, 'dir')
+                missingDeps{end+1} = deps{j}; %#ok<AGROW>
+            end
+        end
+    end
+    missingDeps = unique(missingDeps, 'stable');
+
+    if isempty(missingDeps)
+        return
+    end
+
+    fprintf('\nInstalling new dependencies: %s\n', strjoin(missingDeps, ', '));
+
+    % Record which packages are directly installed before calling mip.install
+    % so we can undo any additions (new deps should not be directly installed).
+    directBefore = mip.state.get_directly_installed();
+
+    mip.install(missingDeps{:});
+
+    directAfter = mip.state.get_directly_installed();
+    newlyDirect = setdiff(directAfter, directBefore);
+    for i = 1:length(newlyDirect)
+        mip.state.remove_directly_installed(newlyDirect{i});
+    end
 end
 
 function reloadPreviouslyLoaded(loadedBefore, directlyLoadedBefore)

--- a/docs/behavior-reference-cheat-sheet.md
+++ b/docs/behavior-reference-cheat-sheet.md
@@ -96,11 +96,11 @@ Dependencies are loaded automatically but tracked separately -- they get pruned 
 
 ```
 mip update chebfun            % update if newer version available
-mip update --force chebfun    % force reinstall + refresh deps
+mip update --force chebfun    % force reinstall even if up to date
 mip update ./mypackage        % local packages always reinstall
 ```
 
-Update = uninstall + reinstall. Load state is preserved across the update.
+Only the named packages are updated -- existing dependencies are left as-is. New dependencies are installed automatically; orphaned dependencies are pruned. Load state is preserved across the update.
 
 ---
 

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -483,7 +483,7 @@ Using an FQN bypasses this check entirely.
 
 ## 7. Updating
 
-`mip update X Y Z` is, for the packages that actually need updating, equivalent to `mip uninstall X Y Z` followed by `mip install X Y Z`, with the set of previously-loaded packages reloaded at the end. This means each updated package's dependency graph is re-resolved against the current channel index, so dependencies are effectively updated as a side-effect of updating the packages that depend on them. Packages that do **not** need updating are left entirely alone (their dependencies are **not** revisited) unless `--force` is specified.
+`mip update X Y Z` updates only the named packages. Existing dependencies are **not** updated. After replacing each package with the latest version from its channel, any new dependencies that the updated packages require are installed and any orphaned packages (old dependencies no longer needed by any directly installed package) are pruned. Packages that do **not** need updating are left entirely alone unless `--force` is specified.
 
 ### 7.1 Update Flow (`mip update X Y Z`)
 
@@ -503,7 +503,7 @@ Using an FQN bypasses this check entirely.
 5. If no packages need updating, return. Otherwise:
    - Snapshot `MIP_LOADED_PACKAGES` and `MIP_DIRECTLY_LOADED_PACKAGES`.
    - **Local packages** are updated in-place: unload if loaded, `rmdir` the old directory, `remove_directly_installed`, then `mip.build.install_local(sourcePath, editable)`. They do **not** go through `mip.uninstall` because the prune step would remove their deps, which `install_local` cannot re-fetch from a channel.
-   - **Remote packages** go through `mip.uninstall(fqn1, fqn2, ...)` which unloads them, removes them from disk, removes them from `directly_installed.txt`, and prunes any orphaned transitive dependencies. Then `mip.install(remoteFqn1, remoteFqn2, ...)` reinstalls them with freshly-resolved dependency graphs.
+   - **Remote packages** are updated in place: unload if loaded, `rmdir` the old directory, download and extract the new version from the channel. The `directly_installed.txt` entry is preserved (no removal/re-addition). Then install any new dependencies that the updated packages require but are not yet installed, and prune any orphaned packages.
    - Reload every package in the pre-update `MIP_LOADED_PACKAGES` snapshot that is not currently loaded and whose directory exists. Packages that were in the snapshot but are no longer installed are skipped with a warning.
    - Restore `MIP_DIRECTLY_LOADED_PACKAGES` to the pre-update snapshot (filtered to entries that are actually loaded now) so that packages which were only transitively loaded before the update remain only transitively loaded after.
 
@@ -516,7 +516,7 @@ Local packages do **not** go through `mip.uninstall` + `mip.install`. Instead, t
 
 ### 7.3 Force Update (`--force`)
 
-Skips the up-to-date check. For remote packages, this forces the full `mip.uninstall` + `mip.install` cycle even when version and commit hash match, causing a fresh dependency resolution against the channel index. This is the way to "update the dependencies" of a package that is itself already up to date (see [§7.6](#76-dependency-updates)). Local packages are always reinstalled regardless of `--force`.
+Skips the up-to-date check. The named package is replaced with the latest version from the channel even when version and commit hash match. Dependencies are still not updated — only the named packages are replaced. To update a dependency, name it explicitly: `mip update dep`.
 
 ### 7.4 Self-Update (`mip update mip`)
 
@@ -526,22 +526,28 @@ Special flow for `mip-org/core/mip`:
 3. Replace the installed package in-place.
 4. Re-run `load_package.m` to reload.
 
-Does not go through the normal uninstall/reinstall flow since mip cannot be uninstalled. Self-update runs before the batch uninstall/install so it is safe to pass `mip` in the same call as other packages.
+Does not go through the normal update flow since mip cannot be uninstalled. Self-update runs before the batch so it is safe to pass `mip` in the same call as other packages.
 
 ### 7.5 Load State Preservation
 
-- Packages that were loaded before the update are reloaded afterward, including transitive dependencies that got pruned as unused during the uninstall step and then brought back by the reinstall.
+- Packages that were loaded before the update are reloaded afterward.
 - Packages that were not loaded before the update remain unloaded afterward.
 - The directly-vs-transitively loaded distinction is preserved: a package that was only transitively loaded before the update is not promoted to directly loaded, even if it needed an explicit `mip.load` call during the reload pass.
-- If a previously-loaded package ends up uninstalled after the update (e.g. it was a transitive dep of the old version but not the new one), it is skipped with a warning; its entry is effectively dropped from the loaded set.
+- If a previously-loaded package ends up uninstalled after the update (e.g. it was a transitive dep of the old version but not the new one, and was pruned), it is skipped with a warning; its entry is effectively dropped from the loaded set.
 
-### 7.6 Dependency Updates
+### 7.6 Dependency Handling
 
-Dependencies are updated only as a side-effect of updating a package that depends on them. `mip update foo` does **not** check whether `foo`'s dependencies have newer versions in the channel index. If `foo` itself is up to date, nothing happens; its dependencies are left alone. If `foo` needs an update, the uninstall+install cycle re-resolves the full dependency graph and pulls in whatever the channel currently has. `mip update --force foo` forces the uninstall+install cycle even when `foo` is up to date, which is the way to refresh `foo`'s dependencies from the channel index.
+`mip update foo` does **not** check whether `foo`'s dependencies have newer versions in the channel index. Only the named packages are updated. After the update:
+
+- **New dependencies**: if the new version of `foo` depends on a package that is not installed, it is installed automatically.
+- **Removed dependencies**: if the old version of `foo` depended on a package that is no longer needed by any directly installed package, it is pruned.
+- **Existing dependencies**: dependencies that are already installed are left as-is, even if newer versions exist in the channel.
+
+To update a dependency, name it explicitly: `mip update dep`.
 
 ### 7.7 Directly Installed Tracking
 
-The `directly_installed.txt` entry for each updated package is preserved across the update: `mip.uninstall` removes it and `mip.install` adds it back. Packages that were only transitive dependencies (not directly installed) before the update remain transitive dependencies after the update.
+The `directly_installed.txt` entry for each updated package is preserved across the update (the entry is never removed). New dependencies installed during the update are **not** added to `directly_installed.txt` — they remain transitive dependencies.
 
 ---
 

--- a/tests/TestUpdateRemote.m
+++ b/tests/TestUpdateRemote.m
@@ -131,10 +131,10 @@ classdef TestUpdateRemote < matlab.unittest.TestCase
 
         %% --- Dependency re-resolution ---
 
-        function testUpdate_ForceReresolveDeps(testCase)
+        function testUpdate_ForceDoesNotReinstallDeps(testCase)
             % Install gamma (depends on alpha). Force-update gamma.
-            % The uninstall+install cycle should prune alpha (orphaned)
-            % and re-install it alongside gamma.
+            % Alpha should NOT be reinstalled — only the named package
+            % is updated.
             mip.install('--channel', 'mip-org/test-channel1', 'gamma');
 
             gammaDir = fullfile(testCase.TestRoot, 'packages', ...
@@ -145,7 +145,7 @@ classdef TestUpdateRemote < matlab.unittest.TestCase
             testCase.verifyTrue(exist(gammaDir, 'dir') > 0);
             testCase.verifyTrue(exist(alphaDir, 'dir') > 0);
 
-            % Drop a marker in alpha to prove it was reinstalled
+            % Drop a marker in alpha to prove it was NOT reinstalled
             marker = fullfile(alphaDir, '.test_marker');
             fid = fopen(marker, 'w'); fclose(fid);
             testCase.verifyTrue(exist(marker, 'file') > 0);
@@ -155,9 +155,9 @@ classdef TestUpdateRemote < matlab.unittest.TestCase
             testCase.verifyTrue(exist(gammaDir, 'dir') > 0, ...
                 'gamma should be reinstalled');
             testCase.verifyTrue(exist(alphaDir, 'dir') > 0, ...
-                'alpha should be re-installed as dependency of gamma');
-            testCase.verifyFalse(exist(marker, 'file') > 0, ...
-                'alpha marker should be gone (dep was pruned and re-installed)');
+                'alpha should still be installed');
+            testCase.verifyTrue(exist(marker, 'file') > 0, ...
+                'alpha marker should still be there (dep was not reinstalled)');
         end
 
         function testUpdate_ForcePreservesLoadedDeps(testCase)


### PR DESCRIPTION
## Summary

- Remote packages are now updated by replacing the directory on disk and downloading the new version, rather than going through `mip.uninstall` + `mip.install`
- Existing dependencies are left as-is (not reinstalled or updated)
- New dependencies required by the updated version are installed automatically
- Orphaned dependencies (no longer needed) are pruned
- Load state is still preserved across updates

Per discussion in #99 — this matches Homebrew-style behavior where `update X` only updates X, not its deps.

Closes #99