### PR TITLE
Reorganize helper functions (issue #134)

### DIFF
--- a/+mip/+build/install_local.m
+++ b/+mip/+build/install_local.m
@@ -64,7 +64,7 @@ end
 mip.state.add_directly_installed(fqn);
 fprintf('Successfully installed "%s"\n', fqn);
 fprintf('\nTo use this package, run:\n');
-fprintf('  mip load %s\n', mip.resolve.load_hint_name(fqn));
+fprintf('  mip load %s\n', mip.resolve.get_shortest_name(fqn));
 
 % Warn if package exists in multiple channels
 allInstalled = mip.resolve.find_all_installed_by_name(packageName);

--- a/+mip/+channel/fetch_index.m
+++ b/+mip/+channel/fetch_index.m
@@ -23,4 +23,20 @@ end
 
 index = jsondecode(indexJson);
 
+% Normalize fields that jsondecode may not return as cell arrays
+if isfield(index, 'packages')
+    if ~iscell(index.packages)
+        index.packages = num2cell(index.packages);
+    end
+    for i = 1:length(index.packages)
+        if ~isfield(index.packages{i}, 'dependencies')
+            index.packages{i}.dependencies = {};
+        elseif isempty(index.packages{i}.dependencies)
+            index.packages{i}.dependencies = {};
+        elseif ~iscell(index.packages{i}.dependencies)
+            index.packages{i}.dependencies = {index.packages{i}.dependencies};
+        end
+    end
+end
+
 end

--- a/+mip/+config/read_package_json.m
+++ b/+mip/+config/read_package_json.m
@@ -38,12 +38,9 @@ try
 
     if ~isfield(pkgInfo, 'dependencies')
         pkgInfo.dependencies = {};
-    elseif isempty(pkgInfo.dependencies) || ...
-           (isnumeric(pkgInfo.dependencies) && isempty(pkgInfo.dependencies))
-        % jsondecode returns 0x0 double for empty JSON arrays
+    elseif isempty(pkgInfo.dependencies)
         pkgInfo.dependencies = {};
     elseif ~iscell(pkgInfo.dependencies)
-        % Convert to cell array if needed
         pkgInfo.dependencies = {pkgInfo.dependencies};
     end
 

--- a/+mip/+dependency/build_dependency_graph.m
+++ b/+mip/+dependency/build_dependency_graph.m
@@ -55,12 +55,6 @@ path = [path, {packageFqn}];
 % Collect all dependencies first
 depList = {};
 dependencies = pkgInfo.dependencies;
-% Handle empty arrays (jsondecode returns 0x0 double for [])
-if isempty(dependencies) || (isnumeric(dependencies) && isempty(dependencies))
-    dependencies = {};
-elseif ~iscell(dependencies)
-    dependencies = {dependencies};
-end
 
 for i = 1:length(dependencies)
     dep = dependencies{i};

--- a/+mip/+dependency/find_all_dependencies.m
+++ b/+mip/+dependency/find_all_dependencies.m
@@ -1,5 +1,5 @@
-function deps = get_all_dependencies(fqn)
-%GET_ALL_DEPENDENCIES   Recursively collect all transitive dependencies of an installed package.
+function deps = find_all_dependencies(fqn)
+%FIND_ALL_DEPENDENCIES   Recursively collect all transitive dependencies of an installed package.
 %
 % Reads mip.json from the installed package directory and resolves bare
 % dependency names to mip-org/core/<name>.
@@ -32,9 +32,6 @@ try
     end
 
     depNames = pkgInfo.dependencies;
-    if ~iscell(depNames)
-        depNames = {depNames};
-    end
     for i = 1:length(depNames)
         dep = depNames{i};
         try
@@ -44,7 +41,7 @@ try
         end
         if ~ismember(depFqn, deps)
             deps{end+1} = depFqn; %#ok<AGROW>
-            transitiveDeps = mip.resolve.get_all_dependencies(depFqn);
+            transitiveDeps = mip.dependency.find_all_dependencies(depFqn);
             deps = unique([deps, transitiveDeps]);
         end
     end

--- a/+mip/+dependency/find_reverse_dependencies.m
+++ b/+mip/+dependency/find_reverse_dependencies.m
@@ -43,10 +43,6 @@ for i = 1:length(allPackages)
         pkgInfo = mip.config.read_package_json(pkgDir);
         dependencies = pkgInfo.dependencies;
 
-        if ~iscell(dependencies)
-            dependencies = {dependencies};
-        end
-
         % Check if this package depends on our target (by bare name or FQN)
         if ismember(bareName, dependencies) || ismember(packageName, dependencies)
             reverseDeps = [reverseDeps, {fqn}]; %#ok<*AGROW>

--- a/+mip/+dependency/topological_sort.m
+++ b/+mip/+dependency/topological_sort.m
@@ -34,12 +34,6 @@ for i = 1:length(packageFqns)
     % Get dependencies
     if isfield(pkgInfo, 'dependencies')
         deps = pkgInfo.dependencies;
-        % Handle empty arrays (jsondecode returns 0x0 double for [])
-        if isempty(deps) || (isnumeric(deps) && isempty(deps))
-            deps = {};
-        elseif ~iscell(deps)
-            deps = {deps};
-        end
     else
         deps = {};
     end

--- a/+mip/+resolve/get_shortest_name.m
+++ b/+mip/+resolve/get_shortest_name.m
@@ -1,7 +1,7 @@
-function name = load_hint_name(fqn)
-%LOAD_HINT_NAME   Return bare name if unique among installed packages, else FQN.
+function name = get_shortest_name(fqn)
+%GET_SHORTEST_NAME   Return bare name if unique among installed packages, else FQN.
 %
-% Used to suggest the simplest name a user can type in `mip load`.
+% Used to suggest the simplest unambiguous name a user can type.
 %
 % Args:
 %   fqn - Fully qualified package name

--- a/+mip/+state/check_broken_dependencies.m
+++ b/+mip/+state/check_broken_dependencies.m
@@ -42,9 +42,6 @@ for i = 1:length(packages)
         end
 
         depNames = pkgInfo.dependencies;
-        if ~iscell(depNames)
-            depNames = {depNames};
-        end
         for j = 1:length(depNames)
             dep = depNames{j};
             if strcmp(mode, 'installed')

--- a/+mip/+state/is_installed.m
+++ b/+mip/+state/is_installed.m
@@ -1,0 +1,14 @@
+function installed = is_installed(fqn)
+%IS_INSTALLED   Check if a package is installed.
+%
+% Args:
+%   fqn - Fully qualified package name (org/channel/name)
+%
+% Returns:
+%   installed - True if the package directory exists
+
+result = mip.parse.parse_package_arg(fqn);
+packageDir = mip.paths.get_package_dir(result.org, result.channel, result.name);
+installed = exist(packageDir, 'dir') ~= 0;
+
+end

--- a/+mip/+state/prune_unused_packages.m
+++ b/+mip/+state/prune_unused_packages.m
@@ -24,7 +24,7 @@ function prune_unused_packages()
     for i = 1:length(directlyInstalled)
         directPkg = directlyInstalled{i};
         if ismember(directPkg, allInstalled)
-            neededPackages = [neededPackages, mip.resolve.get_all_dependencies(directPkg)]; %#ok<AGROW>
+            neededPackages = [neededPackages, mip.dependency.find_all_dependencies(directPkg)]; %#ok<AGROW>
         end
     end
 

--- a/+mip/info.m
+++ b/+mip/info.m
@@ -160,9 +160,6 @@ function showLocalInstallInfo(fqn)
     % Dependencies
     if isfield(pkgInfo, 'dependencies') && ~isempty(pkgInfo.dependencies)
         deps = pkgInfo.dependencies;
-        if ~iscell(deps)
-            deps = {deps};
-        end
         fprintf('    Dependencies: %s\n', strjoin(deps, ', '));
     else
         fprintf('    Dependencies: None\n');
@@ -283,9 +280,6 @@ function showRemoteChannelInfo(channelStr, packageName, index)
 
     if ~isempty(compatibleVariant) && isfield(compatibleVariant, 'dependencies') && ~isempty(compatibleVariant.dependencies)
         deps = compatibleVariant.dependencies;
-        if ~iscell(deps)
-            deps = {deps};
-        end
         fprintf('\n  Dependencies (latest):\n');
         for i = 1:length(deps)
             fprintf('    - %s\n', deps{i});

--- a/+mip/install.m
+++ b/+mip/install.m
@@ -150,7 +150,7 @@ function install(varargin)
         fprintf('\nSuccessfully installed %d package(s).\n', length(installedFqns));
         fprintf('\nTo use installed packages, run:\n');
         for i = 1:length(installedFqns)
-            fprintf('  mip load %s\n', mip.resolve.load_hint_name(installedFqns{i}));
+            fprintf('  mip load %s\n', mip.resolve.get_shortest_name(installedFqns{i}));
         end
     end
 end

--- a/+mip/load.m
+++ b/+mip/load.m
@@ -134,9 +134,6 @@ function loadSingle(packageArg, installIfMissing, stickyPackage, channel, isDire
         try
             mipConfig = mip.config.read_package_json(packageDir);
             deps = mipConfig.dependencies;
-            if ~iscell(deps)
-                deps = {deps};
-            end
         catch ME
             warning('mip:jsonParseError', ...
                     'Could not parse mip.json for package "%s": %s', ...

--- a/+mip/load.m
+++ b/+mip/load.m
@@ -99,7 +99,7 @@ function loadSingle(packageArg, installIfMissing, stickyPackage, channel, isDire
     packageDir = mip.paths.get_package_dir(result.org, result.channel, result.name);
 
     % Check if package exists
-    if ~exist(packageDir, 'dir')
+    if ~mip.state.is_installed(fqn)
         error('mip:packageNotFound', ...
               'Package "%s" is not installed. Run "mip install %s" first.', ...
               fqn, fqn);

--- a/+mip/unload.m
+++ b/+mip/unload.m
@@ -148,7 +148,7 @@ function pruneUnusedPackages()
     neededPackages = {};
     for i = 1:length(MIP_DIRECTLY_LOADED_PACKAGES)
         directPkg = MIP_DIRECTLY_LOADED_PACKAGES{i};
-        neededPackages = [neededPackages, mip.resolve.get_all_dependencies(directPkg)]; %#ok<*AGROW>
+        neededPackages = [neededPackages, mip.dependency.find_all_dependencies(directPkg)]; %#ok<*AGROW>
     end
 
     % Add directly loaded packages themselves

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -530,8 +530,7 @@ function expanded = expandWithDeps(args)
         end
         deps = mip.dependency.find_all_dependencies(r.fqn);
         for j = 1:length(deps)
-            isInstalled = ~isempty(mip.resolve.resolve_to_installed(deps{j}));
-            if isInstalled && ~any(strcmp(expanded, deps{j}))
+            if mip.state.is_installed(deps{j}) && ~any(strcmp(expanded, deps{j}))
                 expanded{end+1} = deps{j}; %#ok<AGROW>
             end
         end

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -384,11 +384,8 @@ function installMissingDeps(remoteFqns)
             continue
         end
         deps = pkgInfo.dependencies;
-        if isempty(deps) || (isnumeric(deps) && isempty(deps))
+        if isempty(deps)
             continue
-        end
-        if ~iscell(deps)
-            deps = {deps};
         end
         for j = 1:length(deps)
             depFqn = mip.resolve.resolve_dependency(deps{j});

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -528,7 +528,7 @@ function expanded = expandWithDeps(args)
             % Not installed — will error later in resolvePackage; skip here
             continue
         end
-        deps = mip.resolve.get_all_dependencies(r.fqn);
+        deps = mip.dependency.find_all_dependencies(r.fqn);
         for j = 1:length(deps)
             isInstalled = ~isempty(mip.resolve.resolve_to_installed(deps{j}));
             if isInstalled && ~any(strcmp(expanded, deps{j}))


### PR DESCRIPTION
## Summary
- Move `get_all_dependencies` from `+resolve/` to `+dependency/` and rename to `find_all_dependencies` to match the search/discovery naming convention
- Rename `load_hint_name` to `get_shortest_name` — it's a general-purpose utility, not specific to `mip load`
- Add `is_installed` utility to `+state/`, consistent with the existing `is_loaded`/`is_sticky`/`is_directly_installed` family
- Normalize `dependencies` to cell arrays in `fetch_index` (matching `read_package_json` and `read_mip_yaml`), then remove 9 redundant `~iscell(deps)` checks from callers

Closes #134

## Test plan
- [x] Full test suite passes (422 passed, 0 failed)