### PR TITLE
Treat @ as literal in local paths, improve hint for @version

### DIFF
--- a/+mip/install.m
+++ b/+mip/install.m
@@ -25,6 +25,8 @@ function install(varargin)
 %   or a Windows drive letter (e.g. 'C:\path\mypkg', 'C:/path/mypkg').
 %   The directory must contain a mip.yaml file. In editable mode, changes
 %   to the source directory are reflected immediately without reinstalling.
+%   '@' in local paths is treated as a literal character, not a version
+%   separator (e.g. './@MyClass', './pkg@dev' are valid local paths).
 %
 %   Bare names like 'chebfun' are always resolved against channels, even
 %   if a directory of the same name exists in the current folder. Use
@@ -514,15 +516,34 @@ end
 function hint = buildLocalDirHint(repoPackages)
 % If any of the repo-style args also exists as a relative directory in
 % the current folder, build a hint suggesting the './' form.
+% Also checks the base name after stripping any @version suffix, since
+% local paths treat '@' as a literal character (not a version separator).
     lines = {};
     for i = 1:length(repoPackages)
-        pkg = repoPackages{i};
-        if isfolder(pkg)
+        dirName = matchLocalDir(repoPackages{i});
+        if ~isempty(dirName)
             lines{end+1} = sprintf( ... %#ok<AGROW>
                 ['Note: a local directory "%s" exists in the current folder.\n' ...
                  'To install it as a local package instead, run:\n' ...
-                 '  mip install ./%s'], pkg, pkg);
+                 '  mip install ./%s'], dirName, dirName);
         end
     end
     hint = strjoin(lines, sprintf('\n\n'));
