### PR TITLE
Make mip.yaml version optional; enforce blank-or-numeric

### DIFF
--- a/+mip/+build/create_mip_json.m
+++ b/+mip/+build/create_mip_json.m
@@ -6,6 +6,7 @@ function create_mip_json(outputDir, mipConfig, architecture, opts)
 %   mipConfig      - Struct from read_mip_yaml
 %   architecture   - Effective architecture string
 %   opts           - (Optional) Struct with fields:
+%     .version     - version string to record (overrides mipConfig.version)
 %     .editable    - true for editable installs
 %     .source_path - original source path (for editable installs)
 %     .install_type - install type string (default: 'local')
@@ -16,7 +17,11 @@ end
 
 mipData = struct();
 mipData.name = mipConfig.name;
-mipData.version = mipConfig.version;
+if isfield(opts, 'version') && ~isempty(opts.version)
+    mipData.version = opts.version;
+else
+    mipData.version = mipConfig.version;
+end
 
 if isfield(mipConfig, 'description')
     mipData.description = mipConfig.description;

--- a/+mip/+build/prepare_package.m
+++ b/+mip/+build/prepare_package.m
@@ -29,8 +29,18 @@ end
 mipConfig = mip.config.read_mip_yaml(sourceDir);
 packageName = mipConfig.name;
 
+% If the channel build supplied a .release_version override, use it for
+% the status message and mip.json. Falls back to mip.yaml's version.
+effectiveVersion = num2str(mipConfig.version);
+sourceReleaseVersionFile = fullfile(sourceDir, '.release_version');
+if exist(sourceReleaseVersionFile, 'file')
+    fid = fopen(sourceReleaseVersionFile, 'r');
+    effectiveVersion = strtrim(fread(fid, '*char')');
+    fclose(fid);
+end
+
 fprintf('Preparing package "%s" (version %s)\n', packageName, ...
-        num2str(mipConfig.version));
+        effectiveVersion);
 
 % Match build for current architecture
 [buildEntry, effectiveArch] = mip.build.match_build(mipConfig, architecture);
@@ -88,6 +98,14 @@ if exist(commitHashFile, 'file')
     jsonOpts.commit_hash = strtrim(fread(fid, '*char')');
     fclose(fid);
     delete(commitHashFile);
+end
+% The channel build drops .release_version next to .source_hash when the
+% release-directory name should override mip.yaml's version (e.g. a branch
+% name like "main" for a blank/numeric mip.yaml version).
+releaseVersionFile = fullfile(pkgSubdir, '.release_version');
+if exist(releaseVersionFile, 'file')
+    jsonOpts.version = effectiveVersion;
+    delete(releaseVersionFile);
 end
 if isfield(resolvedConfig, 'test_script') && ~isempty(resolvedConfig.test_script)
     jsonOpts.test_script = resolvedConfig.test_script;

--- a/+mip/+config/read_mip_yaml.m
+++ b/+mip/+config/read_mip_yaml.m
@@ -35,7 +35,7 @@ if ~isfield(mipConfig, 'name')
 end
 
 if ~isfield(mipConfig, 'version') || isempty(mipConfig.version)
-    mipConfig.version = 'unknown';
+    mipConfig.version = '';
 end
 
 % Normalize dependencies to cell array

--- a/+mip/+config/read_mip_yaml.m
+++ b/+mip/+config/read_mip_yaml.m
@@ -34,7 +34,7 @@ if ~isfield(mipConfig, 'name')
           'mip.yaml is missing required "name" field');
 end
 
-if ~isfield(mipConfig, 'version')
+if ~isfield(mipConfig, 'version') || isempty(mipConfig.version)
     mipConfig.version = 'unknown';
 end
 

--- a/+mip/+config/read_package_json.m
+++ b/+mip/+config/read_package_json.m
@@ -33,7 +33,7 @@ try
     end
 
     if ~isfield(pkgInfo, 'version')
-        pkgInfo.version = 'unknown';
+        pkgInfo.version = '';
     end
 
     if ~isfield(pkgInfo, 'dependencies')

--- a/+mip/bundle.m
+++ b/+mip/bundle.m
@@ -81,7 +81,9 @@ function bundle(varargin)
             mipConfig = mip.build.prepare_package(sourceDir, stagingDir, architecture);
         end
 
