### PR TITLE
Convert source to char in download_mhl

### DIFF
--- a/+mip/+channel/download_mhl.m
+++ b/+mip/+channel/download_mhl.m
@@ -17,6 +17,8 @@ if ~exist(destDir, 'dir')
     mkdir(destDir);
 end
 
+source = char(source);
+
 % Check if source is a URL or local file
 isURL = startsWith(source, {'http://', 'https://'});
 
@@ -31,9 +33,7 @@ if isURL
     if isempty(ext)
         ext = '.mhl'; % Default extension for packages
     end
-    filename = [filename, ext];
-
-    localPath = fullfile(destDir, filename);
+    localPath = fullfile(destDir, [filename ext]);
 
     try
         fprintf('Downloading from %s...\n', source);
@@ -50,9 +50,8 @@ else
     if ~exist(source, 'file')
         error('mip:fileNotFound', 'Local file not found: %s', source);
     end
-
     [~, filename, ext] = fileparts(source);
-    localPath = fullfile(destDir, [filename, ext]);
+    localPath = fullfile(destDir, [filename ext]);
 
     try
         copyfile(source, localPath);


### PR DESCRIPTION
## Summary
- Add `source = char(source)` to handle MATLAB string inputs (not just char arrays)
- Clean up concatenation syntax and whitespace

## Test plan
- [ ] Verify `download_mhl` works when `source` is passed as a MATLAB string (`"https://..."`)
- [ ] Verify `download_mhl` still works with char array inputs (`'https://...'`)
- [ ] Verify local file copy path also handles string inputs