### PR TITLE
Disable SHA-256 verification for .mhl downloads

### DIFF
--- a/+mip/+channel/download_mhl.m
+++ b/+mip/+channel/download_mhl.m
@@ -71,21 +71,27 @@ else
     end
 end
 
-if ~isempty(expectedSha256)
-    actual = mip.channel.sha256(localPath);
-    if isempty(actual)
-        % JVM unavailable (e.g. numbl) — skip verification.
-        return
-    end
-    if ~strcmpi(actual, expectedSha256)
-        if exist(localPath, 'file')
-            delete(localPath);
-        end
-        error('mip:digestMismatch', ...
-              ['SHA-256 mismatch for %s\n' ...
-               '  expected: %s\n' ...
-               '  actual:   %s'], source, expectedSha256, actual);
-    end
-end
+% SHA-256 verification disabled — see mip-org/mip#201.
+% Channel publishing is not atomic: the .mhl asset is uploaded before the
+% index.json is redeployed, so clients fetching during the window get an
+% old digest with a new archive and trip mip:digestMismatch. Re-enable
+% once channel publishing is made atomic (content-addressed asset names
+% or staging→promote).
+% if ~isempty(expectedSha256)
+%     actual = mip.channel.sha256(localPath);
+%     if isempty(actual)
+%         % JVM unavailable (e.g. numbl) — skip verification.
+%         return
+%     end
+%     if ~strcmpi(actual, expectedSha256)
+%         if exist(localPath, 'file')
+%             delete(localPath);
+%         end
+%         error('mip:digestMismatch', ...
+%               ['SHA-256 mismatch for %s\n' ...
+%                '  expected: %s\n' ...
+%                '  actual:   %s'], source, expectedSha256, actual);
+%     end
+% end
 
 end

--- a/tests/TestDownloadMhl.m
+++ b/tests/TestDownloadMhl.m
@@ -39,20 +39,19 @@ classdef TestDownloadMhl < matlab.unittest.TestCase
             testCase.verifyTrue(exist(localPath, 'file') > 0);
         end
 
-        function testMismatchedDigest_ErrorsAndDeletes(testCase)
-            % Tamper-detection path: a wrong digest must raise
-            % mip:digestMismatch AND scrub the local copy, so a poisoned
-            % archive can't be picked up by a later caller.
+        function testMismatchedDigest_SkipsVerification(testCase)
+            % SHA-256 verification is currently disabled (see
+            % mip-org/mip#201) because channel publishing isn't atomic
+            % and the index/asset can briefly disagree. A wrong digest
+            % must therefore NOT error — the download succeeds and the
+            % file is kept. Re-flip to verifyError('mip:digestMismatch')
+            % once publishing is made atomic.
             actualSha = mip.channel.sha256(testCase.SrcFile);
             testCase.assumeNotEmpty(actualSha, 'JVM unavailable — skipping');
             wrongSha = repmat('0', 1, 64);
-            testCase.verifyError( ...
-                @() mip.channel.download_mhl( ...
-                    testCase.SrcFile, testCase.DestDir, wrongSha), ...
-                'mip:digestMismatch');
-            expectedLocal = fullfile(testCase.DestDir, 'pkg.mhl');
-            testCase.verifyFalse(exist(expectedLocal, 'file') > 0, ...
-                'Local copy should be deleted on digest mismatch');
+            localPath = mip.channel.download_mhl( ...
+                testCase.SrcFile, testCase.DestDir, wrongSha);
+            testCase.verifyTrue(exist(localPath, 'file') > 0);
         end
 
         function testEmptyDigest_SkipsVerification(testCase)


### PR DESCRIPTION
## Summary
- Comments out the SHA-256 digest check in `mip.channel.download_mhl` per the decision in #201.
- Flips `TestDownloadMhl.testMismatchedDigest_*` to assert the now-permissive behavior (with a note to restore once publishing is atomic).

Channel publishing isn't atomic: `.mhl` assets are uploaded (with `--clobber`) before `index.json` is redeployed, so clients hitting the window see an old digest with a new archive and raise `mip:digestMismatch` on a valid file. Re-enable once publishing is fixed (content-addressed asset names or staging → promote).