-        % Read mip.json to get the effective architecture
+        % Read mip.json to get the effective architecture and version
+        % (mip.json's version may differ from mip.yaml's when a channel
+        % build supplied a release-dir version override).
         mipJsonPath = fullfile(stagingDir, 'mip.json');
         mipJsonText = fileread(mipJsonPath);
         mipJson = jsondecode(mipJsonText);
@@ -92,7 +94,7 @@ function bundle(varargin)
         % name with '_' in the filename.
         nameForFilename = strrep(mipConfig.name, '-', '_');
         mhlFilename = sprintf('%s-%s-%s.mhl', ...
-            nameForFilename, num2str(mipConfig.version), effectiveArch);
+            nameForFilename, num2str(mipJson.version), effectiveArch);
         mhlPath = fullfile(outputDir, mhlFilename);
 
         % Create .mhl (zip) from staging directory contents

--- a/+mip/init.m
+++ b/+mip/init.m
@@ -119,7 +119,7 @@ function write_mip_yaml(yamlPath, pkgName, addpaths, testScript, repository)
 
     fprintf(fid, 'name: %s\n', pkgName);
     fprintf(fid, 'description: ""\n');
-    fprintf(fid, 'version: "unknown"\n');
+    fprintf(fid, 'version: ""\n');
     fprintf(fid, 'license: ""\n');
     fprintf(fid, 'homepage: ""\n');
     fprintf(fid, 'repository: "%s"\n', repository);

--- a/+mip/list.m
+++ b/+mip/list.m
@@ -56,7 +56,7 @@ for i = 1:n
     displayFqns{i} = mip.parse.display_fqn(fqn);
     pkgDir = mip.paths.get_package_dir(fqn);
 
-    versions{i} = 'unknown';
+    versions{i} = '';
     editablePaths{i} = '';
     try
         pkgInfo = mip.config.read_package_json(pkgDir);

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -296,7 +296,7 @@ function p = resolvePackage(packageArg)
     try
         pkgInfo = mip.config.read_package_json(r.pkg_dir);
     catch
-        pkgInfo = struct('version', 'unknown', 'name', r.name);
+        pkgInfo = struct('version', '', 'name', r.name);
     end
 
     % "Local" here means any non-gh source type (local, fex, or web). Update

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -856,7 +856,7 @@ Behavior:
 1. If the target directory already contains a `mip.yaml`, `mip init` prints a message and exits without modifying anything.
 2. `addpaths` is auto-populated by walking the directory and identifying folders that contain runtime MATLAB code. The walk happens **before** the placeholder test script is created, so the root is not auto-included just because of that new file.
 3. A blank `test_<name>.m` is created at the target root (unless one already exists), and the generated `mip.yaml`'s `test_script` field points at it.
