### PR TITLE
Mark directly-loaded packages as directly_installed (#224)

### DIFF
--- a/+mip/load.m
+++ b/+mip/load.m
@@ -192,6 +192,9 @@ function matched = loadSingle(packageArg, installIfMissing, stickyPackage, chann
         else
             fprintf('Package "%s" is already loaded\n', displayFqn);
         end
+        if isDirect
+            mip.state.add_directly_installed(fqn);
+        end
         % If --sticky was specified, add to sticky packages
         if stickyPackage
             if ~mip.state.is_sticky(fqn)
@@ -257,6 +260,7 @@ function matched = loadSingle(packageArg, installIfMissing, stickyPackage, chann
     % Track directly loaded packages separately
     if isDirect
         mip.state.key_value_append('MIP_DIRECTLY_LOADED_PACKAGES', fqn);
+        mip.state.add_directly_installed(fqn);
     end
 
     % Mark package as sticky if requested

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -438,12 +438,13 @@ Validation happens *before* extraction so that a malicious entry can never write
 4. Look up the package directory. If it doesn't exist, raise `mip:packageNotFound`.
 5. If already loaded:
    - If this is a direct load and the package was previously loaded as a dependency, promote it to "directly loaded".
+   - If this is a direct load, also mark the package as directly installed (idempotent; promotes a previously transitive install).
    - If `--sticky` is specified, add to sticky packages.
    - Return early.
 6. Read `mip.json` and load dependencies first (recursively, as non-direct loads).
 7. Add each entry in the `mip.json` `paths` field to the MATLAB path (see [§4.8](#48-path-addition-from-mipjson)). If the field is missing, raise `mip:loadNotFound` and stop -- the package is **not** marked as loaded.
 8. Add to `MIP_LOADED_PACKAGES`.
-9. If this is a direct load, add to `MIP_DIRECTLY_LOADED_PACKAGES`.
+9. If this is a direct load, add to `MIP_DIRECTLY_LOADED_PACKAGES` and mark the package as directly installed.
 10. If `--sticky`, add to `MIP_STICKY_PACKAGES`.
 
 ### 4.2 The `--sticky` Flag
@@ -467,7 +468,7 @@ When loading a package with dependencies (listed in `mip.json`):
 
 1. Each dependency is resolved using `resolve_dependency` ([§2.4.4](#244-resolving-a-bare-name-dependency-resolve_dependency)): bare names always resolve to `gh/mip-org/core/<name>`.
 2. Dependencies are loaded recursively before the package itself.
-3. Dependencies are loaded as **non-direct** (they won't appear in `MIP_DIRECTLY_LOADED_PACKAGES`).
+3. Dependencies are loaded as **non-direct** (they won't appear in `MIP_DIRECTLY_LOADED_PACKAGES`, and are not added to `directly_installed.txt`).
 4. Dependencies are loaded as **non-sticky** (even if the parent was loaded with `--sticky`).
 5. Already-loaded dependencies are skipped.
 
@@ -903,6 +904,10 @@ Stored via `setappdata(0, key, value)`. Survives `clear all` but not MATLAB rest
 - `get_directly_installed()`: Returns current list.
 
 This tracking is critical for dependency pruning: only directly installed packages are "roots" in the dependency graph. Packages installed only as dependencies can be pruned when no root needs them.
+
+Entries are added by:
+- `mip install <pkg>` — marks the user-requested packages, even if they were already on disk as transitive dependencies (so re-installing a transitive dep promotes it to a root).
+- `mip load <pkg>` — marks any package the user loads directly (`isDirect`). This means a `mip load` of a package previously pulled in only as a transitive dependency promotes it to a root, so a later uninstall of its parent will not prune it. Loads marked `--transitive` (used internally for dependency loads) do not mark.
 
 Writes to `directly_installed.txt` are performed atomically: the new contents are written to `directly_installed.txt.tmp` and then moved into place via `movefile`. If the temp write fails, the existing `directly_installed.txt` is left untouched and the temp file is deleted. A stale `.tmp` from a previous crashed write is overwritten on the next write, not appended to.
 

--- a/tests/TestLoadPackage.m
+++ b/tests/TestLoadPackage.m
@@ -190,6 +190,66 @@ classdef TestLoadPackage < matlab.unittest.TestCase
             testCase.verifyFalse(mip.state.is_directly_loaded('mip-org/core/badpkg'));
         end
 
+        %% Direct loads mark the package as directly_installed
+
+        function testLoadPackage_MarksAsDirectlyInstalled(testCase)
+            % A direct load should add the package to directly_installed,
+            % so it survives an uninstall of any parent that depends on it.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'testpkg');
+            mip.load('mip-org/core/testpkg');
+            testCase.verifyTrue( ...
+                ismember('gh/mip-org/core/testpkg', mip.state.get_directly_installed()));
+        end
+
+        function testLoadPackage_TransitiveDepNotMarkedDirectlyInstalled(testCase)
+            % A package loaded only as a transitive dependency must not
+            % become directly_installed.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'depA');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'mainpkg', ...
+                'dependencies', {'depA'});
+            mip.load('mip-org/core/mainpkg');
+            testCase.verifyTrue( ...
+                ismember('gh/mip-org/core/mainpkg', mip.state.get_directly_installed()));
+            testCase.verifyFalse( ...
+                ismember('gh/mip-org/core/depA', mip.state.get_directly_installed()));
+        end
+
+        function testLoadPackage_PromotesTransitiveDepWhenLoadedDirectly(testCase)
+            % Issue #224: if a package was already loaded as a transitive
+            % dependency, a subsequent direct mip.load on it must promote
+            % it to directly_installed so a later uninstall of the parent
+            % does not prune it.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'depA');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'mainpkg', ...
+                'dependencies', {'depA'});
+            mip.load('mip-org/core/mainpkg');
+            testCase.verifyFalse( ...
+                ismember('gh/mip-org/core/depA', mip.state.get_directly_installed()));
+
+            mip.load('mip-org/core/depA');
+
+            testCase.verifyTrue( ...
+                ismember('gh/mip-org/core/depA', mip.state.get_directly_installed()));
+        end
+
+        function testLoadPackage_LoadedDepSurvivesParentUninstall(testCase)
+            % Full issue #224 scenario: install mainpkg (which pulls in
+            % depA as a transitive dep), then `mip load depA`, then
+            % uninstall mainpkg. depA must NOT be pruned.
+            depDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'depA');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'mainpkg', ...
+                'dependencies', {'depA'});
+            % Simulate `mip install mainpkg` having marked mainpkg (and
+            % only mainpkg) as directly_installed.
+            mip.state.add_directly_installed('mip-org/core/mainpkg');
+
+            mip.load('mip-org/core/depA');
+            mip.uninstall('mip-org/core/mainpkg');
+
+            testCase.verifyTrue(exist(depDir, 'dir') > 0, ...
+                'depA must not be pruned: it was directly loaded');
+        end
+
     end
 end
 


### PR DESCRIPTION
Closes the second half of #224 (the first half was fixed in #225).

When a user runs `mip load <pkg>` on a package that was previously pulled in only as a transitive dependency, the package is now also marked as `directly_installed`. A later `mip uninstall` of the parent will no longer prune it.

Per @danfortunato's final comment on the issue: "Jeremy and I decided that `mip load` will mark the package as directly installed."

Both load paths in `loadSingle` (already-loaded promotion + fresh load) gain a `mip.state.add_directly_installed(fqn)` call gated on `isDirect`, so transitive dependency loads (`--transitive`) are unaffected.