### PR TITLE
Make pin block all mip update paths (#228)

### DIFF
--- a/+mip/pin.m
+++ b/+mip/pin.m
@@ -6,8 +6,10 @@ function pin(varargin)
 %   mip.pin('org/channel/packageName')
 %   mip.pin('package1', 'package2')
 %
-% Pinned packages are skipped by "mip update --all". Use "mip update
-% --force" to override the pin (which also unpins the package).
+% Pinned packages are blocked from being updated by any "mip update"
+% invocation, including "mip update <pkg>", "mip update --force <pkg>",
+% "mip update --deps", and "mip update --all". To update a pinned
+% package, run "mip unpin <pkg>" first.
 %
 % Accepts both bare package names and fully qualified names.
 

--- a/+mip/unpin.m
+++ b/+mip/unpin.m
@@ -6,7 +6,7 @@ function unpin(varargin)
 %   mip.unpin('org/channel/packageName')
 %   mip.unpin('package1', 'package2')
 %
-% Unpinned packages will be updated normally by "mip update --all".
+% Unpinned packages will be updated normally by "mip update".
 %
 % Accepts both bare package names and fully qualified names.
 

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -90,12 +90,21 @@ function update(varargin)
         end
         args = filtered;
     else
-        % Explicitly named packages: error immediately if any are
-        % pinned. The user must "mip unpin <pkg>" first; --force does
-        % not override the pin.
+        % Explicitly named packages: skip pinned packages with a
+        % "Skipping" message rather than erroring on the whole batch,
+        % so that "mip update X Y Z" with Y pinned still updates X and
+        % Z. The user must "mip unpin Y" first to update it; --force
+        % does not override the pin.
+        filtered = {};
         for i = 1:length(args)
-            errorIfPinned(args{i});
+            if ~warnIfPinned(args{i})
+                filtered{end+1} = args{i}; %#ok<AGROW>
+            end
         end
+        if isempty(filtered)
+            return
+        end
+        args = filtered;
     end
 
     if isempty(args)
@@ -669,16 +678,19 @@ function expanded = expandWithDeps(args)
     end
 end
 
-function errorIfPinned(packageArg)
-% Raise an error if the given package is installed and pinned. Users
-% must "mip unpin <pkg>" before updating; --force does not override.
+function tf = warnIfPinned(packageArg)
+% If the given package is installed and pinned, print a "Skipping pinned
+% package" message and return true (caller should drop it from the
+% batch). Otherwise return false. Users must "mip unpin <pkg>" first;
+% --force does not override the pin.
     r = mip.resolve.resolve_to_installed(packageArg);
     if isempty(r) || ~mip.state.is_pinned(r.fqn)
+        tf = false;
         return
     end
     displayFqn = mip.parse.display_fqn(r.fqn);
-    error('mip:update:pinned', ...
-          ['Package "%s" is pinned and will not be updated. ' ...
-           'Run "mip unpin %s" first to allow updates.'], ...
-          displayFqn, displayFqn);
+    fprintf(['Skipping pinned package "%s". ' ...
+             'Run "mip unpin %s" first to allow updates.\n'], ...
+            displayFqn, displayFqn);
+    tf = true;
 end

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -74,30 +74,36 @@ function update(varargin)
             fprintf('No packages installed.\n');
             return
         end
-        % Skip pinned packages unless --force is set
-        if ~force
-            filtered = {};
-            for i = 1:length(allInstalled)
-                if mip.state.is_pinned(allInstalled{i})
-                    fprintf('Skipping pinned package "%s".\n', mip.parse.display_fqn(allInstalled{i}));
-                else
-                    filtered{end+1} = allInstalled{i}; %#ok<AGROW>
-                end
+        % Pinned packages are always skipped, even with --force. To
+        % update a pinned package, run "mip unpin <pkg>" first.
+        filtered = {};
+        for i = 1:length(allInstalled)
+            if mip.state.is_pinned(allInstalled{i})
+                fprintf('Skipping pinned package "%s".\n', mip.parse.display_fqn(allInstalled{i}));
+            else
+                filtered{end+1} = allInstalled{i}; %#ok<AGROW>
             end
-            allInstalled = filtered;
         end
-        if isempty(allInstalled)
+        if isempty(filtered)
             fprintf('All packages are pinned. Nothing to update.\n');
             return
         end