-4. Other optional string fields (`description`, `version`, `license`, `homepage`) are emitted blank for the user to fill in. `version` defaults to `"unknown"`. A single `builds: [{ architectures: [any] }]` entry is emitted.
+4. Other optional string fields (`description`, `version`, `license`, `homepage`) are emitted blank for the user to fill in. An empty `version` is normalized to `"unknown"` when read back via `mip.config.read_mip_yaml`. A single `builds: [{ architectures: [any] }]` entry is emitted.
 
 `mip init` also runs automatically on behalf of local installs that are missing a `mip.yaml` (after the user confirms the prompt -- see [§3.2](#32-local-installation)) and on URL-based installs that land on a source tree with no `mip.yaml` (see [§3.4](#34-installation-from-a-remote-zip-url)).
 
@@ -968,7 +968,7 @@ The `paths` field is the authoritative list of directories that `mip load` adds 
 
 ```yaml
 name: package_name              # Required
-version: "1.0.0"                # Optional (defaults to "unknown")
+version: "1.0.0"                # Optional; blank or numeric. Empty/missing is normalized to "unknown" internally.
 description: "..."              # Optional
 license: MIT                    # Optional
 homepage: "https://..."         # Optional
@@ -982,6 +982,18 @@ builds:                         # Optional
     compile_script: "compile.m" # Optional
     test_script: "run_tests.m"  # Optional
 ```
+
+#### 11.2.1 Channel Version Rules
+
+A channel's package layout is `packages/<name>/<version>/` where the directory name is the authoritative version. `recipe.yaml` does not carry a `version` field. `mip.yaml`'s `version` is optional; when present it must be either blank or numeric (e.g. `1.2.3`). Non-numeric values like branch names belong in the release directory name, not in `mip.yaml`.
+
+The channel build (`prepare_packages.py`) validates that the release-directory name is one of:
+
+1. the numeric `version` in `mip.yaml`,
+2. the `source.branch` in `recipe.yaml`, or
+3. any string, when `mip.yaml`'s `version` is blank/missing.
+
+When `mip.yaml`'s version is blank/missing, the channel build writes the release-directory name into `mip.yaml` before bundling, so the resulting `.mhl`'s `mip.json` carries the correct version string.
 
 ### 11.3 `.mhl` File Format
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -816,7 +816,7 @@ Lists packages available in the channel index. Uses `--channel` to specify which
 
 ### 9.4 `mip version`
 
-Prints the mip version string, read from `mip.yaml` in the package root. If `mip.yaml`'s `version` is blank or missing, `"unknown"` is printed (see [§11.2](#112-mipyaml-schema)).
+Prints the mip version string, read from `mip.yaml` in the package root. If `mip.yaml`'s `version` is blank or missing, an empty string is printed (see [§11.2](#112-mipyaml-schema)).
 
 ### 9.5 `mip index`
 
@@ -861,7 +861,7 @@ Behavior:
 1. If the target directory already contains a `mip.yaml`, `mip init` prints a message and exits without modifying anything.
 2. `addpaths` is auto-populated by walking the directory and identifying folders that contain runtime MATLAB code. The walk happens **before** the placeholder test script is created, so the root is not auto-included just because of that new file.
 3. A blank `test_<name>.m` is created at the target root (unless one already exists), and the generated `mip.yaml`'s `test_script` field points at it.
-4. Other optional string fields (`description`, `version`, `license`, `homepage`) are emitted blank for the user to fill in. An empty `version` is normalized to `"unknown"` when read back via `mip.config.read_mip_yaml`. A single `builds: [{ architectures: [any] }]` entry is emitted.
+4. Other optional string fields (`description`, `version`, `license`, `homepage`) are emitted blank for the user to fill in. A single `builds: [{ architectures: [any] }]` entry is emitted.
 
 `mip init` also runs automatically on behalf of local installs that are missing a `mip.yaml` (after the user confirms the prompt -- see [§3.2](#32-local-installation)) and on URL-based installs that land on a source tree with no `mip.yaml` (see [§3.4](#34-installation-from-a-remote-zip-url)).
 
@@ -973,7 +973,7 @@ The `paths` field is the authoritative list of directories that `mip load` adds 
 
 ```yaml
 name: package_name              # Required
-version: "1.0.0"                # Optional; blank or numeric. Empty/missing is normalized to "unknown" internally.
+version: "1.0.0"                # Optional; blank or numeric
 description: "..."              # Optional
 license: MIT                    # Optional
 homepage: "https://..."         # Optional
@@ -998,7 +998,7 @@ The channel build (`prepare_packages.py`) validates that the release-directory n
 2. the `source.branch` in `recipe.yaml`, or
 3. any string, when `mip.yaml`'s `version` is blank/missing.
 
-When `mip.yaml`'s version is blank/missing, the channel build writes the release-directory name into `mip.yaml` before bundling, so the resulting `.mhl`'s `mip.json` carries the correct version string.
+The channel build passes the release-directory name to `mip bundle` so the bundled `mip.json` carries it as the authoritative version. The source `mip.yaml` in the bundle is unchanged; its `version` may remain blank or numeric while `mip.json` records the release-directory name.
 
 ### 11.3 `.mhl` File Format
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -52,6 +52,11 @@ A **bare name** is just the package name without org/channel (e.g., `chebfun`). 
 
 Versions are either **numeric** (e.g., `1.2.3`) or **non-numeric** (e.g., `main`, `master`, `unspecified`). Numeric versions use dot-separated components that are each parseable as numbers.
 
+A version can live in two places:
+
+- **Channel release directory** (`packages/<name>/<version>/`) — the authoritative version for a channel-published package. May be numeric or non-numeric (e.g., a branch name like `main`).
+- **`mip.yaml`'s `version` field** — optional; when present, must be blank or numeric. Non-numeric values like branch names belong in the release directory name, not in `mip.yaml`. See [§11.2.1](#1121-channel-version-rules) for how the two relate.
+
 ### 1.4 The `@version` Suffix
 
 Any package argument passed to a `mip` command (bare or FQN) can include `@version` to pin a specific version:
@@ -811,7 +816,7 @@ Lists packages available in the channel index. Uses `--channel` to specify which
 
 ### 9.4 `mip version`
 
-Prints the mip version string, read from `mip.yaml` in the package root.
+Prints the mip version string, read from `mip.yaml` in the package root. If `mip.yaml`'s `version` is blank or missing, `"unknown"` is printed (see [§11.2](#112-mipyaml-schema)).
 
 ### 9.5 `mip index`
 

--- a/mip.yaml
+++ b/mip.yaml
@@ -1,6 +1,6 @@
 name: mip
 description: "MIP package manager for MATLAB"
-version: "main"
+version: ""
 license: Apache-2.0
 homepage: "https://mip.sh"
 repository: "https://github.com/mip-org/mip"

--- a/tests/TestInit.m
+++ b/tests/TestInit.m
@@ -177,7 +177,7 @@ classdef TestInit < matlab.unittest.TestCase
         function testInit_BlankOptionalFields(testCase)
             % Optional string fields are emitted blank and dependencies
             % defaults to an empty list, so the scaffolded config loads
-            % cleanly via read_mip_yaml. Version is set to "unknown".
+            % cleanly via read_mip_yaml.
             pkgDir = fullfile(testCase.TestDir, 'mypkg');
             mkdir(pkgDir);
 
@@ -189,7 +189,7 @@ classdef TestInit < matlab.unittest.TestCase
             testCase.verifyEqual(cfg.homepage, '');
             testCase.verifyEqual(cfg.repository, '');
             testCase.verifyEqual(cfg.dependencies, {});
-            testCase.verifyEqual(cfg.version, 'unknown');
+            testCase.verifyEqual(cfg.version, '');
         end
 
         function testInit_RepositoryOverride(testCase)

--- a/tests/TestReadMipYaml.m
+++ b/tests/TestReadMipYaml.m
@@ -76,7 +76,14 @@ classdef TestReadMipYaml < matlab.unittest.TestCase
             writeYaml(testCase.TestDir, 'name: mypkg\n');
 
             cfg = mip.config.read_mip_yaml(testCase.TestDir);
-            testCase.verifyEqual(cfg.version, 'unknown');
+            testCase.verifyEqual(cfg.version, '');
+        end
+
+        function testReadYamlBlankVersion(testCase)
+            writeYaml(testCase.TestDir, 'name: mypkg\nversion: ""\n');
+
+            cfg = mip.config.read_mip_yaml(testCase.TestDir);
+            testCase.verifyEqual(cfg.version, '');
         end
 
         function testReadYamlOptionalFields(testCase)


### PR DESCRIPTION
Resolves the decision in #211. Related: #191.

## Summary

- `version` is optional in `mip.yaml`. If present, it must be blank or numeric.
- Non-numeric values (branch names like `main`/`numbl`) belong in the channel release-directory name, not in `mip.yaml`.
- `mip/mip.yaml` now has `version: ""` (was `"main"`, which is no longer allowed).
- `mip init` emits `version: ""`; `read_mip_yaml` normalizes empty/missing to `"unknown"` for internal display (addressing #191).
- Spec §1.3, §9.4, §11.2, and new §11.2.1 document the channel version rules.

## Coordinated merge

This change must land together with:
- mip-org/mip-channel-template#7
- mip-org/mip-core#5

Needs approval from @danfortunato.

## Follow-up

After merging, the `numbl` tag should be retagged to include this commit (the current `numbl` tag is behind main and has the old `version: "main"` in `mip.yaml`, which the new `prepare_packages.py` will reject).