### PR TITLE
Fix undefined variable in updateSelf

### DIFF
--- a/+mip/update.m
+++ b/+mip/update.m
@@ -403,7 +403,7 @@ function updateSelf(p, force)
         mip.channel.extract_mhl(mhlPath, stagingDir);
         rmdir(pkgDir, 's');
         movefile(stagingDir, pkgDir);
-        fprintf('Successfully updated mip to %s\n', latestVersion);
+        fprintf('Successfully updated mip to %s\n', latestInfo.version);
     catch ME
         if exist(tempDir, 'dir')
             rmdir(tempDir, 's');
@@ -420,6 +420,6 @@ function updateSelf(p, force)
     if exist(loadScript, 'file')
         run(loadScript);
     end
-    fprintf('\nmip has been updated to %s.\n', latestVersion);
+    fprintf('\nmip has been updated to %s.\n', latestInfo.version);
 end
 


### PR DESCRIPTION
## Summary
- `latestVersion` was renamed to `latestInfo.version` in an earlier refactor but two references in `updateSelf` were not updated, causing `mip update mip` to error out after a successful download.

Fixes #140