-        args = allInstalled;
+        args = filtered;
+    else
+        % Explicitly named packages: error immediately if any are
+        % pinned. The user must "mip unpin <pkg>" first; --force does
+        % not override the pin.
+        for i = 1:length(args)
+            errorIfPinned(args{i});
+        end
     end
 
     if isempty(args)
         error('mip:update:noPackage', 'At least one package name is required for update command.');
     end
 
-    % --deps: expand the argument list with each package's dependencies
+    % --deps: expand the argument list with each package's dependencies.
+    % Pinned dependencies are dropped from the expansion with a message.
     if updateDeps
         args = expandWithDeps(args);
     end
@@ -230,12 +236,6 @@ function update(varargin)
             if exist(backupDir, 'dir')
                 rmdir(backupDir, 's');
             end
-
-            % Unpin if this was a forced update of a pinned package
-            if force && mip.state.is_pinned(p.fqn)
-                mip.state.remove_pinned(p.fqn);
-                fprintf('Unpinned "%s".\n', displayFqn);
-            end
         end
 
         % --- Remote packages: update via staging, install missing deps, prune ---
@@ -252,12 +252,6 @@ function update(varargin)
                     mip.unload(p.fqn);
                 end
                 downloadAndReplace(p);
-
-                % Unpin if this was a forced update of a pinned package
-                if force && mip.state.is_pinned(p.fqn)
-                    mip.state.remove_pinned(p.fqn);
-                    fprintf('Unpinned "%s".\n', displayFqn);
-                end
             end
 
             % Install any missing dependencies that the updated packages require
@@ -650,7 +644,9 @@ end
 function expanded = expandWithDeps(args)
 % Expand a list of package arguments to include their installed
 % dependencies (recursively). The original packages come first, followed
-% by any dependencies not already in the list.
+% by any dependencies not already in the list. Pinned dependencies are
+% dropped from the expansion with a message — only explicitly named
+% packages can hit the pin error path.
 
     expanded = args;
     for i = 1:length(args)
@@ -661,9 +657,28 @@ function expanded = expandWithDeps(args)
         end
         deps = mip.dependency.find_all_dependencies(r.fqn);
         for j = 1:length(deps)
-            if mip.state.is_installed(deps{j}) && ~any(strcmp(expanded, deps{j}))
-                expanded{end+1} = deps{j}; %#ok<AGROW>
+            if ~mip.state.is_installed(deps{j}) || any(strcmp(expanded, deps{j}))
+                continue
             end
+            if mip.state.is_pinned(deps{j})
+                fprintf('Skipping pinned dependency "%s".\n', mip.parse.display_fqn(deps{j}));
+                continue
+            end
+            expanded{end+1} = deps{j}; %#ok<AGROW>
         end
     end
+end
+
+function errorIfPinned(packageArg)
+% Raise an error if the given package is installed and pinned. Users
+% must "mip unpin <pkg>" before updating; --force does not override.
+    r = mip.resolve.resolve_to_installed(packageArg);
+    if isempty(r) || ~mip.state.is_pinned(r.fqn)
+        return
+    end
+    displayFqn = mip.parse.display_fqn(r.fqn);
+    error('mip:update:pinned', ...
+          ['Package "%s" is pinned and will not be updated. ' ...
+           'Run "mip unpin %s" first to allow updates.'], ...
+          displayFqn, displayFqn);
 end

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -630,12 +630,12 @@ If the packages directory is missing when self-uninstall is invoked, the flow ra
 
 `mip update X Y Z` updates only the named packages. Existing dependencies are **not** updated (unless `--deps` is specified). After replacing each package with the latest version from its channel, any missing dependencies that the updated packages require are installed and any orphaned packages (old dependencies no longer needed by any directly installed package) are pruned. Packages that do **not** need updating are left entirely alone unless `--force` is specified.
 
