### PR TITLE
feat: reapply cpu_level-aware variant selection and bundle support

### DIFF
--- a/+mip/+build/create_mip_json.m
+++ b/+mip/+build/create_mip_json.m
@@ -53,6 +53,10 @@ end
 
 mipData.architecture = architecture;
 
+if isfield(opts, 'cpu_level') && ~isempty(opts.cpu_level)
+    mipData.cpu_level = opts.cpu_level;
+end
+
 if isfield(opts, 'install_type')
     mipData.install_type = opts.install_type;
 else

--- a/+mip/+resolve/detect_cpu_level.m
+++ b/+mip/+resolve/detect_cpu_level.m
@@ -1,0 +1,110 @@
+function level = detect_cpu_level()
+%DETECT_CPU_LEVEL   Detect the highest supported x86_64 SIMD level.
+%
+%   level = mip.resolve.detect_cpu_level()
+%
+%   Returns one of 'x86_64_v1', 'x86_64_v2', 'x86_64_v3', 'x86_64_v4',
+%   or '' on non-x86_64 platforms (macOS ARM, etc.).
+%
+%   Only relevant for linux_x86_64 and windows_x86_64 — the only platforms
+%   where SIMD variants are built.  Pure MATLAB, no MEX needed.
+
+arch = computer('arch');
+
+if strcmp(arch, 'glnxa64')
+    flags = get_linux_flags();
+elseif strcmp(arch, 'win64')
+    flags = get_windows_flags();
+else
+    % macOS and other platforms: no SIMD variants built
+    level = '';
+    return
+end
+
+% psABI level definitions (cumulative)
+if has_all(flags, {'avx512f','avx512bw','avx512cd','avx512dq','avx512vl'})
+    level = 'x86_64_v4';
+elseif has_all(flags, {'avx2','fma','bmi1','bmi2'})
+    level = 'x86_64_v3';
+elseif has_all(flags, {'sse4_2','ssse3','popcnt'})
+    level = 'x86_64_v2';
+else
+    level = 'x86_64_v1';
+end
+
+end
+
+
+function result = has_all(flags, required)
+%HAS_ALL  True if every element of REQUIRED is in FLAGS.
+result = all(ismember(required, flags));
+end
+
+
+function flags = get_linux_flags()
+%GET_LINUX_FLAGS  Parse /proc/cpuinfo for the 'flags' line.
+flags = {};
+try
+    text = fileread('/proc/cpuinfo');
+    lines = strsplit(text, newline);
+    for i = 1:numel(lines)
+        if startsWith(strtrim(lines{i}), 'flags')
+            parts = strsplit(lines{i}, ':');
+            if numel(parts) >= 2
+                flags = strsplit(strtrim(parts{2}));
+            end
+            return
+        end
+    end
+catch
+    % /proc/cpuinfo unreadable — fall back to v1
+end
+end
+
+
+function flags = get_windows_flags()
+%GET_WINDOWS_FLAGS  Detect CPU features on Windows via kernel32.
+%
+%   Uses IsProcessorFeaturePresent() via PowerShell P/Invoke.
+%   Feature IDs: PF_SSE3_INSTRUCTIONS_AVAILABLE=13,
+%   PF_SSSE3_INSTRUCTIONS_AVAILABLE=36, PF_SSE4_1=37, PF_SSE4_2=38,
+%   PF_AVX_INSTRUCTIONS_AVAILABLE=39, PF_AVX2=40, PF_AVX512F=43.
+
+flags = {};
+try
+    cmd = [ ...
+        'powershell -NoProfile -Command "' ...
+        'Add-Type -MemberDefinition ''[DllImport(""""kernel32.dll"""")]' ...
+        ' public static extern bool IsProcessorFeaturePresent(int f);'' ' ...
+        '-Name K32 -Namespace W32; ' ...
+        '$r = @{}; ' ...
+        'foreach ($kv in @{ssse3=36;sse4_2=38;popcnt=38;avx2=40;avx512f=43}.GetEnumerator()) {' ...
+        '  $r[$kv.Key] = [W32.K32]::IsProcessorFeaturePresent($kv.Value)' ...
+        '}; ' ...
+        '$r.GetEnumerator() | ForEach-Object { Write-Output (""""{0}={1}"""" -f $_.Key,$_.Value) }' ...
+        '"'];
+    [status, output] = system(cmd);
+    if status ~= 0
+        return
+    end
+    lines = strsplit(strtrim(output), newline);
+    for i = 1:numel(lines)
+        parts = strsplit(strtrim(lines{i}), '=');
+        if numel(parts) == 2 && strcmpi(strtrim(parts{2}), 'true')
+            flags{end+1} = strtrim(parts{1}); %#ok<AGROW>
+        end
+    end
+    % AVX2 implies FMA/BMI1/BMI2 on all shipping x86_64 CPUs
+    if ismember('avx2', flags)
+        flags = [flags, {'fma', 'bmi1', 'bmi2'}];
+    end
+    % AVX512F feature ID 43 only checks F; assume full v4 set.
+    % Conservative: if this is wrong, user gets v3 instead of v4,
+    % which is still fast and correct.
+    if ismember('avx512f', flags)
+        flags = [flags, {'avx512bw', 'avx512cd', 'avx512dq', 'avx512vl'}];
+    end
+catch
+    % PowerShell unavailable — fall back to v1
+end
+end