+end
+
+function dirName = matchLocalDir(pkg)
+% Check if pkg matches a local directory, either as-is or after stripping
+% a trailing @version suffix.
+    dirName = '';
+    if isfolder(pkg)
+        dirName = pkg;
+    else
+        atIdx = strfind(pkg, '@');
+        if ~isempty(atIdx)
+            baseName = pkg(1:atIdx(end)-1);
+            if isfolder(baseName)
+                dirName = baseName;
+            end
+        end
+    end
 end

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -32,7 +32,9 @@ Any package argument passed to a `mip` command (bare or FQN) can include `@versi
 
 The `@` is parsed from the last occurrence in the string. The version suffix is stripped before resolving the package identity.
 
-The `@version` suffix applies **only** to command-line package arguments. It is not supported inside the `dependencies` field of `mip.yaml` -- dependency entries are plain package names (bare or FQN) with no version or version-constraint grammar.
+The `@version` suffix applies **only** to command-line package arguments that are not local paths. It is not supported inside the `dependencies` field of `mip.yaml` -- dependency entries are plain package names (bare or FQN) with no version or version-constraint grammar.
+
+When an argument is identified as a local path (see [§3.0](#30-argument-categorization)), `@` is treated as a literal path character, not a version separator. This allows installing from directories whose names contain `@` (e.g., MATLAB class folders like `@MyClass`). For example, `./@MyClass` and `./pkg@dev` are both valid local paths where `@` is part of the directory name.
 
 ### 1.5 Channels
 
@@ -166,7 +168,7 @@ Used by: `mip install` for remote packages
 
 This means a bare name like `chebfun` is **always** treated as a channel install, even if a directory called `chebfun` happens to exist in the current folder. To install a local directory, the user must write `./chebfun`. This was decided in [#107](https://github.com/mip-org/mip/issues/107) to avoid the surprise of a local directory shadowing a channel package.
 
-If a channel install fails (e.g. `mip:packageNotFound`, `mip:indexFetchFailed`) and one of the requested names also exists as a relative directory in the current folder, the error message is augmented with a hint about prefixing with `./` so the user knows how to install it as a local package instead.
+If a channel install fails (e.g. `mip:packageNotFound`, `mip:indexFetchFailed`) and one of the requested names also exists as a relative directory in the current folder, the error message is augmented with a hint about prefixing with `./` so the user knows how to install it as a local package instead. When the argument contains `@` (e.g. `foo@1.0`), the hint also checks the base name with the `@version` suffix stripped (i.e. checks for a directory named `foo`).
 
 The `--editable` / `-e` flag is only valid when at least one local path is present in the argument list. Using `-e` with only bare-name or FQN arguments raises `mip:install:editableRequiresLocal`.
 

--- a/tests/TestInstallLocal.m
+++ b/tests/TestInstallLocal.m
@@ -287,5 +287,80 @@ classdef TestInstallLocal < matlab.unittest.TestCase
                 'mip:install:notADirectory');
         end
 
+        %% --- @ in local paths (issue #107) ---
+        % When a local-path prefix (~, ., /) is present, '@' is a literal
+        % path character, not a version separator.
+
+        function testInstall_DotSlashAtDirTreatedAsLocal(testCase)
+            % './@foo' should be categorized as a local path, not parsed
+            % as a bare name with '@' version syntax.
+            testCase.verifyError(@() mip.install('./@nonexistent_mip_pkg'), ...
+                'mip:install:notADirectory');
+        end
+
+        function testInstall_DotSlashPathWithAtTreatedAsLocal(testCase)
+            % './pkg@1.0' should be categorized as a local path, not
+            % split on '@' to extract a version.
+            testCase.verifyError(@() mip.install('./pkg@1.0'), ...
+                'mip:install:notADirectory');
+        end
+
+        function testInstall_AbsolutePathWithAtTreatedAsLocal(testCase)
+            % An absolute path containing '@' is still a local path.
+            testCase.verifyError(@() mip.install('/nonexistent/@mip_pkg'), ...
+                'mip:install:notADirectory');
+        end
+
+        function testInstall_LocalDirWithAtInstallsSuccessfully(testCase)
+            % A local directory whose name contains '@' should install
+            % when prefixed with './'. The '@' is part of the path, not
+            % a version separator.
+            atDir = fullfile(testCase.SourceDir, 'pkg@dev');
+            mkdir(atDir);
+            fid = fopen(fullfile(atDir, 'mip.yaml'), 'w');
+            fprintf(fid, 'name: mypkg\nversion: "1.0.0"\n');
+            fprintf(fid, 'description: "Test"\nlicense: MIT\n');
+            fprintf(fid, 'dependencies: []\naddpaths:\n  - path: "."\n');
+            fprintf(fid, 'builds:\n  - architectures: [any]\n');
+            fclose(fid);
+            fid = fopen(fullfile(atDir, 'mypkg.m'), 'w');
+            fprintf(fid, 'function r = mypkg(), r = 1; end\n');
+            fclose(fid);
+
+            origCwd = pwd;
+            cleanupCwd = onCleanup(@() cd(origCwd));
+            cd(testCase.SourceDir);
+
+            mip.install('./pkg@dev');
+
+            pkgDir = fullfile(testCase.TestRoot, 'packages', 'local', 'local', 'mypkg');
+            testCase.verifyTrue(exist(pkgDir, 'dir') > 0, ...
+                'Package from @-containing directory should be installed');
+        end
+
+        function testInstall_EditableLocalDirWithAt(testCase)
+            % Editable install from a directory with '@' in the name.
+            atDir = fullfile(testCase.SourceDir, '@MyClass');
+            mkdir(atDir);
+            fid = fopen(fullfile(atDir, 'mip.yaml'), 'w');
+            fprintf(fid, 'name: myclass\nversion: "1.0.0"\n');
+            fprintf(fid, 'description: "Test"\nlicense: MIT\n');
+            fprintf(fid, 'dependencies: []\naddpaths:\n  - path: "."\n');
+            fprintf(fid, 'builds:\n  - architectures: [any]\n');
+            fclose(fid);
+            fid = fopen(fullfile(atDir, 'myclass.m'), 'w');
+            fprintf(fid, 'function r = myclass(), r = 1; end\n');
+            fclose(fid);
+
+            mip.install('-e', atDir);
+
+            pkgDir = fullfile(testCase.TestRoot, 'packages', 'local', 'local', 'myclass');
+            testCase.verifyTrue(exist(pkgDir, 'dir') > 0, ...
+                'Editable install from @-directory should succeed');
+            info = mip.config.read_package_json(pkgDir);
+            testCase.verifyTrue(info.editable);
+            testCase.verifyTrue(contains(info.source_path, '@MyClass'));
+        end
+
     end
 end

--- a/tests/TestInstallRemote.m
+++ b/tests/TestInstallRemote.m
@@ -441,6 +441,54 @@ classdef TestInstallRemote < matlab.unittest.TestCase
             assert(isobject(cleanupScratch) && isobject(cleanupCwd));
         end
 
+        function testInstall_BareNameWithVersionFailureMentionsLocalDirHint(testCase)
+            % If 'foo@1.0' fails on the channel and a directory named 'foo'
+            % exists in cwd, the error should hint at './foo'.
+            scratch = [tempname '_mip_cwd'];
+            mkdir(scratch);
+            cleanupScratch = onCleanup(@() rmdir(scratch, 's'));
+            origCwd = pwd;
+            cleanupCwd = onCleanup(@() cd(origCwd));
+            cd(scratch);
+
+            mkdir(fullfile(scratch, 'no_such_pkg_xyz'));
+
+            try
+                mip.install('no_such_pkg_xyz@1.0');
+                testCase.verifyFail('Expected mip.install to fail');
+            catch ME
+                testCase.verifyTrue(contains(ME.message, './no_such_pkg_xyz'), ...
+                    'Error message should hint at ./no_such_pkg_xyz when @version is stripped');
+            end
+
+            assert(isobject(cleanupScratch) && isobject(cleanupCwd));
+        end
+
+        function testInstall_BareNameWithVersionFailureHintsLiteralAtDir(testCase)
+            % If 'foo@1.0' fails on the channel and both 'foo@1.0' and
+            % 'foo' exist as directories, the hint should prefer the exact
+            % match 'foo@1.0'.
+            scratch = [tempname '_mip_cwd'];
+            mkdir(scratch);
+            cleanupScratch = onCleanup(@() rmdir(scratch, 's'));
+            origCwd = pwd;
+            cleanupCwd = onCleanup(@() cd(origCwd));
+            cd(scratch);
+
+            mkdir(fullfile(scratch, 'no_such_pkg_xyz'));
+            mkdir(fullfile(scratch, 'no_such_pkg_xyz@1.0'));
+
+            try
+                mip.install('no_such_pkg_xyz@1.0');
+                testCase.verifyFail('Expected mip.install to fail');
+            catch ME
+                testCase.verifyTrue(contains(ME.message, './no_such_pkg_xyz@1.0'), ...
+                    'Error message should hint at ./no_such_pkg_xyz@1.0 (exact match preferred)');
+            end
+
+            assert(isobject(cleanupScratch) && isobject(cleanupCwd));
+        end
+
     end
 
 end


### PR DESCRIPTION
## Summary
- Local paths (prefixed with `~`, `.`, `/`) now explicitly treat `@` as a literal path character, not a version separator. This supports MATLAB class directories (`@MyClass`) and directories with `@` in their names (`pkg@dev`).
- `buildLocalDirHint` now strips the `@version` suffix when checking for matching local directories. Previously, `mip install foo@1.0` with a local `foo/` directory showed no hint; now it suggests `mip install ./foo`. Exact-match directories (e.g., `foo@1.0/`) are still preferred.
- Added docs in §1.4 and §3.0 of behavior-reference.md describing `@` semantics in local paths.

Closes #107.

## Test plan
- [x] 5 new offline tests in `TestInstallLocal.m`: `./@foo`, `./pkg@1.0`, `/path/@foo` categorized as local; end-to-end copy and editable installs from `@`-containing directories
- [x] 2 new integration tests in `TestInstallRemote.m`: `foo@1.0` hint fires when `foo/` exists; exact-match `foo@1.0/` directory preferred over stripped `foo/`
- [x] All 378 tests pass