### PR TITLE
Require HTTPS for .mhl downloads and --url installs

### DIFF
--- a/+mip/+channel/download_mhl.m
+++ b/+mip/+channel/download_mhl.m
@@ -2,7 +2,10 @@ function localPath = download_mhl(source, destDir, expectedSha256)
 %DOWNLOAD_MHL   Download a .mhl package file from URL or copy from local path.
 %
 % Args:
-%   source          - URL (http:// or https://) or local file path
+%   source          - HTTPS URL or local file path. Plain http:// is
+%                     rejected (a network attacker could otherwise swap
+%                     .mhl payloads, leading to arbitrary code execution
+%                     once the package is loaded).
 %   destDir         - Destination directory for the downloaded file
 %   expectedSha256  - (Optional) Expected hex SHA-256 of the file (case-insensitive).
 %                     If provided and nonempty, the downloaded/copied file is
@@ -29,8 +32,18 @@ end
 
 source = char(source);
 
+% Reject plain HTTP URLs. mhl_url comes from a channel's index.json, and
+% any third-party channel can be added via `--channel owner/channel`;
+% allowing http:// would let a network attacker swap the payload and
+% achieve persistent code execution once the package is loaded.
+if startsWith(source, 'http://')
+    error('mip:downloadMhl:requireHttps', ...
+          'Refusing to download .mhl over plain HTTP; use https:// instead. Got: %s', ...
+          source);
+end
+
 % Check if source is a URL or local file
-isURL = startsWith(source, {'http://', 'https://'});
+isURL = startsWith(source, 'https://');
 
 if isURL
     % Download from URL using websave

--- a/+mip/install.m
+++ b/+mip/install.m
@@ -672,6 +672,14 @@ function installFromUrlFlag(args, zipUrl, editable, noCompile)
               pkgName);
     end
 
+    % Require HTTPS. A plain http:// fetch lets a network attacker swap
+    % the archive contents, and the unzipped tree is added to the path
+    % on load — i.e. persistent code execution.
+    if startsWith(zipUrl, 'http://')
+        error('mip:install:requireHttps', ...
+              '--url must use https://, not http://. Got: %s', zipUrl);
+    end
+
     % If the URL is a File Exchange landing page, resolve it to the
     % underlying .zip download URL. The resolved URL (with query string
     % stripped) is what gets baked into the generated mip.yaml.
@@ -823,14 +831,15 @@ function zipUrl = resolveFileExchangeUrl(fexUrl)
 end
 
 function tf = isZipUrl(url)
-% Return true if url is an http(s) URL whose path component ends in .zip
+% Return true if url is an https:// URL whose path component ends in .zip
 % (case-insensitive). The path component is everything before the first
-% '?' (query) or '#' (fragment).
+% '?' (query) or '#' (fragment). Plain http:// is rejected — see the
+% requireHttps check in installFromUrlFlag.
     if ~ischar(url) && ~isstring(url)
         tf = false; return;
     end
     url = char(url);
-    if ~startsWith(url, 'http://') && ~startsWith(url, 'https://')
+    if ~startsWith(url, 'https://')
         tf = false;
         return
     end

--- a/+mip/install.m
+++ b/+mip/install.m
@@ -763,13 +763,13 @@ end
 function tf = isFileExchangeUrl(url)
 % A MathWorks File Exchange landing page looks like
 %   https://www.mathworks.com/matlabcentral/fileexchange/<id>[-<slug>]
-% (with optional query string).
+% (with optional query string). Plain http:// is rejected — see the
+% requireHttps check in installFromUrlFlag.
     if ~ischar(url) && ~isstring(url)
         tf = false; return;
     end
     url = char(url);
-    tf = startsWith(url, 'https://www.mathworks.com/matlabcentral/fileexchange/') || ...
-         startsWith(url, 'http://www.mathworks.com/matlabcentral/fileexchange/');
+    tf = startsWith(url, 'https://www.mathworks.com/matlabcentral/fileexchange/');
 end
 
 function zipUrl = resolveFileExchangeUrl(fexUrl)

--- a/tests/TestDownloadMhl.m
+++ b/tests/TestDownloadMhl.m
@@ -70,5 +70,16 @@ classdef TestDownloadMhl < matlab.unittest.TestCase
             testCase.verifyTrue(exist(localPath, 'file') > 0);
         end
 
+        function testHttpUrl_Rejected(testCase)
+            % Plain http:// URLs are refused: mhl_url comes from a
+            % third-party-controllable channel index, and the unpacked
+            % .mhl is loaded as code, so a network attacker swapping the
+            % payload would get persistent code execution. See #229.
+            testCase.verifyError( ...
+                @() mip.channel.download_mhl( ...
+                    'http://example.invalid/pkg.mhl', testCase.DestDir), ...
+                'mip:downloadMhl:requireHttps');
+        end
+
     end
 end

--- a/tests/TestInstallZipUrl.m
+++ b/tests/TestInstallZipUrl.m
@@ -123,6 +123,15 @@ classdef TestInstallZipUrl < matlab.unittest.TestCase
                 'mip:install:urlMustBeZip');
         end
 
+        function testUrl_RejectsHttpScheme(testCase)
+            % Plain http:// is refused: a MITM could swap the archive
+            % and gain code execution once the package is loaded. See
+            % #229.
+            testCase.verifyError( ...
+                @() mip.install('mypkg', '--url', 'http://example.com/foo.zip'), ...
+                'mip:install:requireHttps');
+        end
+
         function testUrl_RejectsZipOnlyInQueryString(testCase)
             % .zip appears only in query string (not path) -> not a zip URL
             testCase.verifyError( ...


### PR DESCRIPTION
Closes #229.

`mhl_url` comes from a channel's `index.json`, and any third-party channel can be added via `--channel owner/channel`. Combined with SHA-256 verification being disabled (#201), accepting `http://` lets a network attacker swap the `.mhl` payload end-to-end. Loading the package adds MEX/.m files to the path — persistent code execution.

## Changes

- `+mip/+channel/download_mhl.m` — reject `http://` with `mip:downloadMhl:requireHttps`
- `+mip/install.m` `installFromUrlFlag` — reject `http://` with `mip:install:requireHttps`
- `isZipUrl` — tightened to `https://` only as defense-in-depth
- Tests added for both rejection paths