--- a/+mip/+resolve/select_best_variant.m
+++ b/+mip/+resolve/select_best_variant.m
@@ -7,6 +7,10 @@ function bestVariant = select_best_variant(variants, currentArch)
 %
 % Returns:
 %   bestVariant - The best matching variant struct, or [] if none compatible
+%
+% When multiple variants match the same architecture but differ in cpu_level,
+% selects the highest cpu_level that does not exceed the host capability.
+% Variants with cpu_level are preferred over those without (non-SIMD).
 
 if isempty(variants)
     bestVariant = [];
@@ -36,19 +40,95 @@ if isempty(compatible)
     return
 end
 
-% Prefer exact match > numbl_wasm fallback > 'any'
+% Separate into priority tiers: exact match > numbl_wasm > 'any'
+exactMatch = {};
+wasmFallback = {};
+anyMatch = {};
 for i = 1:length(compatible)
-    if strcmp(compatible{i}.architecture, currentArch)
-        bestVariant = compatible{i};
-        return
+    a = compatible{i}.architecture;
+    if strcmp(a, currentArch)
+        exactMatch = [exactMatch, {compatible{i}}]; %#ok<AGROW>
+    elseif strcmp(a, 'numbl_wasm')
+        wasmFallback = [wasmFallback, {compatible{i}}]; %#ok<AGROW>
+    else
+        anyMatch = [anyMatch, {compatible{i}}]; %#ok<AGROW>
     end
 end
-for i = 1:length(compatible)
-    if strcmp(compatible{i}.architecture, 'numbl_wasm')
-        bestVariant = compatible{i};
-        return
+
+% Pick from the highest-priority non-empty tier
+if ~isempty(exactMatch)
+    bestVariant = select_best_cpu_variant(exactMatch);
+elseif ~isempty(wasmFallback)
+    bestVariant = wasmFallback{1};
+else
+    bestVariant = anyMatch{1};
+end
+
+end
+
+
+function best = select_best_cpu_variant(variants)
+%SELECT_BEST_CPU_VARIANT  Among same-architecture variants, pick best cpu_level.
+%
+%   If any variants have a cpu_level field, detect the host level and pick
+%   the highest variant <= host.  If none have cpu_level, return the first.
+
+CPU_LEVELS = {'x86_64_v1', 'x86_64_v2', 'x86_64_v3', 'x86_64_v4'};
+
+% Split into SIMD and non-SIMD variants
+simdVariants = {};
+nonSimdVariants = {};
+for i = 1:length(variants)
+    if isfield(variants{i}, 'cpu_level') && ~isempty(variants{i}.cpu_level)
+        simdVariants = [simdVariants, {variants{i}}]; %#ok<AGROW>
+    else
+        nonSimdVariants = [nonSimdVariants, {variants{i}}]; %#ok<AGROW>
     end
 end