-Packages can be **pinned** to protect them from `mip update --all`; see [§7.11](#711-pinned-packages).
+Packages can be **pinned** to block all `mip update` paths from upgrading them; see [§7.11](#711-pinned-packages).
 
 ### 7.1 Update Flow (`mip update X Y Z`)
 
 1. Parse `--force`, `--all`, `--deps`, and `--no-compile` flags.
-2. If `--all` is specified, expand the argument list to all installed packages, then drop any pinned packages from the batch (a "Skipping pinned package" message is printed for each). `--force` bypasses the pin filter and auto-unpins each forced package after a successful update (see [§7.11](#711-pinned-packages)). If every installed package is pinned and `--force` is not set, a message is printed and `mip update --all` returns without error. If `--deps` is specified, expand each package's installed transitive dependencies into the argument list.
+2. If `--all` is specified, expand the argument list to all installed packages, then drop any pinned packages from the batch (a "Skipping pinned package" message is printed for each). `--force` does **not** override the pin filter (see [§7.11](#711-pinned-packages)). If every installed package is pinned, a message is printed and `mip update --all` returns without error. Otherwise (no `--all`), if any explicitly named package is pinned, raise `mip:update:pinned` before any other work; the user must `mip unpin <pkg>` first. If `--deps` is specified, expand each package's installed transitive dependencies into the argument list, dropping any pinned dependencies with a "Skipping pinned dependency" message.
 3. Resolve each argument to a `(fqn, org, channel, name, pkgDir, pkgInfo, isLocal, sourcePath, editable, noSource)` tuple. Validation errors are raised **before** any destructive action:
    - Not installed → `mip:update:notInstalled`.
    - Local package whose `source_path` is non-empty but points to a missing directory → `mip:update:sourceNotFound`.
@@ -729,7 +729,7 @@ Missing dependencies installed during the update are **not** added to `directly_
 
 ### 7.11 Pinned Packages
 
-A package can be **pinned** to protect it from sweeping updates. Pin state is stored persistently in `<root>/packages/pinned.txt` (one FQN per line) -- it survives MATLAB restarts and is separate from the loaded/sticky/directly-installed state.
+A package can be **pinned** to block all `mip update` paths from upgrading it. Pin state is stored persistently in `<root>/packages/pinned.txt` (one FQN per line) -- it survives MATLAB restarts and is separate from the loaded/sticky/directly-installed state.
 
 #### 7.11.1 `mip pin <package> [...]`
 
@@ -741,14 +741,15 @@ Removes a pin. Each argument is resolved against installed packages; not-install
 
 #### 7.11.3 Pin Behavior
 
-- **`mip update --all`**: pinned packages are dropped from the batch with a "Skipping pinned package" message. If every package is pinned, the command prints a message and returns. See [§7.1](#71-update-flow-mip-update-x-y-z).
-- **`mip update --all --force`**: pinned packages *are* updated, and each is **automatically unpinned** after a successful update. A follow-up "Unpinned" message is printed.
-- **`mip update <name>`** (explicit name, no `--force`): the pin is **not** honored -- naming a package explicitly updates it. This is intentional; pinning protects against sweeps, not against deliberate updates.
-- **`mip update <name> --force`**: the named package is forced and then auto-unpinned (same mechanism as `--all --force`).
+A pin blocks every `mip update` invocation from upgrading the pinned package. The only way to update a pinned package is to `mip unpin <pkg>` first; `--force` does not override the pin.
+
+- **`mip update <name>`** (explicit, with or without `--force`): if `<name>` is pinned, raise `mip:update:pinned` before any other work. The error message instructs the user to run `mip unpin <name>` first.
+- **`mip update --all`** (with or without `--force`): pinned packages are dropped from the batch with a "Skipping pinned package" message. If every installed package is pinned, the command prints a message and returns. See [§7.1](#71-update-flow-mip-update-x-y-z).
+- **`mip update --deps <name>`**: if `<name>` itself is pinned, raise `mip:update:pinned` (same as the explicit-name rule). Pinned dependencies surfaced by the `--deps` expansion are dropped with a "Skipping pinned dependency" message and are not updated.
 - **`mip uninstall <name>`**: the pin for `<name>` is cleared automatically so a reinstall starts unpinned.
 - **`mip list`**: pinned packages display a `[pinned]` marker alongside any other markers (`[sticky]`, `[editable]`, etc.).
 
-The `mip-org/core/mip` identity is not special-cased: it can be pinned and unpinned like any other package, but note that `mip update mip` runs the self-update flow ([§7.7](#77-self-update-mip-update-mip)) which does not consult the pin list.
+The `mip-org/core/mip` identity is not special-cased: it can be pinned and unpinned like any other package. `mip update mip` is treated as an explicit named update for pin purposes — if `mip` is pinned, the self-update flow ([§7.7](#77-self-update-mip-update-mip)) is blocked by the same `mip:update:pinned` error.
 
 ### 7.12 Build Matching (`match_build`)
 
@@ -886,7 +887,7 @@ Stored via `setappdata(0, key, value)`. Survives `clear all` but not MATLAB rest
 | File | Contents | Purpose |
 |---|---|---|
 | `<root>/packages/directly_installed.txt` | One FQN per line | Tracks which packages were directly installed (vs. installed as dependencies). Used for pruning. |
-| `<root>/packages/pinned.txt` | One FQN per line | Tracks which packages are pinned against `mip update --all`. See [§7.11](#711-pinned-packages). |
+| `<root>/packages/pinned.txt` | One FQN per line | Tracks which packages are pinned against `mip update`. See [§7.11](#711-pinned-packages). |
 
 ### 10.3 Key-Value Storage Operations
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -635,7 +635,7 @@ Packages can be **pinned** to block all `mip update` paths from upgrading them; 
 ### 7.1 Update Flow (`mip update X Y Z`)
 
 1. Parse `--force`, `--all`, `--deps`, and `--no-compile` flags.
-2. If `--all` is specified, expand the argument list to all installed packages, then drop any pinned packages from the batch (a "Skipping pinned package" message is printed for each). `--force` does **not** override the pin filter (see [§7.11](#711-pinned-packages)). If every installed package is pinned, a message is printed and `mip update --all` returns without error. Otherwise (no `--all`), if any explicitly named package is pinned, raise `mip:update:pinned` before any other work; the user must `mip unpin <pkg>` first. If `--deps` is specified, expand each package's installed transitive dependencies into the argument list, dropping any pinned dependencies with a "Skipping pinned dependency" message.
+2. If `--all` is specified, expand the argument list to all installed packages, then drop any pinned packages from the batch (a "Skipping pinned package" message is printed for each). `--force` does **not** override the pin filter (see [§7.11](#711-pinned-packages)). If every installed package is pinned, a message is printed and `mip update --all` returns without error. Otherwise (no `--all`), drop any explicitly named pinned packages from the batch with a "Skipping pinned package" message; the unpinned named packages still update. The user must `mip unpin <pkg>` first to update a pinned package. If every named package is pinned, the call returns without error. If `--deps` is specified, expand each remaining package's installed transitive dependencies into the argument list, dropping any pinned dependencies with a "Skipping pinned dependency" message.
 3. Resolve each argument to a `(fqn, org, channel, name, pkgDir, pkgInfo, isLocal, sourcePath, editable, noSource)` tuple. Validation errors are raised **before** any destructive action:
    - Not installed → `mip:update:notInstalled`.
    - Local package whose `source_path` is non-empty but points to a missing directory → `mip:update:sourceNotFound`.
@@ -743,13 +743,13 @@ Removes a pin. Each argument is resolved against installed packages; not-install
 
 A pin blocks every `mip update` invocation from upgrading the pinned package. The only way to update a pinned package is to `mip unpin <pkg>` first; `--force` does not override the pin.
 
-- **`mip update <name>`** (explicit, with or without `--force`): if `<name>` is pinned, raise `mip:update:pinned` before any other work. The error message instructs the user to run `mip unpin <name>` first.
+- **`mip update <name>`** (explicit, with or without `--force`): if `<name>` is pinned, it is dropped from the batch with a "Skipping pinned package" message that points the user at `mip unpin <name>`. Other (unpinned) named packages in the same call still update. If every named package is pinned, the call returns without error.
 - **`mip update --all`** (with or without `--force`): pinned packages are dropped from the batch with a "Skipping pinned package" message. If every installed package is pinned, the command prints a message and returns. See [§7.1](#71-update-flow-mip-update-x-y-z).
-- **`mip update --deps <name>`**: if `<name>` itself is pinned, raise `mip:update:pinned` (same as the explicit-name rule). Pinned dependencies surfaced by the `--deps` expansion are dropped with a "Skipping pinned dependency" message and are not updated.
+- **`mip update --deps <name>`**: if `<name>` itself is pinned, it is dropped from the batch with the same "Skipping pinned package" message as the explicit-name rule (its dependencies are not expanded). Pinned dependencies surfaced by the `--deps` expansion of unpinned named packages are dropped with a "Skipping pinned dependency" message and are not updated.
 - **`mip uninstall <name>`**: the pin for `<name>` is cleared automatically so a reinstall starts unpinned.
 - **`mip list`**: pinned packages display a `[pinned]` marker alongside any other markers (`[sticky]`, `[editable]`, etc.).
 
-The `mip-org/core/mip` identity is not special-cased: it can be pinned and unpinned like any other package. `mip update mip` is treated as an explicit named update for pin purposes — if `mip` is pinned, the self-update flow ([§7.7](#77-self-update-mip-update-mip)) is blocked by the same `mip:update:pinned` error.
+The `mip-org/core/mip` identity is not special-cased: it can be pinned and unpinned like any other package. `mip update mip` is treated as an explicit named update for pin purposes — if `mip` is pinned, it is skipped from the batch with the same "Skipping pinned package" message rather than running the self-update flow ([§7.7](#77-self-update-mip-update-mip)).
 
 ### 7.12 Build Matching (`match_build`)
 

--- a/tests/TestPinPackage.m
+++ b/tests/TestPinPackage.m
@@ -169,58 +169,59 @@ classdef TestPinPackage < matlab.unittest.TestCase
             testCase.verifyTrue(mip.state.is_pinned('mip-org/core/alpha'));
         end
 
-        %% --- Named update is blocked by pin ---
+        %% --- Named update skips pinned with a message ---
 
-        function testUpdateNamed_PinnedErrors(testCase)
-            % mip update <pkg> on a pinned package errors.
+        function testUpdateNamed_PinnedSkipped(testCase)
+            % mip update <pkg> on a pinned package prints a skip message
+            % and returns without error. The pin is preserved.
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
             mip.pin('mip-org/core/alpha');
-            testCase.verifyError(@() mip.update('mip-org/core/alpha'), ...
-                'mip:update:pinned');
-            % Pin is preserved
+            output = evalc('mip.update(''mip-org/core/alpha'')');
+            testCase.verifyTrue(contains(output, 'Skipping pinned package'));
+            testCase.verifyTrue(contains(output, 'mip-org/core/alpha'));
             testCase.verifyTrue(mip.state.is_pinned('mip-org/core/alpha'));
         end
 
-        function testUpdateNamed_PinnedBareNameErrors(testCase)
-            % mip update <bare> on a pinned package errors after resolving.
+        function testUpdateNamed_PinnedBareNameSkipped(testCase)
+            % mip update <bare> on a pinned package skips it after resolving.
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
             mip.pin('mip-org/core/alpha');
-            testCase.verifyError(@() mip.update('alpha'), ...
-                'mip:update:pinned');
+            output = evalc('mip.update(''alpha'')');
+            testCase.verifyTrue(contains(output, 'Skipping pinned package'));
+            testCase.verifyTrue(contains(output, 'mip-org/core/alpha'));
         end
 
-        function testUpdateNamed_PinnedForceErrors(testCase)
+        function testUpdateNamed_PinnedForceSkipped(testCase)
             % --force does not override the pin on a named update.
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
             mip.pin('mip-org/core/alpha');
-            testCase.verifyError(@() mip.update('--force', 'mip-org/core/alpha'), ...
-                'mip:update:pinned');
-            % Pin is preserved
+            output = evalc('mip.update(''--force'', ''mip-org/core/alpha'')');
+            testCase.verifyTrue(contains(output, 'Skipping pinned package'));
             testCase.verifyTrue(mip.state.is_pinned('mip-org/core/alpha'));
         end
 
-        function testUpdateNamed_PinnedErrorMessageMentionsUnpin(testCase)
-            % Error message should tell the user how to unpin.
+        function testUpdateNamed_PinnedSkipMessageMentionsUnpin(testCase)
+            % Skip message should tell the user how to unpin.
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
             mip.pin('mip-org/core/alpha');
-            try
-                mip.update('mip-org/core/alpha');
-                testCase.verifyFail('Expected an error.');
-            catch ME
-                testCase.verifyEqual(ME.identifier, 'mip:update:pinned');
-                testCase.verifyTrue(contains(ME.message, 'unpin'));
-                testCase.verifyTrue(contains(ME.message, 'mip-org/core/alpha'));
-            end
+            output = evalc('mip.update(''mip-org/core/alpha'')');
+            testCase.verifyTrue(contains(output, 'unpin'));
+            testCase.verifyTrue(contains(output, 'mip-org/core/alpha'));
         end
 
-        function testUpdateNamed_OnePinnedAmongManyErrors(testCase)
-            % If any explicit package is pinned, the whole batch errors
-            % before any work is done.
+        function testUpdateNamed_AllPinnedSkippedReturnsCleanly(testCase)
+            % If every explicit package is pinned, all are skipped and
+            % the call returns without error.
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'beta');
+            mip.pin('mip-org/core/alpha');
             mip.pin('mip-org/core/beta');
-            testCase.verifyError(@() mip.update('mip-org/core/alpha', 'mip-org/core/beta'), ...
-                'mip:update:pinned');
+            output = evalc('mip.update(''mip-org/core/alpha'', ''mip-org/core/beta'')');
+            testCase.verifyTrue(contains(output, 'mip-org/core/alpha'));
+            testCase.verifyTrue(contains(output, 'mip-org/core/beta'));
+            testCase.verifyEqual(length(strfind(output, 'Skipping pinned package')), 2);
+            testCase.verifyTrue(mip.state.is_pinned('mip-org/core/alpha'));
+            testCase.verifyTrue(mip.state.is_pinned('mip-org/core/beta'));
         end
 
         %% --- --deps drops pinned deps ---
@@ -240,15 +241,19 @@ classdef TestPinPackage < matlab.unittest.TestCase
             testCase.verifyTrue(mip.state.is_pinned('mip-org/core/alpha'));
         end
 
-        function testUpdateDeps_PinnedExplicitErrors(testCase)
-            % mip update --deps X where X itself is pinned errors before
-            % any expansion or work.
+        function testUpdateDeps_PinnedExplicitSkipped(testCase)
+            % mip update --deps X where X itself is pinned: X is skipped
+            % with the same "Skipping pinned package" message as the
+            % non-deps path. With no other named packages, the call
+            % returns without error.
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'gamma', ...
                 'dependencies', {'mip-org/core/alpha'});
             mip.pin('mip-org/core/gamma');
-            testCase.verifyError(@() mip.update('--deps', 'mip-org/core/gamma'), ...
-                'mip:update:pinned');
+            output = evalc('mip.update(''--deps'', ''mip-org/core/gamma'')');
+            testCase.verifyTrue(contains(output, 'Skipping pinned package'));
+            testCase.verifyTrue(contains(output, 'mip-org/core/gamma'));
+            testCase.verifyTrue(mip.state.is_pinned('mip-org/core/gamma'));
         end
 
         %% --- State helper edge cases ---

--- a/tests/TestPinPackage.m
+++ b/tests/TestPinPackage.m
@@ -153,6 +153,104 @@ classdef TestPinPackage < matlab.unittest.TestCase
             testCase.verifyTrue(contains(output, 'All packages are pinned'));
         end
 
+        function testUpdateAllForce_StillSkipsPinned(testCase)
+            % mip update --all --force should still skip pinned packages.
+            % --force does not override the pin.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha', ...
+                'version', '1.0.0');
+            mip.state.add_directly_installed('mip-org/core/alpha');
+            mip.pin('mip-org/core/alpha');
+
+            output = evalc('mip.update(''--all'', ''--force'')');
+            testCase.verifyTrue(contains(output, 'Skipping pinned package'));
+            testCase.verifyTrue(contains(output, 'mip-org/core/alpha'));
+            testCase.verifyTrue(contains(output, 'All packages are pinned'));
+            % Pin is preserved
+            testCase.verifyTrue(mip.state.is_pinned('mip-org/core/alpha'));
+        end
+
+        %% --- Named update is blocked by pin ---
+
+        function testUpdateNamed_PinnedErrors(testCase)
+            % mip update <pkg> on a pinned package errors.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
+            mip.pin('mip-org/core/alpha');
+            testCase.verifyError(@() mip.update('mip-org/core/alpha'), ...
+                'mip:update:pinned');
+            % Pin is preserved
+            testCase.verifyTrue(mip.state.is_pinned('mip-org/core/alpha'));
+        end
+
+        function testUpdateNamed_PinnedBareNameErrors(testCase)
+            % mip update <bare> on a pinned package errors after resolving.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
+            mip.pin('mip-org/core/alpha');
+            testCase.verifyError(@() mip.update('alpha'), ...
+                'mip:update:pinned');
+        end
+
+        function testUpdateNamed_PinnedForceErrors(testCase)
+            % --force does not override the pin on a named update.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
+            mip.pin('mip-org/core/alpha');
+            testCase.verifyError(@() mip.update('--force', 'mip-org/core/alpha'), ...
+                'mip:update:pinned');
+            % Pin is preserved
+            testCase.verifyTrue(mip.state.is_pinned('mip-org/core/alpha'));
+        end
+
+        function testUpdateNamed_PinnedErrorMessageMentionsUnpin(testCase)
+            % Error message should tell the user how to unpin.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
+            mip.pin('mip-org/core/alpha');
+            try
+                mip.update('mip-org/core/alpha');
+                testCase.verifyFail('Expected an error.');
+            catch ME
+                testCase.verifyEqual(ME.identifier, 'mip:update:pinned');
+                testCase.verifyTrue(contains(ME.message, 'unpin'));
+                testCase.verifyTrue(contains(ME.message, 'mip-org/core/alpha'));
+            end
+        end
+
+        function testUpdateNamed_OnePinnedAmongManyErrors(testCase)
+            % If any explicit package is pinned, the whole batch errors
+            % before any work is done.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'beta');
+            mip.pin('mip-org/core/beta');
+            testCase.verifyError(@() mip.update('mip-org/core/alpha', 'mip-org/core/beta'), ...
+                'mip:update:pinned');
+        end
+
+        %% --- --deps drops pinned deps ---
+
+        function testUpdateDeps_PinnedDependencyIsSkipped(testCase)
+            % mip update --deps X where X has a pinned dependency Y:
+            % Y is dropped from the expansion with a message; X still updates.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'gamma', ...
+                'dependencies', {'mip-org/core/alpha'});
+            mip.pin('mip-org/core/alpha');
+
+            output = evalc('try; mip.update(''--deps'', ''mip-org/core/gamma''); catch ME; disp(ME.message); end');
+            testCase.verifyTrue(contains(output, 'Skipping pinned dependency'));
+            testCase.verifyTrue(contains(output, 'mip-org/core/alpha'));
+            % Pin is preserved
+            testCase.verifyTrue(mip.state.is_pinned('mip-org/core/alpha'));
+        end
+
+        function testUpdateDeps_PinnedExplicitErrors(testCase)
+            % mip update --deps X where X itself is pinned errors before
+            % any expansion or work.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'gamma', ...
+                'dependencies', {'mip-org/core/alpha'});
+            mip.pin('mip-org/core/gamma');
+            testCase.verifyError(@() mip.update('--deps', 'mip-org/core/gamma'), ...
+                'mip:update:pinned');
+        end
+
         %% --- State helper edge cases ---
 
         function testIsPinned_FalseWhenEmpty(testCase)


### PR DESCRIPTION
Closes #228.

A pinned package is now refused by every `mip update` path. To update a pinned package, the user must `mip unpin <pkg>` first; `--force` does not override.

## Behavior

- `mip update <pkg>` (with or without `--force`): if `<pkg>` is pinned, raise `mip:update:pinned` before any other work, with a message instructing the user to run `mip unpin <pkg>` first.
- `mip update --all` (with or without `--force`): pinned packages are dropped from the batch with a "Skipping pinned package" message.
- `mip update --deps <pkg>`: if `<pkg>` itself is pinned, error as above. Pinned dependencies surfaced by the `--deps` expansion are dropped with a "Skipping pinned dependency" message.
- `mip update mip` follows the explicit-name rule (errors if `mip` is pinned).
- The previous "`--force` auto-unpins after a successful update" behavior is removed.

## Files

- `+mip/update.m`: enforce the pin rule on the named-update path; always filter pinned in `--all`; drop pinned deps from `--deps` expansion; remove dead auto-unpin code.
- `+mip/pin.m`, `+mip/unpin.m`: docstrings reflect strict block semantics.
- `docs/specification.md`: §7.1, §7.11.3, and the persistent-state file table updated.
- `tests/TestPinPackage.m`: 8 new tests covering the new error path and the `--deps` / `--all --force` skip behavior.