### PR TITLE
Remove legacy load_package.m / unload_package.m support

### DIFF
--- a/+mip/+config/read_package_json.m
+++ b/+mip/+config/read_package_json.m
@@ -44,7 +44,7 @@ try
         pkgInfo.dependencies = {pkgInfo.dependencies};
     end
 
-    % Normalize paths field IF present. The field is left absent when the
+    % Normalize paths field if present. The field is left absent when the
     % package has no "paths" entry in mip.json; callers treat that as a
     % malformed package and fail.
     if isfield(pkgInfo, 'paths')

--- a/+mip/+config/read_package_json.m
+++ b/+mip/+config/read_package_json.m
@@ -44,10 +44,9 @@ try
         pkgInfo.dependencies = {pkgInfo.dependencies};
     end
 
-    % Normalize paths field IF present. The field is intentionally left
-    % absent when the package has no "paths" entry in mip.json, so callers
-    % can distinguish new-style packages (paths present, even if empty)
-    % from legacy packages (paths absent, use load_package.m instead).
+    % Normalize paths field IF present. The field is left absent when the
+    % package has no "paths" entry in mip.json; callers treat that as a
+    % malformed package and fail.
     if isfield(pkgInfo, 'paths')
         if isempty(pkgInfo.paths)
             pkgInfo.paths = {};

--- a/+mip/bundle.m
+++ b/+mip/bundle.m
@@ -11,8 +11,6 @@ function bundle(varargin)
 %   --arch <arch>    Override architecture (default: auto-detect via mip.arch())
 %
 % The .mhl file is a ZIP archive containing:
-%   load_package.m
-%   unload_package.m
 %   mip.json
 %   <package_name>/
 %     [all package source files]

--- a/+mip/load.m
+++ b/+mip/load.m
@@ -19,11 +19,12 @@ function load(varargin)
 %   --install       Automatically install the package(s) if not already installed
 %   --channel <c>   Channel to install from when using --install
 %   --addpath <rel> Add this source-relative subpath to the MATLAB path AFTER
-%                   load_package.m runs. May be repeated. Only valid with a
-%                   single positional package; applies only to direct loads
-%                   (not transitive dependencies).
+%                   the paths from mip.json are added. May be repeated. Only
+%                   valid with a single positional package; applies only to
+%                   direct loads (not transitive dependencies).
 %   --rmpath  <rel> Remove this source-relative subpath from the MATLAB path
-%                   AFTER load_package.m runs. Same constraints as --addpath.
+%                   AFTER the paths from mip.json are added. Same constraints
+%                   as --addpath.
 %   --transitive    (internal) Load as a transitive dependency, not a direct load
 
     % Parse flags and package names from arguments
@@ -98,8 +99,8 @@ function loadSingle(packageArg, installIfMissing, stickyPackage, channel, isDire
 % Load a single package (and its dependencies recursively).
 %
 % addPathRels / rmPathRels: cell arrays of source-relative paths to
-% addpath / rmpath after load_package.m runs. Only honored for direct
-% loads (the recursive call for dependencies passes empty).
+% addpath / rmpath after the mip.json paths are applied. Only honored
+% for direct loads (the recursive call for dependencies passes empty).
 
     % Resolve the FQN for this package, installing first if requested
     try
@@ -201,48 +202,16 @@ function loadSingle(packageArg, installIfMissing, stickyPackage, channel, isDire
         end
     end
 
-    % Add paths from mip.json (new-style packages). Legacy packages that
-    % predate the paths field omit it entirely; they rely on
-    % load_package.m below instead.
-    hasPathsField = ~isempty(mipConfig) && isfield(mipConfig, 'paths');
-    if hasPathsField
-        applyMipJsonPaths(packageDir, mipConfig);
-    end
-
-    % Look for load_package.m file (legacy support; also allowed alongside
-    % the paths field for packages that need custom init logic).
-    loadFile = fullfile(packageDir, 'load_package.m');
-    hasLoadScript = exist(loadFile, 'file') ~= 0;
-
-    if ~hasPathsField && ~hasLoadScript
+    % Add paths from mip.json.
+    if isempty(mipConfig) || ~isfield(mipConfig, 'paths')
         error('mip:loadNotFound', ...
-              ['Package "%s" has no "paths" field in mip.json and no ' ...
-               'load_package.m file'], displayFqn);
+              'Package "%s" has no "paths" field in mip.json', displayFqn);
     end
+    applyMipJsonPaths(packageDir, mipConfig);
 
-    % Execute the load_package.m file. If it errors, the package is NOT
-    % marked as loaded, so the user can fix the issue and retry. We do not
-    % attempt to roll back any path or state changes that load_package.m
-    % (or the paths field above) may have made before failing -- doing so
-    % reliably is not possible.
-    if hasLoadScript
-        originalDir = pwd;
-        restoreDir = onCleanup(@() cd(originalDir));
-        cd(packageDir);
-        try
-            run(loadFile);
-        catch ME
-            loadErr = MException('mip:loadError', ...
-                'Error executing load_package.m for package "%s": %s', ...
-                displayFqn, ME.message);
-            loadErr = addCause(loadErr, ME);
-            throw(loadErr);
-        end
-        clear restoreDir;
-    end
     fprintf('Loaded package "%s"\n', displayFqn);
 
-    % Apply --addpath / --rmpath after load_package.m has run.
+    % Apply --addpath / --rmpath after the mip.json paths have been added.
     applyPathAdjustments(packageDir, addPathRels, rmPathRels);
 
     % Mark package as loaded

--- a/+mip/unload.m
+++ b/+mip/unload.m
@@ -62,7 +62,7 @@ function unload(varargin)
             packageDir = '';
         end
 
-        % Execute unload_package.m if it exists
+        % Remove paths declared in mip.json
         executeUnload(packageDir, fqn);
 
         % Remove from all load-state lists
@@ -132,31 +132,9 @@ end
 
 function executeUnload(packageDir, fqn)
     displayFqn = mip.parse.display_fqn(fqn);
-    unloadFile = '';
-    hasUnloadScript = false;
-    if ~isempty(packageDir)
-        unloadFile = fullfile(packageDir, 'unload_package.m');
-        hasUnloadScript = exist(unloadFile, 'file') ~= 0;
-    end
 
-    % Legacy unload_package.m runs first so it sees the paths it expects
-    % to remove before we strip the mip.json "paths" entries.
-    if hasUnloadScript
-        originalDir = pwd;
-        cd(packageDir);
-        try
-            run(unloadFile);
-        catch ME
-            warning('mip:unloadError', ...
-                    'Error executing unload_package.m for package "%s": %s', ...
-                    displayFqn, ME.message);
-        end
-        cd(originalDir);
-    end
-
-    % Remove paths declared in mip.json (new-style packages). Missing
-    % packageDir or unreadable mip.json are non-fatal -- the sweep below
-    % is the backstop.
+    % Remove paths declared in mip.json. Missing packageDir or unreadable
+    % mip.json are non-fatal -- the sweep below is the backstop.
     pkgInfo = [];
     if ~isempty(packageDir) && isfolder(packageDir)
         try
@@ -180,21 +158,15 @@ function executeUnload(packageDir, fqn)
             rmpath(target);
         end
         clear restoreWarn;
-    end
-
-    % Warn only when legacy scripts are missing AND the package predates
-    % the mip.json "paths" field -- i.e. we have no authoritative path
-    % list at all and must rely purely on the defensive sweep.
-    if ~hasUnloadScript && ~hasPathsField
+    else
         warning('mip:unloadNotFound', ...
-                'Package "%s" does not have a unload_package.m file. Path changes may persist.', ...
+                'Package "%s" has no "paths" field in mip.json. Path changes may persist.', ...
                 displayFqn);
     end
 
     % Defensive sweep: remove any remaining MATLAB path entries that fall
     % under this package's source directory. This catches paths added via
-    % `mip load --addpath`, plus anything load_package.m put on the path
-    % that the mip.json "paths" list or unload_package.m did not cover.
+    % `mip load --addpath` that the mip.json "paths" list did not cover.
     sweepPathEntries(packageDir, fqn, pkgInfo);
 end
 

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -606,30 +606,20 @@ function updateSelf(p, force)
             newPathsToAdd = resolvePathList(newSrcDir, newPkgInfo.paths);
         end
 
-        % Unload the currently installed mip. Prefer the legacy
-        % unload_package.m when present; otherwise rmpath the entries
+        % Unload the currently installed mip by rmpath'ing the entries
         % declared in the old mip.json "paths" field.
-        unloadScript = fullfile(pkgDir, 'unload_package.m');
-        if exist(unloadScript, 'file')
-            run(unloadScript);
-        else
-            oldWarn = warning('off', 'MATLAB:rmpath:DirNotFound');
-            for k = 1:length(oldPathsToRemove)
-                rmpath(oldPathsToRemove{k});
-            end
-            warning(oldWarn);
+        oldWarn = warning('off', 'MATLAB:rmpath:DirNotFound');
+        for k = 1:length(oldPathsToRemove)
+            rmpath(oldPathsToRemove{k});
         end
+        warning(oldWarn);
         rmdir(pkgDir, 's');
         movefile(stagingDir, pkgDir);
 
-        % Reload mip: addpath new entries (these now point into the
-        % just-moved pkgDir), then run legacy load_package.m if present.
+        % Reload mip by addpath'ing the new entries (these now point into
+        % the just-moved pkgDir).
         for k = 1:length(newPathsToAdd)
             addpath(newPathsToAdd{k});