-bestVariant = compatible{1};
+
+if isempty(simdVariants)
+    best = nonSimdVariants{1};
+    return
+end
+
+% Detect host CPU level
+hostLevel = mip.resolve.detect_cpu_level();
+if isempty(hostLevel)
+    hostLevel = 'x86_64_v1';
+end
+fprintf('Detected host CPU level: %s\n', hostLevel);
+hostRank = find(strcmp(CPU_LEVELS, hostLevel), 1);
+if isempty(hostRank)
+    hostRank = 1;
+end
+
+% Find the best SIMD variant: highest cpu_level <= hostRank
+bestRank = 0;
+best = [];
+for i = 1:length(simdVariants)
+    lvl = simdVariants{i}.cpu_level;
+    rank = find(strcmp(CPU_LEVELS, lvl), 1);
+    if isempty(rank)
+        continue
+    end
+    if rank <= hostRank && rank > bestRank
+        bestRank = rank;
+        best = simdVariants{i};
+    end
+end
+
+% Fallback to non-SIMD if no SIMD variant fits
+if isempty(best)
+    if ~isempty(nonSimdVariants)
+        best = nonSimdVariants{1};
+        fprintf('No matching SIMD variant; using non-SIMD build\n');
+    else
+        % Last resort: pick lowest SIMD variant (v1)
+        best = simdVariants{1};
+        fprintf('No matching SIMD variant; falling back to %s\n', best.cpu_level);
+    end
+else
+    fprintf('Selected SIMD variant: %s\n', best.cpu_level);
+end
 
 end

--- a/+mip/bundle.m
+++ b/+mip/bundle.m
@@ -28,6 +28,7 @@ function bundle(varargin)
     sourceDir = '';
     outputDir = pwd;
     architecture = '';
+    cpuLevel = '';
 
     i = 1;
     while i <= length(varargin)
@@ -43,6 +44,12 @@ function bundle(varargin)
                 error('mip:bundle:missingArch', '--arch requires an architecture argument');
             end
             architecture = varargin{i + 1};
+            i = i + 2;
+        elseif ischar(arg) && strcmp(arg, '--cpu-level')
+            if i + 1 > length(varargin)
+                error('mip:bundle:missingCpuLevel', '--cpu-level requires a level argument');
+            end
+            cpuLevel = varargin{i + 1};
             i = i + 2;
         elseif isempty(sourceDir)
             sourceDir = arg;
@@ -100,9 +107,23 @@ function bundle(varargin)
         mipJson = jsondecode(mipJsonText);
         effectiveArch = mipJson.architecture;
 
-        % Build output filename
-        mhlFilename = sprintf('%s-%s-%s.mhl', ...
-            mipConfig.name, num2str(mipConfig.version), effectiveArch);
+        % Write cpu_level into mip.json if provided
+        if ~isempty(cpuLevel)
+            mipJson.cpu_level = cpuLevel;
+            mipJsonText = jsonencode(mipJson);
+            fid = fopen(mipJsonPath, 'w');
+            fwrite(fid, mipJsonText);
+            fclose(fid);
+        end
+
+        % Build output filename (with optional cpu_level suffix)
+        if ~isempty(cpuLevel)
+            mhlFilename = sprintf('%s-%s-%s-%s.mhl', ...
+                mipConfig.name, num2str(mipConfig.version), effectiveArch, cpuLevel);
+        else
+            mhlFilename = sprintf('%s-%s-%s.mhl', ...
+                mipConfig.name, num2str(mipConfig.version), effectiveArch);
+        end
         mhlPath = fullfile(outputDir, mhlFilename);
 
         % Create .mhl (zip) from staging directory contents


### PR DESCRIPTION
## Summary
- Reapplies the changes from #109 (reverted in #121)
- Adds `detect_cpu_level.m` for pure-MATLAB CPU SIMD level detection (Linux via `/proc/cpuinfo`, Windows via `kernel32`)
- `select_best_variant.m` picks the highest cpu_level variant that doesn't exceed host capability
- `bundle.m` gains `--cpu-level` flag; `create_mip_json.m` stores `cpu_level` field

## Changes from original PR
- `detect_cpu_level.m` placed in `+mip/+resolve/` (was `+mip/+utils/` which no longer exists after the refactor in #126)
- Updated namespace reference from `mip.utils.detect_cpu_level` to `mip.resolve.detect_cpu_level`