### PR TITLE
Reload packages after partial batch update failure

### DIFF
--- a/+mip/update.m
+++ b/+mip/update.m
@@ -109,53 +109,67 @@ function update(varargin)
     loadedBefore = mip.state.key_value_get('MIP_LOADED_PACKAGES');
     directlyLoadedBefore = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
 
-    % --- Local packages: rmdir + install_local (no mip.uninstall) ---
-    % Local packages cannot go through mip.uninstall because that prunes
-    % orphaned deps, and install_local cannot re-fetch them from a channel.
-    for i = 1:length(localPkgs)
-        p = localPkgs{i};
-        fprintf('Updating local package "%s"...\n', p.fqn);
+    % Wrap the update loops in try-catch so that reloadPreviouslyLoaded
+    % always runs. Without this, a failure mid-batch would leave
+    % already-updated packages unloaded for the rest of the session.
+    updateError = [];
+    try
+        % --- Local packages: rmdir + install_local (no mip.uninstall) ---
+        % Local packages cannot go through mip.uninstall because that prunes
+        % orphaned deps, and install_local cannot re-fetch them from a channel.
+        for i = 1:length(localPkgs)
+            p = localPkgs{i};
+            fprintf('Updating local package "%s"...\n', p.fqn);
 
-        if mip.state.is_loaded(p.fqn)
-            fprintf('Unloading "%s" before update...\n', p.fqn);
-            mip.unload(p.fqn);
-        end
-
-        rmdir(p.pkgDir, 's');
-        mip.state.remove_directly_installed(p.fqn);
-        packagesDir = mip.paths.get_packages_dir();
-        mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'local', 'local'));
-        mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'local'));
-
-        fprintf('Reinstalling "%s" from %s...\n', p.fqn, p.sourcePath);
-        mip.build.install_local(p.sourcePath, p.editable);
-    end
-
-    % --- Remote packages: update in place, install new deps, prune ---
-    % Each package is replaced on disk with the latest version from the
-    % channel. Existing dependencies are left alone. After all packages are
-    % updated, any new dependencies are installed and orphaned packages are
-    % pruned.
-    if ~isempty(remotePkgs)
-        for i = 1:length(remotePkgs)
-            p = remotePkgs{i};
             if mip.state.is_loaded(p.fqn)
                 fprintf('Unloading "%s" before update...\n', p.fqn);
                 mip.unload(p.fqn);
             end
-            downloadAndReplace(p);
+
+            rmdir(p.pkgDir, 's');
+            mip.state.remove_directly_installed(p.fqn);
+            packagesDir = mip.paths.get_packages_dir();
+            mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'local', 'local'));
+            mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'local'));
+
+            fprintf('Reinstalling "%s" from %s...\n', p.fqn, p.sourcePath);
+            mip.build.install_local(p.sourcePath, p.editable);
         end
 
-        % Install any new dependencies that the updated packages require
-        remoteFqns = cellfun(@(p) p.fqn, remotePkgs, 'UniformOutput', false);
-        installMissingDeps(remoteFqns);
+        % --- Remote packages: update in place, install new deps, prune ---
+        % Each package is replaced on disk with the latest version from the
+        % channel. Existing dependencies are left alone. After all packages are
+        % updated, any new dependencies are installed and orphaned packages are
+        % pruned.
+        if ~isempty(remotePkgs)
+            for i = 1:length(remotePkgs)
+                p = remotePkgs{i};
+                if mip.state.is_loaded(p.fqn)
+                    fprintf('Unloading "%s" before update...\n', p.fqn);
+                    mip.unload(p.fqn);
+                end
+                downloadAndReplace(p);
+            end
 
-        % Prune packages that are no longer needed
-        mip.state.prune_unused_packages();
+            % Install any new dependencies that the updated packages require
+            remoteFqns = cellfun(@(p) p.fqn, remotePkgs, 'UniformOutput', false);
+            installMissingDeps(remoteFqns);
+
+            % Prune packages that are no longer needed
+            mip.state.prune_unused_packages();
+        end
+    catch ME
+        updateError = ME;
     end
 
     % Reload anything that was loaded before update but isn't now.
+    % This runs even after a partial failure so that successfully-updated
+    % packages are not left unloaded.
     reloadPreviouslyLoaded(loadedBefore, directlyLoadedBefore);