-        end
-        loadScript = fullfile(pkgDir, 'load_package.m');
-        if exist(loadScript, 'file')
-            run(loadScript);
         end
         fprintf('Successfully updated mip to %s\n', latestInfo.version);
     catch ME

--- a/docs/specification-high-level.md
+++ b/docs/specification-high-level.md
@@ -139,7 +139,7 @@ builds:
 
 **`mip.json`** -- generated at install time, lives in the installed package directory. Contains resolved metadata (name, version, architecture, dependencies, paths).
 
-**`.mhl`** -- a ZIP archive containing `load_package.m`, `unload_package.m`, `mip.json`, and the package source.
+**`.mhl`** -- a ZIP archive containing `mip.json` and the package source.
 
 ---
 
@@ -152,8 +152,6 @@ builds:
     mip-org/
       core/
         chebfun/
-          load_package.m
-          unload_package.m
           mip.json
           chebfun/                # source files
     local/

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -436,7 +436,7 @@ Validation happens *before* extraction so that a malicious entry can never write
    - If `--sticky` is specified, add to sticky packages.
    - Return early.
 6. Read `mip.json` and load dependencies first (recursively, as non-direct loads).
-7. Execute `load_package.m` in the package directory (changes `pwd` temporarily). If it errors, raise `mip:loadError` and stop -- the package is **not** marked as loaded (see [§4.8](#48-load_packagem-execution)).
+7. Add each entry in the `mip.json` `paths` field to the MATLAB path (see [§4.8](#48-path-addition-from-mipjson)). If the field is missing, raise `mip:loadNotFound` and stop -- the package is **not** marked as loaded.
 8. Add to `MIP_LOADED_PACKAGES`.
 9. If this is a direct load, add to `MIP_DIRECTLY_LOADED_PACKAGES`.
 10. If `--sticky`, add to `MIP_STICKY_PACKAGES`.
@@ -476,7 +476,7 @@ A loading stack tracks the current dependency chain. If a package appears in its
 
 ### 4.7 The `--addpath` and `--rmpath` Flags
 
-`mip load <pkg> --addpath <relpath>` adds `fullfile(srcDir, relpath)` to the MATLAB path **after** `load_package.m` has run. `--rmpath <relpath>` removes the same. **Both flags may be repeated** to specify multiple paths in one call (e.g. `mip load foo --addpath src/a --addpath src/b --rmpath src/legacy`); each occurrence is accumulated and applied in argument order.
+`mip load <pkg> --addpath <relpath>` adds `fullfile(srcDir, relpath)` to the MATLAB path **after** the entries from `mip.json` `paths` have been added. `--rmpath <relpath>` removes the same. **Both flags may be repeated** to specify multiple paths in one call (e.g. `mip load foo --addpath src/a --addpath src/b --rmpath src/legacy`); each occurrence is accumulated and applied in argument order.
 
 The `srcDir` resolution is the same one used elsewhere ([`mip.paths.get_source_dir`](../+mip/+paths/get_source_dir.m)):
 - **Editable installs**: `srcDir = source_path` (the user's original source directory).
@@ -493,15 +493,13 @@ Constraints:
 
 These adjustments are not separately tracked because the unload sweep (§5.8) removes everything under `srcDir` regardless.
 
-### 4.8 `load_package.m` Execution
+### 4.8 Path Addition from `mip.json`
 
-The load script is executed by `cd`-ing to the package directory and calling `run(loadFile)`. For:
-- **Non-editable installs**: paths are relative, computed from the package directory.
-- **Editable installs**: paths are absolute, pointing to the source directory.
+Each entry in the `mip.json` `paths` field is resolved relative to `srcDir` (see [`mip.paths.get_source_dir`](../+mip/+paths/get_source_dir.m)) and passed to `addpath`. The entry `.` means `srcDir` itself; other entries are resolved via `fullfile(srcDir, entry)`. For:
+- **Non-editable installs**: `srcDir = pkgDir/<name>/`, so paths resolve under the installed copy.
+- **Editable installs**: `srcDir = source_path`, so paths resolve under the user's original source directory.
 
-If `load_package.m` doesn't exist, raises `mip:loadNotFound`.
-
-If `load_package.m` throws during execution, the working directory is restored and `mip:loadError` is raised (with the original error attached as a cause). The package is **not** added to `MIP_LOADED_PACKAGES` or `MIP_DIRECTLY_LOADED_PACKAGES`, so the user can fix the issue and retry without first having to run `mip unload`. The error propagates up through dependency recursion, so a parent package whose dependency failed to load is also not marked as loaded. mip does **not** attempt to undo whatever the partially-executed `load_package.m` did to the path -- recovering arbitrary path or workspace mutations is not generally possible. Users should treat a `mip:loadError` as a signal that the path may be in a partial state and restart MATLAB if anything looks wrong.
+If `mip.json` has no `paths` field, raises `mip:loadNotFound` and the package is **not** added to `MIP_LOADED_PACKAGES` or `MIP_DIRECTLY_LOADED_PACKAGES`.
 
 ---
 
@@ -512,7 +510,7 @@ If `load_package.m` throws during execution, the working directory is restored a
 1. Resolve the package argument to an FQN (see section 2.4.2 for bare name resolution among loaded packages).
 2. If the FQN is `mip-org/core/mip`, raise `mip:cannotUnloadMip`.
 3. If not loaded, print a message and continue (no error).
-4. Execute `unload_package.m` if it exists.
+4. Remove the `mip.json` `paths` entries from the MATLAB path (see [§5.8](#58-path-removal-from-mipjson)).
 5. Remove from `MIP_STICKY_PACKAGES`.
 6. Remove from `MIP_DIRECTLY_LOADED_PACKAGES`.
 7. Remove from `MIP_LOADED_PACKAGES`.
@@ -527,14 +525,14 @@ When multiple loaded packages share the same bare name:
 ### 5.3 Unload All (`mip unload --all`)
 
 1. Find all loaded packages that are **not** in `MIP_STICKY_PACKAGES`.
-2. Execute `unload_package.m` for each.
+2. Remove the `mip.json` `paths` entries for each.
 3. Update state: `MIP_LOADED_PACKAGES` is set to just the sticky packages.
 4. `MIP_DIRECTLY_LOADED_PACKAGES` is filtered to only those that are also sticky.
 
 ### 5.4 Unload All Force (`mip unload --all --force`)
 
 1. Find all loaded packages **except** `mip-org/core/mip`.
-2. Execute `unload_package.m` for each.
+2. Remove the `mip.json` `paths` entries for each.
 3. Reset state:
    - `MIP_LOADED_PACKAGES` = `{'mip-org/core/mip'}`
    - `MIP_DIRECTLY_LOADED_PACKAGES` = `{}`
@@ -546,7 +544,7 @@ After unloading one or more packages, the system prunes dependencies that are no
 
 1. Build the set of "needed" packages: all directly loaded packages plus their transitive dependencies.
 2. For each loaded package not in the needed set (and not `mip-org/core/mip`):
-   - Execute `unload_package.m`.
+   - Remove the `mip.json` `paths` entries.
    - Remove from `MIP_LOADED_PACKAGES`.
 3. After pruning, check for broken dependencies (warn if any loaded package's dependency is no longer loaded).
 
@@ -560,20 +558,13 @@ If two directly-loaded packages share a dependency:
 
 `mip unload pkg1 pkg2` unloads all listed packages, then runs a single prune pass. If one of the listed packages is not loaded, it prints a message but continues with the others.
 
-### 5.8 `unload_package.m` Execution
+### 5.8 Path Removal from `mip.json`
 
-Unload proceeds in two stages:
+Each entry in the `mip.json` `paths` field is resolved against `srcDir` (see [§4.8](#48-path-addition-from-mipjson)) and passed to `rmpath`. MATLAB's `MATLAB:rmpath:DirNotFound` warning is suppressed during this pass so stale or missing entries do not produce noise.
 
-1. **Declarative unload via `mip.json` `paths`**: if `mip.json` contains a `paths` field (the modern layout — see [§3.2.1](#321-non-editable-copy-install), [§3.2.2](#322-editable-install--e----editable)), each entry is `rmpath`'d against `srcDir`. MATLAB's `MATLAB:rmpath:DirNotFound` warning is suppressed during this pass.
-2. **Legacy `unload_package.m`**: if the file exists, it is executed by `cd`-ing to the package directory and calling `run(unloadFile)`.
+If `mip.json` has no `paths` field, the `mip:unloadNotFound` warning is issued. The package is still removed from tracking either way.
 
-The `mip:unloadNotFound` warning is issued **only when both** the `paths` field and `unload_package.m` are absent — i.e. the package has no authoritative list of path entries to remove. Packages that ship either one (or both) unload cleanly without the warning. Either way, the package is still removed from tracking.
-
-**Defensive path sweep**: after the stages above (regardless of outcome), mip walks the current MATLAB path and `rmpath`s every entry that equals `srcDir` or starts with `srcDir<filesep>`. The `srcDir` is resolved via [`mip.paths.get_source_dir`](../+mip/+paths/get_source_dir.m) — the same base used for `mip load --addpath`/`--rmpath`. The sweep handles three cases:
-
-- Paths added via `mip load --addpath` (which neither the `paths` field nor `unload_package.m` knows about).
-- Paths added by `load_package.m` that the matching `unload_package.m` failed to remove (e.g. user-edited scripts that drift out of sync).
-- Packages with no `paths` field and no `unload_package.m` at all — the `mip:unloadNotFound` warning fires, but the path is at least swept clean.
+**Defensive path sweep**: after the step above, mip walks the current MATLAB path and `rmpath`s every entry that equals `srcDir` or starts with `srcDir<filesep>`. The `srcDir` is resolved via [`mip.paths.get_source_dir`](../+mip/+paths/get_source_dir.m) — the same base used for `mip load --addpath`/`--rmpath`. The sweep is what catches paths added via `mip load --addpath` that are not listed in the `paths` field.
 
 Each swept entry is reported (`swept residual path entry for "<fqn>": <path>`). Because the sweep matches only entries beginning with `srcDir<filesep>` (or exactly equal to `srcDir`), a sibling directory whose name happens to share a prefix is never touched.
 
@@ -700,7 +691,7 @@ Special flow for `mip-org/core/mip`:
 1. Fetch the latest from the `mip-org/core` channel.
 2. Download the new `.mhl`, extract to staging.
 3. Replace the installed package in-place.
-4. Reload: `addpath` each entry from the new `mip.json` `paths` field (resolved against the new package dir), then `run` `load_package.m` if present.
+4. Reload: `addpath` each entry from the new `mip.json` `paths` field (resolved against the new package dir).
 
 Does not go through the normal uninstall-and-reinstall update flow, since mip is running and cannot remove itself mid-update. Self-update runs before the batch so it is safe to pass `mip` in the same call as other packages. (This is distinct from `mip uninstall mip`, which is a user-initiated tear-down — see [§6.4](#64-self-uninstall-mip-uninstall-mip).)
 
@@ -927,13 +918,9 @@ Pinned packages are stored in `<root>/packages/pinned.txt`, one FQN per line. Th
     mip-org/
       core/
         mip/                               # The package manager itself
-          load_package.m
-          unload_package.m
           mip.json
           mip/                             # Package source files
         chebfun/
-          load_package.m
-          unload_package.m
           mip.json
           chebfun/
       test-channel1/
@@ -946,12 +933,8 @@ Pinned packages are stored in `<root>/packages/pinned.txt`, one FQN per line. Th
     local/
       local/
         devpkg/                            # Editable install (thin wrapper)
-          load_package.m                   # Contains absolute paths to source
-          unload_package.m
           mip.json                         # editable: true, source_path: /path/to/source
         copypkg/                           # Non-editable local install
-          load_package.m                   # Contains relative paths
-          unload_package.m
           mip.json                         # source_path: /original/source (for updates)
           copypkg/                         # Copied source files
 ```
@@ -979,7 +962,7 @@ Pinned packages are stored in `<root>/packages/pinned.txt`, one FQN per line. Th
 
 Required: `name`. All other fields have defaults or are optional.
 
-The `paths` field is the authoritative list of directories that `mip load` adds to the MATLAB path. Each entry is interpreted relative to `srcDir` (see [`mip.paths.get_source_dir`](../+mip/+paths/get_source_dir.m)): the installed package's source subdir for copy installs, or `source_path` for editable installs. Entries are `rmpath`'d in matching fashion by `mip unload` (see [§5.8](#58-unload_packagem-execution)). Legacy `load_package.m` / `unload_package.m` scripts, if present, are still honored for back-compat but are not generated by modern installs.
+The `paths` field is the authoritative list of directories that `mip load` adds to the MATLAB path. Each entry is interpreted relative to `srcDir` (see [`mip.paths.get_source_dir`](../+mip/+paths/get_source_dir.m)): the installed package's source subdir for copy installs, or `source_path` for editable installs. Entries are `rmpath`'d in matching fashion by `mip unload` (see [§5.8](#58-path-removal-from-mipjson)).
 
 ### 11.2 `mip.yaml` Schema
 
@@ -1008,8 +991,6 @@ mip.json
 <package_name>/
   [source files]
 ```
-
-Legacy `.mhl` archives may additionally contain `load_package.m` and/or `unload_package.m` at the top level; these are still honored for back-compat (see [§4.8](#48-load_packagem-execution) and [§5.8](#58-unload_packagem-execution)) but are not produced by `mip bundle`.
 
 ### 11.4 Empty Directory Cleanup
 
@@ -1073,8 +1054,7 @@ Channel index downloads are cached on disk under `<root>/cache/index/<org>/<chan
 | `mip:circularDependency` | Circular dependency detected |
 | `mip:dependencyNotFound` | A dependency is not installed |
 | `mip:cannotUnloadMip` | Attempt to unload `mip-org/core/mip` |
-| `mip:loadNotFound` | `load_package.m` missing |
-| `mip:loadError` | `load_package.m` threw an error during execution |
+| `mip:loadNotFound` | `mip.json` has no `paths` field |
 | `mip:load:missingChannel` | `--channel` flag without a value in `mip load` |
 | `mip:load:missingAddpathValue` | `--addpath` flag without a value |
 | `mip:load:missingRmpathValue` | `--rmpath` flag without a value |
@@ -1163,7 +1143,7 @@ The following **warning** identifiers are also issued:
 
 | Warning ID | Trigger |
 |---|---|
-| `mip:unloadNotFound` | `mip unload <pkg>` on a package whose `mip.json` has no `paths` field **and** has no `unload_package.m` (see [§5.8](#58-unload_packagem-execution)) |
+| `mip:unloadNotFound` | `mip unload <pkg>` on a package whose `mip.json` has no `paths` field (see [§5.8](#58-path-removal-from-mipjson)) |
 | `mip:brokenDependencies` | After an unload/uninstall, at least one still-loaded or still-installed package has a dependency that is no longer loaded/installed |
 
 ---

--- a/tests/TestBundleCommand.m
+++ b/tests/TestBundleCommand.m
@@ -123,10 +123,6 @@ classdef TestBundleCommand < matlab.unittest.TestCase
 
             testCase.verifyTrue(exist(fullfile(extractDir, 'mip.json'), 'file') > 0);
             testCase.verifyTrue(exist(fullfile(extractDir, 'mypkg'), 'dir') > 0);
-            % Bundles no longer emit load_package.m / unload_package.m;
-            % the install path list lives in mip.json.
-            testCase.verifyFalse(exist(fullfile(extractDir, 'load_package.m'), 'file') > 0);
-            testCase.verifyFalse(exist(fullfile(extractDir, 'unload_package.m'), 'file') > 0);
         end
 
         function testBundle_MipJsonContainsPaths(testCase)

--- a/tests/TestInstallLocal.m
+++ b/tests/TestInstallLocal.m
@@ -59,8 +59,7 @@ classdef TestInstallLocal < matlab.unittest.TestCase
         end
 
         function testEditableInstall_RecordsPathsInMipJson(testCase)
-            % New-style installs carry the paths list inside mip.json and
-            % no longer emit load_package.m / unload_package.m scripts.
+            % Installs carry the paths list inside mip.json.
             srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg');
             mip.install('-e', srcDir);
 
@@ -68,10 +67,6 @@ classdef TestInstallLocal < matlab.unittest.TestCase
             info = mip.config.read_package_json(pkgDir);
             testCase.verifyTrue(isfield(info, 'paths'), ...
                 'Editable install should record "paths" in mip.json');
-            testCase.verifyFalse(exist(fullfile(pkgDir, 'load_package.m'), 'file') > 0, ...
-                'Editable install should no longer generate load_package.m');
-            testCase.verifyFalse(exist(fullfile(pkgDir, 'unload_package.m'), 'file') > 0, ...
-                'Editable install should no longer generate unload_package.m');
         end
 
         function testEditableInstall_MarkedAsDirectlyInstalled(testCase)
@@ -84,8 +79,8 @@ classdef TestInstallLocal < matlab.unittest.TestCase
 
         function testEditableInstall_LoadResolvesToSourceDir(testCase)
             % Editable installs resolve "paths" against source_path (the
-            % original source dir), giving the same effect the old
-            % absolute-path load_package.m provided.
+            % original source dir), so mip.load adds that directory to the
+            % MATLAB path.
             srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg');
             mip.install('-e', srcDir);
 

--- a/tests/TestLoadAddpathRmpath.m
+++ b/tests/TestLoadAddpathRmpath.m
@@ -39,34 +39,28 @@ classdef TestLoadAddpathRmpath < matlab.unittest.TestCase
         %% --- Flag parsing / validation ---
 
         function testAddpath_MissingValue_Errors(testCase)
-            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true);
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo');
             testCase.verifyError(@() mip.load('foo', '--addpath'), ...
                 'mip:load:missingAddpathValue');
         end
 
         function testRmpath_MissingValue_Errors(testCase)
-            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true);
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo');
             testCase.verifyError(@() mip.load('foo', '--rmpath'), ...
                 'mip:load:missingRmpathValue');
         end
 
         function testAddpath_MultiplePackages_Errors(testCase)
-            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true);
-            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'bar', ...
-                'sourceSubdir', true);
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'bar');
             testCase.verifyError( ...
                 @() mip.load('foo', 'bar', '--addpath', 'src'), ...
                 'mip:load:addpathSinglePackage');
         end
 
         function testRmpath_MultiplePackages_Errors(testCase)
-            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true);
-            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'bar', ...
-                'sourceSubdir', true);
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'bar');
             testCase.verifyError( ...
                 @() mip.load('foo', 'bar', '--rmpath', 'src'), ...
                 'mip:load:addpathSinglePackage');
@@ -76,7 +70,7 @@ classdef TestLoadAddpathRmpath < matlab.unittest.TestCase
 
         function testAddpath_AddsSourceRelativePath(testCase)
             pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true, 'subdirs', {'src/extra'});
+                'subdirs', {'src/extra'});
             mip.load('foo', '--addpath', 'src/extra');
             expected = fullfile(pkgDir, 'foo', 'src', 'extra');
             testCase.verifyTrue(onPath(expected), ...
@@ -85,7 +79,7 @@ classdef TestLoadAddpathRmpath < matlab.unittest.TestCase
 
         function testAddpath_MultipleFlagsAccumulate(testCase)
             pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true, 'subdirs', {'src/a', 'src/b'});
+                'subdirs', {'src/a', 'src/b'});
             mip.load('foo', '--addpath', 'src/a', '--addpath', 'src/b');
             testCase.verifyTrue(onPath(fullfile(pkgDir, 'foo', 'src', 'a')));
             testCase.verifyTrue(onPath(fullfile(pkgDir, 'foo', 'src', 'b')));
@@ -93,8 +87,7 @@ classdef TestLoadAddpathRmpath < matlab.unittest.TestCase
 
         function testAddpath_MissingDirWarns(testCase)
             % Rely on MATLAB's native addpath warning rather than a custom one.
-            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true);
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo');
             testCase.verifyWarning( ...
                 @() mip.load('foo', '--addpath', 'does/not/exist'), ...
                 'MATLAB:mpath:nameNonexistentOrNotADirectory');
@@ -102,7 +95,7 @@ classdef TestLoadAddpathRmpath < matlab.unittest.TestCase
 
         function testAddpath_AppliesToAlreadyLoaded(testCase)
             pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true, 'subdirs', {'src/extra'});
+                'subdirs', {'src/extra'});
             mip.load('foo');
             % Now adjust the path on the already-loaded package
             mip.load('foo', '--addpath', 'src/extra');
@@ -112,13 +105,10 @@ classdef TestLoadAddpathRmpath < matlab.unittest.TestCase
         %% --- Apply --rmpath ---
 
         function testRmpath_RemovesPreLoadedPath(testCase)
-            % load_package.m adds pkg_dir/foo; --rmpath . removes the
-            % source subdir if it was on the path.
-            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true);
+            % `--rmpath .` removes the package source subdir from the path
+            % after load has addpath'd it.
+            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo');
             sourceSubdir = fullfile(pkgDir, 'foo');
-            addpath(sourceSubdir);
-            testCase.verifyTrue(onPath(sourceSubdir));
             mip.load('foo', '--rmpath', '.');
             testCase.verifyFalse(onPath(sourceSubdir), ...
                 '--rmpath should remove the source-relative target');
@@ -129,7 +119,7 @@ classdef TestLoadAddpathRmpath < matlab.unittest.TestCase
             % surfaces MATLAB's native rmpath warning. This pins the
             % documented behavior (rmpath warns rather than errors).
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true, 'subdirs', {'src/extra'});
+                'subdirs', {'src/extra'});
             testCase.verifyWarning( ...
                 @() mip.load('foo', '--rmpath', 'src/extra'), ...
                 'MATLAB:rmpath:DirNotFound');
@@ -139,7 +129,7 @@ classdef TestLoadAddpathRmpath < matlab.unittest.TestCase
 
         function testUnload_SweepsAddpathEntries(testCase)
             pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true, 'subdirs', {'src/extra'});
+                'subdirs', {'src/extra'});
             mip.load('foo', '--addpath', 'src/extra');
             target = fullfile(pkgDir, 'foo', 'src', 'extra');
             testCase.verifyTrue(onPath(target));
@@ -149,50 +139,10 @@ classdef TestLoadAddpathRmpath < matlab.unittest.TestCase
                 'unload sweep should remove --addpath entries');
         end
 
-        function testUnload_SweepsResidualEntriesFromStaleUnloadScript(testCase)
-            % Build a package where load_package.m adds a path but
-            % unload_package.m DOES NOT remove it. The sweep should still
-            % clean it up.
-            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true);
-            sourceSubdir = fullfile(pkgDir, 'foo');
-            % Replace unload_package.m with a no-op
-            fid = fopen(fullfile(pkgDir, 'unload_package.m'), 'w');
-            fprintf(fid, 'function unload_package()\nend\n');
-            fclose(fid);
-
-            mip.load('foo');
-            testCase.verifyTrue(onPath(sourceSubdir), ...
-                'load_package.m should have added the source subdir');
-
-            mip.unload('foo');
-            testCase.verifyFalse(onPath(sourceSubdir), ...
-                'sweep should remove the residual entry');
-        end
-
-        function testUnload_SweepsWhenUnloadScriptMissing(testCase)
-            % Legacy-only package (no "paths" in mip.json). When
-            % unload_package.m is also absent, mip:unloadNotFound fires
-            % AND the defensive sweep still cleans up the path entry that
-            % load_package.m added.
-            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true, 'style', 'legacy');
-            sourceSubdir = fullfile(pkgDir, 'foo');
-            delete(fullfile(pkgDir, 'unload_package.m'));
-
-            mip.load('foo');
-            testCase.verifyTrue(onPath(sourceSubdir));
-
-            testCase.verifyWarning(@() mip.unload('foo'), 'mip:unloadNotFound');
-            testCase.verifyFalse(onPath(sourceSubdir), ...
-                'sweep should run even when unload_package.m is absent');
-        end
-
         function testUnload_DoesNotTouchUnrelatedSiblingPaths(testCase)
             % Create a sibling directory whose name shares a prefix with
             % the package source dir. The sweep must not touch it.
-            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo', ...
-                'sourceSubdir', true);
+            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'foo');
             sourceSubdir = fullfile(pkgDir, 'foo');
             siblingDir = [sourceSubdir '_sibling'];
             mkdir(siblingDir);
@@ -212,9 +162,9 @@ classdef TestLoadAddpathRmpath < matlab.unittest.TestCase
             % Loading the main package with --addpath src/extra should
             % NOT addpath the dep's src/extra.
             depDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'dep1', ...
-                'sourceSubdir', true, 'subdirs', {'src/extra'});
+                'subdirs', {'src/extra'});
             mainDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'main', ...
-                'sourceSubdir', true, 'subdirs', {'src/extra'}, ...
+                'subdirs', {'src/extra'}, ...
                 'dependencies', {'dep1'});
 
             mip.load('main', '--addpath', 'src/extra');

--- a/tests/TestLoadPackage.m
+++ b/tests/TestLoadPackage.m
@@ -123,7 +123,8 @@ classdef TestLoadPackage < matlab.unittest.TestCase
         function testLoadPackage_AddsToPath(testCase)
             pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'testpkg');
             mip.load('mip-org/core/testpkg');
-            testCase.verifyTrue(ismember(pkgDir, strsplit(path, pathsep)));
+            srcDir = fullfile(pkgDir, 'testpkg');
+            testCase.verifyTrue(ismember(srcDir, strsplit(path, pathsep)));
         end
 
         function testLoadPackage_MultipleDependencies(testCase)
@@ -169,17 +170,17 @@ classdef TestLoadPackage < matlab.unittest.TestCase
             testCase.verifyTrue(mip.state.is_loaded('mip-org/core/pkgB'));
         end
 
-        function testLoadPackage_LoadScriptError_Throws(testCase)
-            % If load_package.m errors, mip.load should throw mip:loadError.
+        function testLoadPackage_MissingPathsField_Errors(testCase)
+            % A package whose mip.json has no "paths" field cannot be loaded.
             pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'badpkg');
-            writeFailingLoadScript(fullfile(pkgDir, 'load_package.m'));
-            testCase.verifyError(@() mip.load('mip-org/core/badpkg'), 'mip:loadError');
+            removePathsField(fullfile(pkgDir, 'mip.json'));
+            testCase.verifyError(@() mip.load('mip-org/core/badpkg'), 'mip:loadNotFound');
         end
 
-        function testLoadPackage_LoadScriptError_NotMarkedLoaded(testCase)
+        function testLoadPackage_MissingPathsField_NotMarkedLoaded(testCase)
             % After a failed load, the package must not be marked as loaded.
             pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'badpkg');
-            writeFailingLoadScript(fullfile(pkgDir, 'load_package.m'));
+            removePathsField(fullfile(pkgDir, 'mip.json'));
             try
                 mip.load('mip-org/core/badpkg');
             catch
@@ -189,59 +190,17 @@ classdef TestLoadPackage < matlab.unittest.TestCase
             testCase.verifyFalse(mip.state.is_directly_loaded('mip-org/core/badpkg'));
         end
 
-        function testLoadPackage_LoadScriptError_CanRetry(testCase)
-            % After a failed load, fixing the script and reloading should work.
-            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'badpkg');
-            loadScript = fullfile(pkgDir, 'load_package.m');
-            writeFailingLoadScript(loadScript);
-            try
-                mip.load('mip-org/core/badpkg');
-            catch
-                % expected
-            end
-            % Replace with a working load_package.m and retry
-            fid = fopen(loadScript, 'w');
-            fprintf(fid, 'function load_package()\n');
-            fprintf(fid, '    pkg_dir = fileparts(mfilename(''fullpath''));\n');
-            fprintf(fid, '    addpath(pkg_dir);\n');
-            fprintf(fid, 'end\n');
-            fclose(fid);
-            mip.load('mip-org/core/badpkg');
-            testCase.verifyTrue(mip.state.is_loaded('mip-org/core/badpkg'));
-        end
-
-        function testLoadPackage_LoadScriptError_RestoresWorkingDir(testCase)
-            % A failing load_package.m must not leave pwd inside the package dir.
-            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'badpkg');
-            writeFailingLoadScript(fullfile(pkgDir, 'load_package.m'));
-            origDir = pwd;
-            try
-                mip.load('mip-org/core/badpkg');
-            catch
-                % expected
-            end
-            testCase.verifyEqual(pwd, origDir);
-        end
-
-        function testLoadPackage_DependencyLoadError_ParentNotLoaded(testCase)
-            % If a dependency fails to load, the parent must also not be marked loaded.
-            depDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'baddep');
-            writeFailingLoadScript(fullfile(depDir, 'load_package.m'));
-            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'mainpkg', ...
-                'dependencies', {'baddep'});
-            testCase.verifyError(@() mip.load('mip-org/core/mainpkg'), 'mip:loadError');
-            testCase.verifyFalse(mip.state.is_loaded('mip-org/core/mainpkg'));
-            testCase.verifyFalse(mip.state.is_loaded('mip-org/core/baddep'));
-        end
-
     end
 end
 
-function writeFailingLoadScript(scriptPath)
-%WRITEFAILINGLOADSCRIPT   Overwrite a load_package.m so that it errors.
-    fid = fopen(scriptPath, 'w');
-    fprintf(fid, 'function load_package()\n');
-    fprintf(fid, '    error(''test:loadFailed'', ''intentional load failure'');\n');
-    fprintf(fid, 'end\n');
+function removePathsField(mipJsonPath)
+%REMOVEPATHSFIELD   Rewrite mip.json with the "paths" field stripped.
+    text = fileread(mipJsonPath);
+    data = jsondecode(text);
+    if isfield(data, 'paths')
+        data = rmfield(data, 'paths');
+    end
+    fid = fopen(mipJsonPath, 'w');
+    fwrite(fid, jsonencode(data));
     fclose(fid);
 end

--- a/tests/TestResetCommand.m
+++ b/tests/TestResetCommand.m
@@ -64,12 +64,13 @@ classdef TestResetCommand < matlab.unittest.TestCase
 
         function testReset_RemovesFromPath(testCase)
             pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgA');
+            srcDir = fullfile(pkgDir, 'pkgA');
             mip.load('mip-org/core/pkgA');
-            testCase.verifyTrue(ismember(pkgDir, strsplit(path, pathsep)));
+            testCase.verifyTrue(ismember(srcDir, strsplit(path, pathsep)));
 
             mip.reset();
 
-            testCase.verifyFalse(ismember(pkgDir, strsplit(path, pathsep)));
+            testCase.verifyFalse(ismember(srcDir, strsplit(path, pathsep)));
         end
 
     end

--- a/tests/TestUnloadPackage.m
+++ b/tests/TestUnloadPackage.m
@@ -41,11 +41,12 @@ classdef TestUnloadPackage < matlab.unittest.TestCase
 
         function testUnloadPackage_RemovesFromPath(testCase)
             pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'testpkg');
+            srcDir = fullfile(pkgDir, 'testpkg');
             mip.load('mip-org/core/testpkg');
-            testCase.verifyTrue(ismember(pkgDir, strsplit(path, pathsep)));
+            testCase.verifyTrue(ismember(srcDir, strsplit(path, pathsep)));
 
             mip.unload('mip-org/core/testpkg');
-            testCase.verifyFalse(ismember(pkgDir, strsplit(path, pathsep)));
+            testCase.verifyFalse(ismember(srcDir, strsplit(path, pathsep)));
         end
 
         function testUnloadPackage_RemovesFromAllLists(testCase)

--- a/tests/TestUpdateSelf.m
+++ b/tests/TestUpdateSelf.m
@@ -61,11 +61,11 @@ classdef TestUpdateSelf < matlab.unittest.TestCase
             % there surfaces here as a test error.
             mip.update('--force', 'mip-org/core/mip');
 
-            % Remove any MATLAB path entries the downloaded mip's
-            % load_package.m just added, so the verify calls below run
-            % against the repo's mip.* functions, not the test-root
-            % payload (they should be equivalent, but keeping the path
-            % clean avoids surprises if they ever diverge).
+            % Remove any MATLAB path entries the downloaded mip just added,
+            % so the verify calls below run against the repo's mip.*
+            % functions, not the test-root payload (they should be
+            % equivalent, but keeping the path clean avoids surprises if
+            % they ever diverge).
             cleanupTestPaths(testCase.TestRoot);
 
             % Verify the swap succeeded: directory still present, version
@@ -78,14 +78,8 @@ classdef TestUpdateSelf < matlab.unittest.TestCase
                 'version should be replaced with real mip version from channel');
             testCase.verifyEqual(info2.name, 'mip', ...
                 'mip.json name should be "mip"');
-            % The downloaded payload is driven by whatever the published
-            % mhl contains -- either a legacy load_package.m or, once the
-            % channel is republished under the new scheme, a "paths" field
-            % in mip.json. Accept either.
-            hasLoadScript = exist(fullfile(pkgDir, 'load_package.m'), 'file') > 0;
-            hasPathsField = isfield(info2, 'paths');
-            testCase.verifyTrue(hasLoadScript || hasPathsField, ...
-                'downloaded mip payload should expose load_package.m or mip.json "paths"');
+            testCase.verifyTrue(isfield(info2, 'paths'), ...
+                'downloaded mip payload should expose mip.json "paths"');
         end
 
     end

--- a/tests/helpers/createTestPackage.m
+++ b/tests/helpers/createTestPackage.m
@@ -9,6 +9,9 @@ function pkgDir = createTestPackage(rootDir, org, channel, pkgName, varargin)
 %     is the package name, with org/channel omitted or passed as ''.
 %     Pass source-type via the 'type' name-value ('local' or 'fex').
 %
+% The package is created with a "paths" field in mip.json that points at
+% the pkgDir/<name>/ source subdirectory.
+%
 % Args:
 %   rootDir  - The MIP_ROOT directory (e.g. tempdir)
 %   org      - Organization name (e.g. 'mip-org'). Use '' for non-gh.
@@ -18,26 +21,13 @@ function pkgDir = createTestPackage(rootDir, org, channel, pkgName, varargin)
 % Optional name-value pairs:
 %   'version'      - Version string (default: '1.0.0')
 %   'dependencies' - Cell array of dependency names (default: {})
-%   'sourceSubdir' - If true, create a pkgDir/<pkgName>/ source subdir
-%                    (matches mip's real non-editable install layout) and
-%                    have load/unload_package.m target that subdir. Required
-%                    for tests that exercise mip.paths.get_source_dir.
-%                    Default: false (source lives at pkgDir top level).
 %   'subdirs'      - Cell array of source-relative subdirs to mkdir under
-%                    the effective source directory (default: {}).
-%   'style'        - Controls which load/unload mechanism is emitted:
-%                      'legacy' - only load_package.m / unload_package.m
-%                      'new'    - only "paths" field in mip.json (no scripts)
-%                      'both'   - both (default). For sourceSubdir=false the
-%                                 flat layout has no realistic source dir, so
-%                                 'both' falls back to legacy-only.
+%                    the source directory (default: {}).
 
 p = inputParser;
 addParameter(p, 'version', '1.0.0', @ischar);
 addParameter(p, 'dependencies', {}, @iscell);
-addParameter(p, 'sourceSubdir', false, @islogical);
 addParameter(p, 'subdirs', {}, @iscell);
-addParameter(p, 'style', 'both', @(s) ischar(s) && ismember(s, {'legacy', 'new', 'both'}));
 addParameter(p, 'type', '', @ischar);
 parse(p, varargin{:});
 
@@ -61,36 +51,21 @@ if strcmp(sourceType, 'gh')
 else
     pkgDir = fullfile(rootDir, 'packages', sourceType, pkgName);
 end
-style = p.Results.style;
-useSourceSubdir = p.Results.sourceSubdir;
 
-% Create directory tree
 if ~exist(pkgDir, 'dir')
     mkdir(pkgDir);
 end
 
-if useSourceSubdir
-    sourceDir = fullfile(pkgDir, pkgName);
-    if ~exist(sourceDir, 'dir')
-        mkdir(sourceDir);
-    end
-else
-    sourceDir = pkgDir;
+sourceDir = fullfile(pkgDir, pkgName);
+if ~exist(sourceDir, 'dir')
+    mkdir(sourceDir);
 end
 
 for i = 1:numel(p.Results.subdirs)
     mkdir(fullfile(sourceDir, p.Results.subdirs{i}));
 end
 
-% The "paths" field in mip.json only makes sense when the package has a
-% real source subdir that mip.paths.get_source_dir can return. Flat test
-% layouts (sourceSubdir=false) don't, so 'both' and 'new' fall back to
-% legacy-only there. Callers that need the new-style behavior on a flat
-% layout should pass sourceSubdir=true.
-emitPathsField = useSourceSubdir && ismember(style, {'new', 'both'});
-emitLegacyScripts = ~useSourceSubdir || ismember(style, {'legacy', 'both'});
-
-% Create mip.json
+% Create mip.json with a "paths" field pointing at the source subdir.
 mipData = struct();
 mipData.name = pkgName;
 mipData.version = p.Results.version;
@@ -105,41 +80,10 @@ else
     mipData.dependencies = deps;
 end
 
-if emitPathsField
-    mipData.paths = {'.'};
-end
+mipData.paths = {'.'};
 
 fid = fopen(fullfile(pkgDir, 'mip.json'), 'w');
 fwrite(fid, jsonencode(mipData));
-fclose(fid);
-
-if ~emitLegacyScripts
-    return
-end
-
-% Build load/unload scripts. When sourceSubdir is set, target pkgDir/<name>/;
-% otherwise target pkgDir itself.
-if useSourceSubdir
-    targetExpr = sprintf('fullfile(pkg_dir, ''%s'')', pkgName);
-else
-    targetExpr = 'pkg_dir';
-end
-
-fid = fopen(fullfile(pkgDir, 'load_package.m'), 'w');
-fprintf(fid, 'function load_package()\n');
-fprintf(fid, '    pkg_dir = fileparts(mfilename(''fullpath''));\n');
-fprintf(fid, '    addpath(%s);\n', targetExpr);
-fprintf(fid, 'end\n');
-fclose(fid);
-
-fid = fopen(fullfile(pkgDir, 'unload_package.m'), 'w');
-fprintf(fid, 'function unload_package()\n');
-fprintf(fid, '    pkg_dir = fileparts(mfilename(''fullpath''));\n');
-fprintf(fid, '    target = %s;\n', targetExpr);
-fprintf(fid, '    if ismember(target, strsplit(path, pathsep))\n');
-fprintf(fid, '        rmpath(target);\n');
-fprintf(fid, '    end\n');
-fprintf(fid, 'end\n');
 fclose(fid);
 
 end


### PR DESCRIPTION
Closes #207.

`mip.json` `paths` is now the sole mechanism for declaring which directories mip adds to the MATLAB path. Packages without a `paths` field now fail to load with `mip:loadNotFound`; mip no longer executes `load_package.m` / `unload_package.m` scripts if present.

## Changes
- `+mip/load.m`: drop the `load_package.m` branch; `mip:loadError` is gone
- `+mip/unload.m`: drop the `unload_package.m` branch; the defensive sweep stays (catches `--addpath` entries not in the paths field)
- `+mip/update.m`: self-update no longer falls back to the legacy scripts
- `+mip/bundle.m`: drop stale comment listing legacy scripts in `.mhl` layout
- `createTestPackage` helper: emit paths-only packages; drop `style` and `sourceSubdir` parameters
- Tests: delete legacy-script error coverage, update path assertions to target `pkgDir/<name>/` (the source subdir)
- Spec (`specification.md`, `specification-high-level.md`): rewrite §4.8 and §5.8, strip legacy references from layout diagrams, error tables, and `.mhl` description

527/527 tests pass (`MIP_SKIP_REMOTE=1`).