### PR TITLE
Use fileattrib for absolute path resolution

### DIFF
--- a/+mip/+paths/get_absolute_path.m
+++ b/+mip/+paths/get_absolute_path.m
@@ -9,9 +9,10 @@ function absPath = get_absolute_path(relPath)
 %
 % Errors if the file or directory does not exist.
 
-absPath = matlab.io.internal.filesystem.resolveRelativeLocation(relPath);
-if isempty(char(absPath)) || ~exist(absPath, 'file')
+[status, info] = fileattrib(relPath);
+if ~status
     error('mip:notAFileOrDirectory', '"%s" is not a file or directory.', relPath);
 end
+absPath = info.Name;
 
 end


### PR DESCRIPTION
## Summary

- Replace undocumented `matlab.io.internal.filesystem.resolveRelativeLocation` with the public `fileattrib` function for resolving absolute paths in `get_absolute_path`
- Simplifies the logic: `fileattrib` returns status and path info in one call, removing the need for a separate `exist` check