### PR TITLE
Unload mip before rmdir in updateSelf to suppress path warning

### DIFF
--- a/+mip/update.m
+++ b/+mip/update.m
@@ -401,6 +401,10 @@ function updateSelf(p, force)
         mhlPath = mip.channel.download_mhl(latestInfo.mhl_url, tempDir);
         stagingDir = fullfile(tempDir, 'staging');
         mip.channel.extract_mhl(mhlPath, stagingDir);
+        unloadScript = fullfile(pkgDir, 'unload_package.m');
+        if exist(unloadScript, 'file')
+            run(unloadScript);
+        end
         rmdir(pkgDir, 's');
         movefile(stagingDir, pkgDir);
         fprintf('Successfully updated mip to %s\n', latestInfo.version);


### PR DESCRIPTION
## Summary
- Run `unload_package.m` before `rmdir(pkgDir, 's')` in `updateSelf` to cleanly remove path entries, suppressing the MATLAB path-removal warning (fixes #142)

Fixes #142