### PR TITLE
bundle: encode canonical '-' as '_' in .mhl filename

### DIFF
--- a/+mip/bundle.m
+++ b/+mip/bundle.m
@@ -89,9 +89,12 @@ function bundle(varargin)
         mipJson = jsondecode(mipJsonText);
         effectiveArch = mipJson.architecture;
 
-        % Build output filename
+        % Build output filename. Canonical package names may contain '-',
+        % but the filename uses '-' as a field separator, so encode the
+        % name with '_' in the filename.
+        nameForFilename = strrep(mipConfig.name, '-', '_');
         mhlFilename = sprintf('%s-%s-%s.mhl', ...
-            mipConfig.name, num2str(mipConfig.version), effectiveArch);
+            nameForFilename, num2str(mipConfig.version), effectiveArch);
         mhlPath = fullfile(outputDir, mhlFilename);
 
         % Create .mhl (zip) from staging directory contents

--- a/tests/TestBundleCommand.m
+++ b/tests/TestBundleCommand.m
@@ -45,6 +45,24 @@ classdef TestBundleCommand < matlab.unittest.TestCase
                 sprintf('Expected file %s to exist', expected));
         end
 
+        function testBundle_HyphenInNameEncodedAsUnderscoreInFilename(testCase)
+            % Canonical names may contain '-', but the filename uses '-'
+            % as a field separator, so the name is encoded with '_' in
+            % the filename. The canonical name is preserved in mip.json.
+            srcDir = createTestSourcePackage(testCase.SourceDir, 'foo-bar', 'version', '1.0.0');
+            mip.bundle(srcDir, '--output', testCase.OutputDir, '--arch', 'any');
+
+            expected = 'foo_bar-1.0.0-any.mhl';
+            testCase.verifyTrue(exist(fullfile(testCase.OutputDir, expected), 'file') > 0, ...
+                sprintf('Expected file %s to exist', expected));
+
+            jsonFiles = dir(fullfile(testCase.OutputDir, '*.mip.json'));
+            jsonText = fileread(fullfile(testCase.OutputDir, jsonFiles(1).name));
+            jsonData = jsondecode(jsonText);
+            testCase.verifyEqual(jsonData.name, 'foo-bar', ...
+                'Canonical name must be preserved in mip.json');
+        end
+
         function testBundle_ProducesMipJson(testCase)
             srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg');
             mip.bundle(srcDir, '--output', testCase.OutputDir, '--arch', 'any');


### PR DESCRIPTION
## Summary

- Canonical package names may now contain `-` (e.g. `foo-bar`), but `-` is the field separator in the `{name}-{version}-{arch}.mhl` filename scheme. Encode `-` as `_` in the filename only; the canonical name is preserved verbatim in the bundled `mip.json`.
- `mip.name.normalize` already treats `-` and `_` as equivalent for name resolution, so this encoding is transparent to the CLI at install time (`install` reads the canonical name from the embedded `mip.json`, not from the filename).

## Companion PR

[mip-org/mip-channel-template#4](https://github.com/mip-org/mip-channel-template/pull/4) applies the same swap in `scripts/prepare_packages.py` (cache-check filename construction) and documents the convention in `release_tag_from_mhl`.

## Test plan

- [x] New unit test `testBundle_HyphenInNameEncodedAsUnderscoreInFilename` in `TestBundleCommand.m` — bundles a package named `foo-bar` and verifies: (a) output file is `foo_bar-1.0.0-any.mhl`, (b) embedded `mip.json` has `name: foo-bar` preserved.