### PR TITLE
Add --no-compile flag to mip update

### DIFF
--- a/+mip/update.m
+++ b/+mip/update.m
@@ -14,6 +14,7 @@ function update(varargin)
 %   --force           Force update even if already up to date
 %   --all             Update all installed packages
 %   --deps            Also update the dependencies of the named packages
+%   --no-compile      Skip compilation when updating editable local installs
 %
 % For each requested package, checks whether an update is needed. For
 % remote packages, the installed version (and commit hash) is compared
@@ -41,10 +42,11 @@ function update(varargin)
         error('mip:update:noPackage', 'At least one package name is required for update command.');
     end
 
-    % Check for --force, --all, and --deps flags
+    % Check for --force, --all, --deps, and --no-compile flags
     force = false;
     updateAll = false;
     updateDeps = false;
+    noCompile = false;
     args = {};
     for i = 1:length(varargin)
         arg = varargin{i};
@@ -54,6 +56,8 @@ function update(varargin)
             updateAll = true;
         elseif ischar(arg) && strcmp(arg, '--deps')
             updateDeps = true;
+        elseif ischar(arg) && strcmp(arg, '--no-compile')
+            noCompile = true;
         else
             args{end+1} = arg; %#ok<AGROW>
         end
@@ -169,7 +173,7 @@ function update(varargin)
 
             fprintf('Reinstalling "%s" from %s...\n', p.fqn, p.sourcePath);
             try
-                mip.build.install_local(p.sourcePath, p.editable);
+                mip.build.install_local(p.sourcePath, p.editable, noCompile);
             catch ME
                 % Restore old package on failure
                 parentDir = fileparts(p.pkgDir);

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -94,6 +94,19 @@ function update(varargin)
         toProcess{i} = resolvePackage(args{i});
     end
 
+    % --no-compile only applies to editable local installs. Error if any
+    % package in the batch is not an editable local install.
+    if noCompile
+        for i = 1:length(toProcess)
+            p = toProcess{i};
+            if ~(p.isLocal && p.editable)
+                error('mip:update:noCompileRequiresEditable', ...
+                      '--no-compile can only be used when all updated packages are editable local installs (offending package: "%s").', ...
+                      p.fqn);
+            end
+        end
+    end
+
     % Handle self-update (`mip-org/core/mip`) separately and remove it
     % from the batch. mip cannot be uninstalled through the normal flow.
     keepMask = true(1, length(toProcess));

--- a/docs/behavior-reference-cheat-sheet.md
+++ b/docs/behavior-reference-cheat-sheet.md
@@ -40,6 +40,7 @@ Pin a version with `@`: `chebfun@1.2.0`, `mip-org/core/chebfun@main`
 | `mip update <pkg>` | Reinstall latest version, preserve load state |
 | `mip update --deps <pkg>` | Update package and its dependencies |
 | `mip update --all` | Update all installed packages |
+| `mip update --no-compile <pkg>` | Update editable local install without re-running compile_script |
 | `mip load <pkg>` | Add package (+ deps) to MATLAB path |
 | `mip unload <pkg>` | Remove package from path, prune unused deps |
 | `mip list` | List installed packages |
@@ -102,6 +103,7 @@ mip update --force chebfun    % force reinstall even if up to date
 mip update --deps chebfun     % update chebfun and its dependencies
 mip update --all              % update all installed packages
 mip update ./mypackage        % local packages always reinstall
