### PR TITLE
Extract get_absolute_path to replace fragile what() calls

### DIFF
--- a/+mip/+build/compute_addpaths.m
+++ b/+mip/+build/compute_addpaths.m
@@ -84,16 +84,8 @@ end
 
 function rel = getRelativePath(targetDir, baseDir)
 % Get relative path from baseDir to targetDir.
-    w = what(targetDir);
-    if isempty(w)
-        error('mip:build:notADirectory', '"%s" is not a directory.', targetDir);
-    end
-    targetDir = w.path;
-    w = what(baseDir);
-    if isempty(w)
-        error('mip:build:notADirectory', '"%s" is not a directory.', baseDir);
-    end
-    baseDir = w.path;
+    targetDir = mip.paths.get_absolute_path(targetDir);
+    baseDir   = mip.paths.get_absolute_path(baseDir);
     if strcmp(targetDir, baseDir)
         rel = '.';
     elseif startsWith(targetDir, [baseDir filesep])

--- a/+mip/+build/install_local.m
+++ b/+mip/+build/install_local.m
@@ -14,11 +14,7 @@ if nargin < 3
 end
 
 % Resolve to absolute path
-w = what(sourceDir);
-if isempty(w)
-    error('mip:install:notADirectory', '"%s" is not a directory.', sourceDir);
-end
-sourceDir = w.path;
+sourceDir = mip.paths.get_absolute_path(sourceDir);
 
 % Read mip.yaml to get package name
 mipConfig = mip.config.read_mip_yaml(sourceDir);

--- a/+mip/+paths/get_absolute_path.m
+++ b/+mip/+paths/get_absolute_path.m
@@ -10,7 +10,7 @@ function absPath = get_absolute_path(relPath)
 % Errors if the file or directory does not exist.
 
 absPath = matlab.io.internal.filesystem.resolveRelativeLocation(relPath);
-if isempty(char(absPath))
+if isempty(char(absPath)) || ~exist(absPath, 'file')
     error('mip:notAFileOrDirectory', '"%s" is not a file or directory.', relPath);
 end
 

--- a/+mip/+paths/get_absolute_path.m
+++ b/+mip/+paths/get_absolute_path.m
@@ -1,0 +1,17 @@
+function absPath = get_absolute_path(relPath)
+%GET_ABSOLUTE_PATH   Resolve a file or directory path to an absolute path.
+%
+% Args:
+%   relPath - A relative or absolute file or directory path.
+%
+% Returns:
+%   absPath - The absolute path to the file or directory.
+%
+% Errors if the file or directory does not exist.
+
+absPath = matlab.io.internal.filesystem.resolveRelativeLocation(relPath);
+if isempty(char(absPath))
+    error('mip:notAFileOrDirectory', '"%s" is not a file or directory.', relPath);
+end
+
+end

--- a/+mip/bundle.m
+++ b/+mip/bundle.m
@@ -58,14 +58,7 @@ function bundle(varargin)
     end
 
     % Resolve source directory
-    if ~exist(sourceDir, 'dir')
-        error('mip:bundle:notADirectory', '"%s" is not a directory.', sourceDir);
-    end
-    w = what(sourceDir);
-    if isempty(w)
-        error('mip:bundle:notADirectory', '"%s" is not a directory.', sourceDir);
-    end
-    sourceDir = w.path;
+    sourceDir = mip.paths.get_absolute_path(sourceDir);
 
     % Check for mip.yaml
     if ~exist(fullfile(sourceDir, 'mip.yaml'), 'file')
@@ -77,11 +70,7 @@ function bundle(varargin)
     if ~exist(outputDir, 'dir')
         mkdir(outputDir);
     end
-    w = what(outputDir);
-    if isempty(w)
-        error('mip:bundle:notADirectory', '"%s" is not a directory.', outputDir);
-    end
-    outputDir = w.path;
+    outputDir = mip.paths.get_absolute_path(outputDir);
 
     % Prepare in a staging directory
     stagingDir = tempname;

--- a/tests/TestBundleCommand.m
+++ b/tests/TestBundleCommand.m
@@ -70,7 +70,7 @@ classdef TestBundleCommand < matlab.unittest.TestCase
         function testBundle_NonexistentDirectoryErrors(testCase)
             testCase.verifyError( ...
                 @() mip.bundle('/nonexistent/path/12345'), ...
-                'mip:bundle:notADirectory');
+                'mip:notAFileOrDirectory');
         end
 
         function testBundle_NoMipYamlErrors(testCase)


### PR DESCRIPTION
## Summary
- Introduces `mip.paths.get_absolute_path`, a robust utility for resolving relative paths to absolute paths using `matlab.io.internal.filesystem.resolveRelativeLocation`
- Replaces all uses of MATLAB's `what()` for path resolution across `compute_addpaths`, `install_local`, and `bundle`, which was fragile and limited to directories on the MATLAB path
- Simplifies error handling by consolidating repeated `what()`/`isempty` checks into a single reusable function