### PR TITLE
Add code coverage support with Codecov integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,3 +21,20 @@ jobs:
       - uses: matlab-actions/run-command@v2
         with:
           command: "addpath('tests'); addpath('tests/helpers'); results = run_tests(); assert(all([results.Passed]), 'Some tests failed');"
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: matlab-actions/setup-matlab@v2
+
+      - uses: matlab-actions/run-command@v2
+        with:
+          command: "addpath('tests'); addpath('tests/helpers'); results = run_tests('Coverage', true); assert(all([results.Passed]), 'Some tests failed');"
+
+      - uses: codecov/codecov-action@v5
+        if: always()
+        with:
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ build/
 dist/
 *.egg-info/
 
+# Coverage
+coverage.xml
+coverage-report/
+
 # IDE
 .vscode/
 .idea/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
-[![codecov](https://codecov.io/gh/mip-org/mip/graph/badge.svg)](https://codecov.io/gh/mip-org/mip)
-
 Visit [mip.sh](https://mip.sh)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![codecov](https://codecov.io/gh/mip-org/mip/graph/badge.svg)](https://codecov.io/gh/mip-org/mip)
+
 Visit [mip.sh](https://mip.sh)

--- a/tests/run_tests.m
+++ b/tests/run_tests.m
@@ -1,8 +1,13 @@
-function results = run_tests()
+function results = run_tests(varargin)
 %RUN_TESTS   Run all mip unit tests.
 %
 % Usage:
 %   results = run_tests();
+%   results = run_tests('Coverage', true);
+%
+% Name-Value Arguments:
+%   Coverage - Enable code coverage reporting (default: false).
+%              Generates coverage.xml (Cobertura format) in the repo root.
 %
 % Returns:
 %   results - TestResult array from MATLAB's testing framework
@@ -10,6 +15,11 @@ function results = run_tests()
 import matlab.unittest.TestSuite
 import matlab.unittest.TestRunner
 import matlab.unittest.plugins.DiagnosticsValidationPlugin
+
+% Parse optional arguments
+p = inputParser;
+addParameter(p, 'Coverage', false, @islogical);
+parse(p, varargin{:});
 
 % Get the directory containing this script
 testDir = fileparts(mfilename('fullpath'));
@@ -61,6 +71,25 @@ end
 
 % Run tests
 runner = TestRunner.withTextOutput('Verbosity', 3);
+
+% Add coverage plugins if requested
+if p.Results.Coverage
+    import matlab.unittest.plugins.CodeCoveragePlugin
+    import matlab.unittest.plugins.codecoverage.CoberturaFormat
+    import matlab.unittest.plugins.codecoverage.CoverageReport
+
+    sourceFolder = fullfile(repoRoot, '+mip');
+    coverageFile = fullfile(repoRoot, 'coverage.xml');
+    coverageDir = fullfile(repoRoot, 'coverage-report');
+    runner.addPlugin(CodeCoveragePlugin.forFolder(sourceFolder, ...
+        'IncludingSubfolders', true, ...
+        'Producing', [CoberturaFormat(coverageFile), ...
+                      CoverageReport(coverageDir)]));
+    fprintf('Code coverage enabled.\n');
+    fprintf('  Cobertura XML: %s\n', coverageFile);
+    fprintf('  HTML report:   %s\n', fullfile(coverageDir, 'index.html'));
+end
+
 results = runner.run(suite);
 
 % Print summary


### PR DESCRIPTION
## Summary
- Add optional `'Coverage', true` flag to `run_tests` that instruments all `+mip/` source files and generates Cobertura XML + HTML coverage reports
- Add a `coverage` CI job that uploads results to Codecov on every push/PR to main
- Add Codecov badge to README