### PR TITLE
Use userpath/mip as the default root instead of ~/.mip

### DIFF
--- a/+mip/+paths/get_package_dir.m
+++ b/+mip/+paths/get_package_dir.m
@@ -7,7 +7,7 @@ function pkgDir = get_package_dir(org, channelName, packageName)
 %   packageName - Package name (e.g. 'chebfun')
 %
 % Returns:
-%   pkgDir - Full path: ~/.mip/packages/<org>/<channel>/<package>/
+%   pkgDir - Full path: <root>/packages/<org>/<channel>/<package>/
 
 packagesDir = mip.paths.get_packages_dir();
 pkgDir = fullfile(packagesDir, org, channelName, packageName);

--- a/+mip/+paths/get_packages_dir.m
+++ b/+mip/+paths/get_packages_dir.m
@@ -2,7 +2,7 @@ function packagesDir = get_packages_dir()
 %GET_PACKAGES_DIR   Get the mip packages directory path.
 %
 % Returns:
-%   Path to the packages directory (Default: ~/.mip/packages)
+%   Path to the packages directory: <root>/packages
 
 mipDir = mip.root();
 packagesDir = fullfile(mipDir, 'packages');

--- a/+mip/root.m
+++ b/+mip/root.m
@@ -27,28 +27,26 @@ end
 
 % Navigate up from this file's location:
 %   +mip/root -> +mip -> mip (source) -> mip (package) -> core -> mip-org -> packages -> root
-this_dir = fileparts(mfilename('fullpath'));   % .../+mip
-source_dir = fileparts(this_dir);             % .../mip/mip
-package_dir = fileparts(source_dir);          % .../core/mip
-channel_dir = fileparts(package_dir);         % .../mip-org/core
-org_dir = fileparts(channel_dir);             % .../packages/mip-org
-packages_dir = fileparts(org_dir);            % .../packages
-root = fileparts(packages_dir);               % .../root
+this_dir     = fileparts(mfilename('fullpath')); % .../+mip
+source_dir   = fileparts(this_dir);              % .../mip/mip
+package_dir  = fileparts(source_dir);            % .../core/mip
+channel_dir  = fileparts(package_dir);           % .../mip-org/core
+org_dir      = fileparts(channel_dir);           % .../packages/mip-org
+packages_dir = fileparts(org_dir);               % .../packages
+root         = fileparts(packages_dir);          % .../root
 
 if ~isfolder(fullfile(root, 'packages'))
     % Path-based detection failed (e.g., editable install where
-    % mfilename returns the source path). Fall back to ~/.mip.
-    if ispc
-        home_dir = char(java.lang.System.getProperty('user.home'));
-    else
-        home_dir = '~';
-    end
-    root = fullfile(home_dir, '.mip');
+    % mfilename returns the source path). Fall back to <userpath>/mip.
+    root = fullfile(userpath, 'mip');
     if ~isfolder(fullfile(root, 'packages'))
+        if ~ispc && ~isempty(getenv('HOME'))
+            root = replace(root, getenv('HOME'), '~');
+        end
         error('mip:rootNotFound', ...
             ['Could not determine the mip root directory.\n' ...
              'Set the MIP_ROOT environment variable to point to your mip root directory.\n' ...
-             'For example: setenv(''MIP_ROOT'', ''%s/.mip'')'], home_dir);
+             'For example: setenv(''MIP_ROOT'', ''%s'')'], root);
     end
 end
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ A package manager for MATLAB/MEX. Handles installing, updating, loading, and unl
 - **FQN (Fully Qualified Name)**: `org/channel/package` (e.g., `mip-org/core/chebfun`)
 - **Bare name**: Just `package` — resolved via priority: `mip-org/core` first, then alphabetical
 - **Channels**: Package repositories hosted on GitHub Pages (e.g., `mip-org/mip-core`)
-- **Packages installed at**: `~/.mip/packages/<org>/<channel>/<package>/`
+- **Packages installed at**: `<root>/packages/<org>/<channel>/<package>/`
 - **Editable installs**: Thin wrapper at `local/local/<pkg>/` pointing to source directory
 - **Persistent state**: Uses `setappdata(0, key, value)` for loaded/sticky/directly-loaded package tracking; `directly_installed.txt` for install tracking
 
@@ -42,5 +42,5 @@ results = run_tests();
 
 ## Development Rules
 
-- **Always add unit tests** for new functionality. Tests go in `tests/Test*.m` as `matlab.unittest.TestCase` subclasses. Use `createTestPackage` and `createTestSourcePackage` helpers to set up fake packages in temporary directories. Use `MIP_ROOT` env var to isolate tests from the real `~/.mip`.
+- **Always add unit tests** for new functionality. Tests go in `tests/Test*.m` as `matlab.unittest.TestCase` subclasses. Use `createTestPackage` and `createTestSourcePackage` helpers to set up fake packages in temporary directories. Use `MIP_ROOT` env var to isolate tests from the real `<root>` directory.
 - The special identity `mip-org/core/mip` must always be checked by FQN, never by bare name `'mip'`. Other packages named `mip` on different channels must not get special treatment.


### PR DESCRIPTION
## Summary
- Replace the hardcoded `~/.mip` fallback with MATLAB's `userpath` function, which respects the user's configured MATLAB path
- Update doc comments and CLAUDE.md to use `<root>` instead of the old hardcoded `~/.mip` path

Fixes #114