+
+    if ~isempty(updateError)
+        rethrow(updateError);
+    end
 end
 
 function p = resolvePackage(packageArg)

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -534,6 +534,7 @@ Does not go through the normal update flow since mip cannot be uninstalled. Self
 - Packages that were not loaded before the update remain unloaded afterward.
 - The directly-vs-transitively loaded distinction is preserved: a package that was only transitively loaded before the update is not promoted to directly loaded, even if it needed an explicit `mip.load` call during the reload pass.
 - If a previously-loaded package ends up uninstalled after the update (e.g. it was a transitive dep of the old version but not the new one, and was pruned), it is skipped with a warning; its entry is effectively dropped from the loaded set.
+- **Partial failure**: if a package fails mid-batch, the reload pass still runs so that packages updated earlier in the batch are not left unloaded. The original error is re-raised after reloading.
 
 ### 7.6 Dependency Handling
 

--- a/tests/TestUpdateLocal.m
+++ b/tests/TestUpdateLocal.m
@@ -317,6 +317,8 @@ classdef TestUpdateLocal < matlab.unittest.TestCase
         function testUpdate_BatchFailureReloadsEarlierPackages(testCase)
             % When updating pkgA and pkgB, if pkgB fails, pkgA should
             % still be reloaded (not left unloaded).
+            % Local packages are processed in argument order, so pkgA
+            % (listed first) succeeds before pkgB fails.
             srcA = createTestSourcePackage(testCase.SourceDir, 'pkgA');
             srcB = createTestSourcePackage(testCase.SourceDir, 'pkgB');
             mip.install(srcA);
@@ -337,6 +339,31 @@ classdef TestUpdateLocal < matlab.unittest.TestCase
 
             testCase.verifyTrue(mip.state.is_loaded('local/local/pkgA'), ...
                 'pkgA should be reloaded even though pkgB failed');
+        end
+
+        function testUpdate_BatchFailureReloadsLaterPackages(testCase)
+            % Reverse ordering: pkgA fails first, pkgB (listed second)
+            % should still be reloaded.
+            srcA = createTestSourcePackage(testCase.SourceDir, 'pkgA');
+            srcB = createTestSourcePackage(testCase.SourceDir, 'pkgB');
+            mip.install(srcA);
+            mip.install(srcB);
+
+            mip.load('local/local/pkgA');
+            mip.load('local/local/pkgB');
+            testCase.verifyTrue(mip.state.is_loaded('local/local/pkgA'));
+            testCase.verifyTrue(mip.state.is_loaded('local/local/pkgB'));
+
+            % Break pkgA's source so its update fails
+            delete(fullfile(srcA, 'mip.yaml'));
+
+            % Update both — pkgA fails first but pkgB should still reload
+            testCase.verifyError( ...
+                @() mip.update('local/local/pkgA', 'local/local/pkgB'), ...
+                'mip:mipYamlNotFound');
+
+            testCase.verifyTrue(mip.state.is_loaded('local/local/pkgB'), ...
+                'pkgB should be reloaded even though pkgA failed');
         end
 
     end

--- a/tests/TestUpdateLocal.m
+++ b/tests/TestUpdateLocal.m
@@ -312,5 +312,32 @@ classdef TestUpdateLocal < matlab.unittest.TestCase
                 'pkgB should have been reinstalled');
         end
 
+        %% --- Partial batch failure reloads earlier packages (issue #146) ---
+
+        function testUpdate_BatchFailureReloadsEarlierPackages(testCase)
+            % When updating pkgA and pkgB, if pkgB fails, pkgA should
+            % still be reloaded (not left unloaded).
+            srcA = createTestSourcePackage(testCase.SourceDir, 'pkgA');
+            srcB = createTestSourcePackage(testCase.SourceDir, 'pkgB');
+            mip.install(srcA);
+            mip.install(srcB);
+
+            mip.load('local/local/pkgA');
+            mip.load('local/local/pkgB');
+            testCase.verifyTrue(mip.state.is_loaded('local/local/pkgA'));
+            testCase.verifyTrue(mip.state.is_loaded('local/local/pkgB'));
+
+            % Break pkgB's source so its update fails
+            delete(fullfile(srcB, 'mip.yaml'));
+
+            % Update both — pkgB should fail but pkgA should still reload
+            testCase.verifyError( ...
+                @() mip.update('local/local/pkgA', 'local/local/pkgB'), ...
+                'mip:mipYamlNotFound');
+
+            testCase.verifyTrue(mip.state.is_loaded('local/local/pkgA'), ...
+                'pkgA should be reloaded even though pkgB failed');
+        end
+
     end
 end


### PR DESCRIPTION
## Summary
- Wrapped local and remote update loops in try-catch so `reloadPreviouslyLoaded` always runs, even when a package fails mid-batch
- The original error is re-raised after reloading
- Previously, if package N failed during `mip update A B C`, packages 1..N-1 would be left unloaded for the rest of the session

Fixes #146