### PR TITLE
Atomic write for directly_installed.txt

### DIFF
--- a/+mip/+state/set_directly_installed.m
+++ b/+mip/+state/set_directly_installed.m
@@ -5,22 +5,22 @@ function set_directly_installed(packages)
 %   packages - Cell array of package names that are directly installed
 
     packagesDir = mip.paths.get_packages_dir();
-    
-    % Create packages directory if it doesn't exist
+
     if ~exist(packagesDir, 'dir')
         mkdir(packagesDir);
     end
-    
+
     directFile = fullfile(packagesDir, 'directly_installed.txt');
-    
+    tmpFile = [directFile '.tmp'];
+
     % Sort packages for consistent ordering
     packages = sort(packages);
-    
-    fid = fopen(directFile, 'w');
+
+    fid = fopen(tmpFile, 'w');
     if fid == -1
-        error('mip:fileError', 'Could not write to directly_installed.txt');
+        error('mip:fileError', 'Could not write to directly_installed.txt.tmp');
     end
-    
+
     try
         for i = 1:length(packages)
             fprintf(fid, '%s\n', packages{i});
@@ -28,6 +28,17 @@ function set_directly_installed(packages)
         fclose(fid);
     catch ME
         fclose(fid);
+        if exist(tmpFile, 'file')
+            delete(tmpFile);
+        end
         rethrow(ME);
+    end
+
+    [ok, msg] = movefile(tmpFile, directFile, 'f');
+    if ~ok
+        if exist(tmpFile, 'file')
+            delete(tmpFile);
+        end
+        error('mip:fileError', 'Could not rename tmp file into place: %s', msg);
     end
 end

--- a/tests/TestPackageDiscovery.m
+++ b/tests/TestPackageDiscovery.m
@@ -172,6 +172,27 @@ classdef TestPackageDiscovery < matlab.unittest.TestCase
             testCase.verifyEqual(sort(pkgs), sort({'mip-org/core/new1', 'mip-org/core/new2'}));
         end
 
+        function testDirectlyInstalled_StaleTmpReplaced(testCase)
+            % A leftover directly_installed.txt.tmp (e.g. from a prior crash)
+            % must be replaced, and the final file must contain only the
+            % new entries.
+            packagesDir = mip.paths.get_packages_dir();
+            if ~exist(packagesDir, 'dir')
+                mkdir(packagesDir);
+            end
+            tmpPath = fullfile(packagesDir, 'directly_installed.txt.tmp');
+            fid = fopen(tmpPath, 'w');
+            fprintf(fid, 'mip-org/core/garbage\n');
+            fclose(fid);
+
+            mip.state.set_directly_installed({'mip-org/core/alpha', 'mip-org/core/beta'});
+
+            pkgs = mip.state.get_directly_installed();
+            testCase.verifyEqual(sort(pkgs), sort({'mip-org/core/alpha', 'mip-org/core/beta'}));
+            testCase.verifyFalse(exist(tmpPath, 'file') > 0, ...
+                'directly_installed.txt.tmp should not exist after a successful write');
+        end
+
         %% get_package_dir tests
 
         function testGetPackageDir(testCase)

--- a/tests/TestPackageDiscovery.m
+++ b/tests/TestPackageDiscovery.m
@@ -193,6 +193,27 @@ classdef TestPackageDiscovery < matlab.unittest.TestCase
                 'directly_installed.txt.tmp should not exist after a successful write');
         end
 
+        function testDirectlyInstalled_PreservedOnWriteFailure(testCase)
+            % If writing to the tmp file fails, the original
+            % directly_installed.txt must remain intact — this is the
+            % invariant the atomic write protects.
+            mip.state.set_directly_installed({'mip-org/core/keep1', 'mip-org/core/keep2'});
+
+            % Force fopen(tmpPath, 'w') to fail by pre-creating the tmp
+            % path as a directory.
+            packagesDir = mip.paths.get_packages_dir();
+            tmpPath = fullfile(packagesDir, 'directly_installed.txt.tmp');
+            mkdir(tmpPath);
+
+            testCase.verifyError( ...
+                @() mip.state.set_directly_installed({'mip-org/core/nope'}), ...
+                'mip:fileError');
+
+            pkgs = mip.state.get_directly_installed();
+            testCase.verifyEqual(sort(pkgs), ...
+                sort({'mip-org/core/keep1', 'mip-org/core/keep2'}));
+        end
+
         %% get_package_dir tests
 
         function testGetPackageDir(testCase)


### PR DESCRIPTION
Closes #164.

## Summary
- Write package list to `directly_installed.txt.tmp` first, then `movefile` into place, so a crash or Ctrl-C mid-write can no longer leave the file truncated.
- On failure, the tmp file is cleaned up and the original `directly_installed.txt` is left untouched.