+mip update --no-compile <pkg> % editable local: skip compile_script
 ```
 
 Only the named packages are updated -- existing dependencies are left as-is unless `--deps` is specified. Missing dependencies are installed automatically; orphaned dependencies are pruned. Load state is preserved across the update.
@@ -114,7 +116,7 @@ Only the named packages are updated -- existing dependencies are left as-is unle
 
 **Directly installed vs. dependencies.** MIP tracks which packages you explicitly installed vs. which were pulled in as dependencies. Orphaned dependencies are automatically pruned on uninstall or unload.
 
-**Editable installs** create a thin wrapper that points to your source directory. Changes to source files take effect immediately. `mip update` re-runs compilation.
+**Editable installs** create a thin wrapper that points to your source directory. Changes to source files take effect immediately. `mip update` re-runs compilation by default; pass `--no-compile` to skip it for a given update.
 
 **Sticky packages** survive `mip unload --all`. Use `--force` to override.
 

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -516,7 +516,7 @@ Using an FQN bypasses this check entirely.
 Local packages do **not** go through `mip.uninstall` + `mip.install`. Instead, the old package directory is moved to a temporary backup and `mip.build.install_local` is called with the original `source_path` and `editable` flag from `mip.json`. If `install_local` fails, the backup is restored and the package remains in its pre-update state. This avoids pruning transitive dependencies that `install_local` cannot re-fetch.
 
 - The up-to-date check is skipped -- local packages are always reinstalled.
-- Timestamps change on every update. For editable installs the `compile_script` runs again on every update; the `--no-compile` flag from the original install is **not** preserved.
+- Timestamps change on every update. For editable installs the `compile_script` runs again on every update; the `--no-compile` flag from the original install is **not** preserved. Pass `--no-compile` to `mip update` to skip compilation for the current update.
 
 ### 7.3 Force Update (`--force`)
 

--- a/docs/behavior-reference.md
+++ b/docs/behavior-reference.md
@@ -490,13 +490,14 @@ Using an FQN bypasses this check entirely.
 
 ### 7.1 Update Flow (`mip update X Y Z`)
 
-1. Parse `--force`, `--all`, and `--deps` flags.
+1. Parse `--force`, `--all`, `--deps`, and `--no-compile` flags.
 2. If `--all` is specified, expand the argument list to all installed packages. If `--deps` is specified, expand each package's installed transitive dependencies into the argument list.
 3. Resolve each argument to a `(fqn, org, channel, name, pkgDir, pkgInfo, isLocal, sourcePath, editable)` tuple. Validation errors are raised **before** any destructive action:
    - Not installed → `mip:update:notInstalled`.
    - Local package without `source_path` in `mip.json` → `mip:update:noSourcePath`.
    - Local package whose source directory is missing → `mip:update:sourceNotFound`.
-4. If `mip-org/core/mip` is among the arguments, handle it via the self-update flow ([§7.6](#76-self-update-mip-update-mip)) and remove it from the batch.
+   - `--no-compile` specified but any package in the batch is not an editable local install → `mip:update:noCompileRequiresEditable`.
+4. If `mip-org/core/mip` is among the arguments, handle it via the self-update flow ([§7.7](#77-self-update-mip-update-mip)) and remove it from the batch.
 5. For each remaining package, decide whether it needs updating:
    - `--force`: always yes.
    - Local package: always yes (no up-to-date check).
@@ -506,7 +507,7 @@ Using an FQN bypasses this check entirely.
      - Different version: update.
 6. If no packages need updating, return. Otherwise:
    - Snapshot `MIP_LOADED_PACKAGES` and `MIP_DIRECTLY_LOADED_PACKAGES`.
-   - **Local packages** are updated via backup-and-restore: unload if loaded, move the old directory to a temporary backup, `remove_directly_installed`, then `mip.build.install_local(sourcePath, editable)`. If `install_local` fails, the backup is moved back and `directly_installed` is restored. They do **not** go through `mip.uninstall` because the prune step would remove their deps, which `install_local` cannot re-fetch from a channel.
+   - **Local packages** are updated via backup-and-restore: unload if loaded, move the old directory to a temporary backup, `remove_directly_installed`, then `mip.build.install_local(sourcePath, editable, noCompile)`. If `install_local` fails, the backup is moved back and `directly_installed` is restored. They do **not** go through `mip.uninstall` because the prune step would remove their deps, which `install_local` cannot re-fetch from a channel.
    - **Remote packages** are updated via staging: unload if loaded, download and extract the new version to a temporary staging directory, then move the old directory to a backup and move the staged version into place. If the swap fails, the backup is restored. The old package is never destroyed until the new version is fully in place. The `directly_installed.txt` entry is preserved (no removal/re-addition). Then install any missing dependencies that the updated packages require, and prune any orphaned packages.
    - Reload every package in the pre-update `MIP_LOADED_PACKAGES` snapshot that is not currently loaded and whose directory exists. Packages that were in the snapshot but are no longer installed are skipped with a warning.
    - Restore `MIP_DIRECTLY_LOADED_PACKAGES` to the pre-update snapshot (filtered to entries that are actually loaded now) so that packages which were only transitively loaded before the update remain only transitively loaded after.
@@ -516,7 +517,7 @@ Using an FQN bypasses this check entirely.
 Local packages do **not** go through `mip.uninstall` + `mip.install`. Instead, the old package directory is moved to a temporary backup and `mip.build.install_local` is called with the original `source_path` and `editable` flag from `mip.json`. If `install_local` fails, the backup is restored and the package remains in its pre-update state. This avoids pruning transitive dependencies that `install_local` cannot re-fetch.
 
 - The up-to-date check is skipped -- local packages are always reinstalled.
-- Timestamps change on every update. For editable installs the `compile_script` runs again on every update; the `--no-compile` flag from the original install is **not** preserved. Pass `--no-compile` to `mip update` to skip compilation for the current update.
+- Timestamps change on every update. For editable installs the `compile_script` runs again on every update by default; the `--no-compile` flag from the original install is **not** preserved. Pass `--no-compile` to `mip update` to skip compilation for the current update ([§7.6](#76-skip-compilation-no-compile)).
 
 ### 7.3 Force Update (`--force`)
 
@@ -530,7 +531,11 @@ Skips the up-to-date check. The named package is replaced with the latest versio
 
 `mip update --deps foo` updates `foo` **and** all of its installed transitive dependencies. Dependencies are resolved recursively from each package's `mip.json`. Only dependencies that are actually installed are included — missing dependencies are not installed by this flag (they are handled by the normal new-dependency installation step after the update). Can be combined with `--force`. Can be combined with multiple package names: `mip update --deps foo bar`.
 
-### 7.6 Self-Update (`mip update mip`)
+### 7.6 Skip Compilation (`--no-compile`)
+
+`mip update --no-compile foo` skips the `compile_script` step when updating `foo`. Only applies to editable local installs — if any package in the batch is not an editable local install (non-editable local, remote, or `mip` itself), the call raises `mip:update:noCompileRequiresEditable` **before** any destructive action. Can be combined with `--force`, `--all`, and `--deps`, but only when every resolved package is an editable local install.
+
+### 7.7 Self-Update (`mip update mip`)
 
 Special flow for `mip-org/core/mip`:
 1. Fetch the latest from the `mip-org/core` channel.
@@ -540,7 +545,7 @@ Special flow for `mip-org/core/mip`:
 
 Does not go through the normal update flow since mip cannot be uninstalled. Self-update runs before the batch so it is safe to pass `mip` in the same call as other packages.
 
-### 7.7 Load State Preservation
+### 7.8 Load State Preservation
 
 - Packages that were loaded before the update are reloaded afterward.
 - Packages that were not loaded before the update remain unloaded afterward.
@@ -548,7 +553,7 @@ Does not go through the normal update flow since mip cannot be uninstalled. Self
 - If a previously-loaded package ends up uninstalled after the update (e.g. it was a transitive dep of the old version but not the new one, and was pruned), it is skipped with a warning; its entry is effectively dropped from the loaded set.
 - **Partial failure**: if a package fails mid-batch, the reload pass still runs so that packages updated earlier in the batch are not left unloaded. The original error is re-raised after reloading.
 
-### 7.8 Dependency Handling
+### 7.9 Dependency Handling
 
 `mip update foo` does **not** check whether `foo`'s dependencies have newer versions in the channel index. Only the named packages are updated. After the update:
 
@@ -558,7 +563,7 @@ Does not go through the normal update flow since mip cannot be uninstalled. Self
 
 To update a dependency, name it explicitly (`mip update dep`) or use `--deps` to update a package and all its dependencies in one command.
 
-### 7.9 Directly Installed Tracking
+### 7.10 Directly Installed Tracking
 
 The `directly_installed.txt` entry for each updated package is preserved across the update (the entry is never removed). Missing dependencies installed during the update are **not** added to `directly_installed.txt` — they remain transitive dependencies.
 

--- a/mip.m
+++ b/mip.m
@@ -10,6 +10,7 @@ function varargout = mip(command, varargin)
 %   mip update --force <package>             - Force update even if up to date
 %   mip update --deps <package>              - Update package and its dependencies
 %   mip update --all                         - Update all installed packages
+%   mip update --no-compile <package>        - Skip compile step (editable local installs)
 %   mip update mip                           - Update mip itself
 %   mip uninstall <package> [...]            - Uninstall one or more packages
 %   mip uninstall mip                        - Uninstall mip itself

--- a/tests/TestUpdateLocal.m
+++ b/tests/TestUpdateLocal.m
@@ -169,6 +169,27 @@ classdef TestUpdateLocal < matlab.unittest.TestCase
                 'mip:update:noCompileRequiresEditable');
         end
 
+        function testUpdateLocalPackage_NoCompileWithForce(testCase)
+            % `mip update --no-compile --force` on an editable install
+            % should skip the compile_script while still forcing the update.
+            srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg', ...
+                'compile_script', 'compile.m');
+            mip.install('-e', srcDir);
+
+            markerPath = fullfile(srcDir, '.compiled');
+            testCase.verifyTrue(exist(markerPath, 'file') > 0, ...
+                'compile_script should run on initial install');
+
+            % Delete marker, then update with --no-compile --force
+            delete(markerPath);
+            testCase.verifyFalse(exist(markerPath, 'file') > 0);
+
+            mip.update('--no-compile', '--force', 'local/local/mypkg');
+
+            testCase.verifyFalse(exist(markerPath, 'file') > 0, ...
+                'compile_script should NOT run when update uses --no-compile --force');
+        end
+
         %% --- Load state preserved across update ---
 
         function testUpdateLocalPackage_PreservesLoadState(testCase)

--- a/tests/TestUpdateLocal.m
+++ b/tests/TestUpdateLocal.m
@@ -137,6 +137,27 @@ classdef TestUpdateLocal < matlab.unittest.TestCase
                 'compile_script should run on update even though original install used --no-compile');
         end
 
+        function testUpdateLocalPackage_NoCompileFlagSkipsCompilation(testCase)
+            % `mip update --no-compile` on an editable install should skip
+            % the compile_script (issue #130).
+            srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg', ...
+                'compile_script', 'compile.m');
+            mip.install('-e', srcDir);
+
+            markerPath = fullfile(srcDir, '.compiled');
+            testCase.verifyTrue(exist(markerPath, 'file') > 0, ...
+                'compile_script should run on initial install');
+
+            % Delete marker, then update with --no-compile
+            delete(markerPath);
+            testCase.verifyFalse(exist(markerPath, 'file') > 0);
+
+            mip.update('--no-compile', 'local/local/mypkg');
+
+            testCase.verifyFalse(exist(markerPath, 'file') > 0, ...
+                'compile_script should NOT run when update uses --no-compile');
+        end
+
         %% --- Load state preserved across update ---
 
         function testUpdateLocalPackage_PreservesLoadState(testCase)

--- a/tests/TestUpdateLocal.m
+++ b/tests/TestUpdateLocal.m
@@ -158,6 +158,17 @@ classdef TestUpdateLocal < matlab.unittest.TestCase
                 'compile_script should NOT run when update uses --no-compile');
         end
 
+        function testUpdateLocalPackage_NoCompileErrorsOnNonEditable(testCase)
+            % `mip update --no-compile` on a non-editable local install
+            % should error — the flag only applies to editable installs.
+            srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg');
+            mip.install(srcDir);
+
+            testCase.verifyError( ...
+                @() mip.update('--no-compile', 'local/local/mypkg'), ...
+                'mip:update:noCompileRequiresEditable');
+        end
+
         %% --- Load state preserved across update ---
 
         function testUpdateLocalPackage_PreservesLoadState(testCase)


### PR DESCRIPTION
Closes #130.

Adds `--no-compile` to `mip update`, mirroring the existing flag on `mip install`. When set, the compile_script is skipped for editable local installs during the update. No effect on non-editable or remote packages (they don't run compile during update).