### PR TITLE
Auto-fill name and repository in mip init from .git/config

### DIFF
--- a/+mip/+init/git_info.m
+++ b/+mip/+init/git_info.m
@@ -1,0 +1,87 @@
+function [repoName, repoUrl] = git_info(targetDir)
+%GIT_INFO   Extract a package name and remote URL from .git/config.
+%
+% Reads <targetDir>/.git/config (if present) and returns the URL of the
+% [remote "origin"] (or the first remote in file order if origin is
+% absent), plus a repo name derived from the URL. Returns empty strings
+% when no .git/config is found, no remote URL is configured, or the
+% config cannot be parsed.
+%
+% The .git/config file is parsed directly rather than shelling out to
+% `git`, so this works even when git is not on the PATH.
+
+repoName = '';
+repoUrl = '';
+
+configPath = fullfile(char(targetDir), '.git', 'config');
+if exist(configPath, 'file') ~= 2
+    return;
+end
+
+fid = fopen(configPath, 'r');
+if fid == -1
+    return;
+end
+cleaner = onCleanup(@() fclose(fid)); %#ok<NASGU>
+
+% Walk through the INI-style config collecting `url = ...` entries from
+% [remote "<name>"] sections. Preserve file order so we can fall back to
+% the first-seen remote when origin is absent.
+remoteNames = {};
+remoteUrls = {};
+currentSection = '';
+currentRemote = '';
+while true
+    line = fgetl(fid);
+    if ~ischar(line); break; end
+    line = strtrim(line);
+    if isempty(line) || line(1) == '#' || line(1) == ';'
+        continue;
+    end
+
+    % Subsection headers like [remote "origin"] — try this first.
+    subTok = regexp(line, '^\[(\w+)\s+"([^"]*)"\]$', 'tokens', 'once');
+    if ~isempty(subTok)
+        currentSection = subTok{1};
+        currentRemote = subTok{2};
+        continue;
+    end
+    % Plain section headers like [core].
+    secTok = regexp(line, '^\[(\w+)\]$', 'tokens', 'once');
+    if ~isempty(secTok)
+        currentSection = secTok{1};
+        currentRemote = '';
+        continue;
+    end
+
+    if strcmp(currentSection, 'remote') && ~isempty(currentRemote)
+        kvTok = regexp(line, '^(\w+)\s*=\s*(.*)$', 'tokens', 'once');
+        if ~isempty(kvTok) && strcmpi(kvTok{1}, 'url')
+            remoteNames{end+1} = currentRemote; %#ok<AGROW>
+            remoteUrls{end+1} = strtrim(kvTok{2}); %#ok<AGROW>
+        end
+    end
+end
+
+if isempty(remoteUrls)
+    return;
+end
+
+% Prefer origin; otherwise the first remote seen in file order.
+idx = find(strcmp(remoteNames, 'origin'), 1);
+if isempty(idx)
+    idx = 1;
+end
+repoUrl = remoteUrls{idx};
+
+% Derive the repo name from the URL: strip a trailing `.git`, then take
+% the last segment after splitting on `/` or `:` (handles https,
+% ssh://, and git@host:owner/repo forms).
+nameSrc = regexprep(repoUrl, '\.git$', '');
+parts = regexp(nameSrc, '[/:]', 'split');
+parts = parts(~cellfun(@isempty, parts));
+if ~isempty(parts)
+    repoName = parts{end};
+end
+
+end

--- a/+mip/init.m
+++ b/+mip/init.m
@@ -14,6 +14,12 @@ function init(varargin)
 % automatically by walking the directory and identifying folders that
 % contain runtime MATLAB code.
 %
+% If the target directory contains a .git/config with a remote URL, the
+% repo name (derived from the URL) is used as the default package name
+% in place of the directory basename, and the URL is filled into the
+% `repository` field. Both are still overridable via --name and
+% --repository.
+%
 % A blank `test_<name>.m` script is created (if not already present) and
 % referenced from the generated mip.yaml's `test_script` field.
 %
@@ -23,6 +29,8 @@ function init(varargin)
     targetPath = '';
     overrideName = '';
     repository = '';
+    nameProvided = false;
+    repositoryProvided = false;
 
     i = 1;
     while i <= numel(varargin)
@@ -32,6 +40,7 @@ function init(varargin)
                 error('mip:init:missingNameValue', '--name requires a value.');
             end
             overrideName = varargin{i + 1};
+            nameProvided = true;
             i = i + 2;
         elseif ischar(arg) && strcmp(arg, '--repository')
             if i + 1 > numel(varargin)
@@ -39,6 +48,7 @@ function init(varargin)
                       '--repository requires a value.');
             end
             repository = varargin{i + 1};
+            repositoryProvided = true;
             i = i + 2;
         elseif isempty(targetPath)
             targetPath = arg;
@@ -64,8 +74,15 @@ function init(varargin)
         return;
     end
 
-    if ~isempty(overrideName)
+    [gitRepoName, gitRepoUrl] = mip.init.git_info(targetDir);
+
+    if nameProvided
         pkgName = overrideName;
+    elseif ~isempty(gitRepoName)
+        % Lowercase the git repo name to produce a canonical name. Other
+        % non-canonical characters (dots, spaces) still cause a failure
+        % below — use --name for those.
+        pkgName = lower(gitRepoName);
     else
         normalizedDir = regexprep(targetDir, '[/\\]+$', '');
         [~, baseName, ext] = fileparts(normalizedDir);
@@ -73,6 +90,10 @@ function init(varargin)
         % Other non-canonical characters (dots, spaces, leading/trailing
         % separators) still cause a failure below — use --name for those.
         pkgName = lower([baseName, ext]);
+    end
+
+    if ~repositoryProvided && ~isempty(gitRepoUrl)
+        repository = gitRepoUrl;
     end
 
     if ~mip.name.is_valid_canonical(pkgName)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -854,8 +854,8 @@ mip init [<path>] [--name <packagename>] [--repository <url>]
 ```
 
 - **`<path>`** (optional positional) -- directory to initialize. Defaults to the current directory (`.`) when omitted. Must already exist; otherwise raises `mip:init:notADirectory`.
-- **`--name <packagename>`** (optional) -- overrides the default package name. When omitted, the name defaults to the target directory's basename. Names must match the regex `^[a-zA-Z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?$` (letters/digits/hyphens/underscores, starting and ending with a letter or digit); otherwise raises `mip:init:invalidName` with a hint to use `--name` to override.
-- **`--repository <url>`** (optional) -- fills in the generated `mip.yaml`'s `repository` field. Omit to leave it blank.
+- **`--name <packagename>`** (optional) -- overrides the default package name. When omitted, the name defaults to the git repo name (if a `.git/config` is detected -- see below) and otherwise to the target directory's basename. The default is lowercased before validation; an explicit `--name` is not. Names must match the regex `^[a-zA-Z0-9]([-a-zA-Z0-9_]*[a-zA-Z0-9])?$` (letters/digits/hyphens/underscores, starting and ending with a letter or digit); otherwise raises `mip:init:invalidName` with a hint to use `--name` to override.
+- **`--repository <url>`** (optional) -- fills in the generated `mip.yaml`'s `repository` field. When omitted, the field is auto-filled from `.git/config` if a remote URL is detected (see below) and is otherwise left blank.
 
 Behavior:
 
@@ -863,8 +863,9 @@ Behavior:
 2. `paths` is auto-populated by walking the directory and identifying folders that contain runtime MATLAB code. The walk happens **before** the placeholder test script is created, so the root is not auto-included just because of that new file.
 3. A blank `test_<name>.m` is created at the target root (unless one already exists), and the generated `mip.yaml`'s `test_script` field points at it.
 4. Other optional string fields (`description`, `version`, `license`, `homepage`) are emitted blank for the user to fill in. A single `builds: [{ architectures: [any] }]` entry is emitted.
+5. If `<path>/.git/config` exists, it is parsed directly (no `git` shellout) for `[remote "<name>"] url = ...` entries. The URL of `[remote "origin"]` is used if present; otherwise the first remote in file order. The repo name is derived by stripping a trailing `.git` from the URL and taking the last `/`- or `:`-delimited segment, so `https://`, `ssh://`, and `git@host:owner/repo` forms all work. The URL is preserved verbatim (with any `.git` suffix) when written to the `repository` field. If no `.git/config` is found, no remotes are configured, or the file cannot be parsed, both fields fall back to their non-git defaults. Auto-detection only inspects `<path>/.git/`; parent directories are not searched, so a sub-package inside a larger git repo will not pick up the outer repo's URL.
 
-`mip init` also runs automatically on behalf of local installs that are missing a `mip.yaml` (after the user confirms the prompt -- see [§3.2](#32-local-installation)) and on URL-based installs that land on a source tree with no `mip.yaml` (see [§3.4](#34-installation-from-a-remote-zip-url)).
+`mip init` also runs automatically on behalf of local installs that are missing a `mip.yaml` (after the user confirms the prompt -- see [§3.2](#32-local-installation)) and on URL-based installs that land on a source tree with no `mip.yaml` (see [§3.4](#34-installation-from-a-remote-zip-url)). The local-install auto-invocation passes no flags, so the git-config auto-detection applies normally. The URL-based auto-invocation passes `--name` and `--repository` explicitly (the resolved zip URL), so the git-config auto-detection has no effect there.
 
 Error identifiers: `mip:init:notADirectory`, `mip:init:invalidName`, `mip:init:missingNameValue`, `mip:init:missingRepositoryValue`, `mip:init:unexpectedArg`, `mip:init:writeFailed`.
 

--- a/tests/TestInit.m
+++ b/tests/TestInit.m
@@ -398,6 +398,171 @@ classdef TestInit < matlab.unittest.TestCase
             testCase.verifyTrue(contains(yamlText, 'paths: []'));
         end
 
+        function testInit_GitConfigFillsNameAndRepository(testCase)
+            % If targetDir contains a .git/config with an origin URL,
+            % init derives the package name from the URL and writes the
+            % URL into `repository`. The folder basename is ignored
+            % (folder is "mypkg", git repo is "chebfun").
+            pkgDir = fullfile(testCase.TestDir, 'mypkg');
+            mkdir(pkgDir);
+            writeGitConfigOrigin(pkgDir, 'https://github.com/chebfun/chebfun');
+
+            mip.init(pkgDir);
+
+            cfg = mip.config.read_mip_yaml(pkgDir);
+            testCase.verifyEqual(cfg.name, 'chebfun');
+            testCase.verifyEqual(cfg.repository, ...
+                'https://github.com/chebfun/chebfun');
+        end
+
+        function testInit_GitConfigStripsDotGitFromName(testCase)
+            % An origin URL ending in .git keeps the suffix in the
+            % `repository` field (canonical clone URL) but does not
+            % include it in the derived package name.
+            pkgDir = fullfile(testCase.TestDir, 'mypkg');
+            mkdir(pkgDir);
+            writeGitConfigOrigin(pkgDir, 'https://github.com/owner/myrepo.git');
+
+            mip.init(pkgDir);
+
+            cfg = mip.config.read_mip_yaml(pkgDir);
+            testCase.verifyEqual(cfg.name, 'myrepo');
+            testCase.verifyEqual(cfg.repository, ...
+                'https://github.com/owner/myrepo.git');
+        end
+
+        function testInit_GitConfigSshUrl(testCase)
+            % SSH-style URLs (git@host:owner/repo.git) parse correctly:
+            % the URL is preserved in `repository` and the repo name is
+            % the trailing path segment with .git stripped.
+            pkgDir = fullfile(testCase.TestDir, 'mypkg');
+            mkdir(pkgDir);
+            writeGitConfigOrigin(pkgDir, 'git@github.com:owner/sshrepo.git');
+
+            mip.init(pkgDir);
+
+            cfg = mip.config.read_mip_yaml(pkgDir);
+            testCase.verifyEqual(cfg.name, 'sshrepo');
+            testCase.verifyEqual(cfg.repository, ...
+                'git@github.com:owner/sshrepo.git');
+        end
+
+        function testInit_GitConfigLowercasesName(testCase)
+            % An uppercase repo name is lowercased to produce a
+            % canonical package name (mirrors the dir-basename path).
+            pkgDir = fullfile(testCase.TestDir, 'mypkg');
+            mkdir(pkgDir);
+            writeGitConfigOrigin(pkgDir, 'https://github.com/Owner/MyRepo');
+
+            mip.init(pkgDir);
+
+            cfg = mip.config.read_mip_yaml(pkgDir);
+            testCase.verifyEqual(cfg.name, 'myrepo');
+        end
+
+        function testInit_GitConfigNameOverrideStillWins(testCase)
+            % --name continues to take precedence over the git-derived
+            % name (and the dir basename).
+            pkgDir = fullfile(testCase.TestDir, 'mypkg');
+            mkdir(pkgDir);
+            writeGitConfigOrigin(pkgDir, 'https://github.com/owner/repo');
+
+            mip.init(pkgDir, '--name', 'overridden');
+
+            cfg = mip.config.read_mip_yaml(pkgDir);
+            testCase.verifyEqual(cfg.name, 'overridden');
+            % Repository is still auto-filled when --name is used.
+            testCase.verifyEqual(cfg.repository, ...
+                'https://github.com/owner/repo');
+        end
+
+        function testInit_GitConfigRepositoryOverrideStillWins(testCase)
+            % --repository continues to take precedence over the
+            % git-derived URL (even an empty string passed by the user).
+            pkgDir = fullfile(testCase.TestDir, 'mypkg');
+            mkdir(pkgDir);
+            writeGitConfigOrigin(pkgDir, 'https://github.com/owner/repo');
+
+            url = 'https://example.com/custom.zip';
+            mip.init(pkgDir, '--repository', url);
+
+            cfg = mip.config.read_mip_yaml(pkgDir);
+            % Name is still auto-derived from the git config.
+            testCase.verifyEqual(cfg.name, 'repo');
+            testCase.verifyEqual(cfg.repository, url);
+        end
+
+        function testInit_GitConfigNoRemoteFallsBack(testCase)
+            % A .git/config with no remote URL leaves `repository`
+            % blank and falls back to the directory basename for the
+            % package name.
+            pkgDir = fullfile(testCase.TestDir, 'mypkg');
+            mkdir(pkgDir);
+            mkdir(fullfile(pkgDir, '.git'));
+            fid = fopen(fullfile(pkgDir, '.git', 'config'), 'w');
+            fprintf(fid, '[core]\n\trepositoryformatversion = 0\n');
+            fclose(fid);
+
+            mip.init(pkgDir);
+
+            cfg = mip.config.read_mip_yaml(pkgDir);
+            testCase.verifyEqual(cfg.name, 'mypkg');
+            testCase.verifyEqual(cfg.repository, '');
+        end
+
+        function testInit_GitConfigPrefersOriginOverOtherRemotes(testCase)
+            % When several remotes are listed, origin wins regardless
+            % of file order.
+            pkgDir = fullfile(testCase.TestDir, 'mypkg');
+            mkdir(pkgDir);
+            mkdir(fullfile(pkgDir, '.git'));
+            fid = fopen(fullfile(pkgDir, '.git', 'config'), 'w');
+            fprintf(fid, '[remote "upstream"]\n');
+            fprintf(fid, '\turl = https://github.com/upstream/wrong\n');
+            fprintf(fid, '[remote "origin"]\n');
+            fprintf(fid, '\turl = https://github.com/me/right\n');
+            fclose(fid);
+
+            mip.init(pkgDir);
+
+            cfg = mip.config.read_mip_yaml(pkgDir);
+            testCase.verifyEqual(cfg.name, 'right');
+            testCase.verifyEqual(cfg.repository, ...
+                'https://github.com/me/right');
+        end
+
+        function testInit_GitConfigFallsBackToFirstRemoteWhenNoOrigin(testCase)
+            % If no [remote "origin"] section exists, the first remote
+            % seen in file order is used.
+            pkgDir = fullfile(testCase.TestDir, 'mypkg');
+            mkdir(pkgDir);
+            mkdir(fullfile(pkgDir, '.git'));
+            fid = fopen(fullfile(pkgDir, '.git', 'config'), 'w');
+            fprintf(fid, '[remote "upstream"]\n');
+            fprintf(fid, '\turl = https://github.com/upstream/first\n');
+            fprintf(fid, '[remote "fork"]\n');
+            fprintf(fid, '\turl = https://github.com/fork/second\n');
+            fclose(fid);
+
+            mip.init(pkgDir);
+
+            cfg = mip.config.read_mip_yaml(pkgDir);
+            testCase.verifyEqual(cfg.name, 'first');
+            testCase.verifyEqual(cfg.repository, ...
+                'https://github.com/upstream/first');
+        end
+
+        function testInit_GitInfoHelperReturnsEmptyWhenNoGit(testCase)
+            % Direct unit test for the helper: a directory with no
+            % .git/ returns empty strings.
+            pkgDir = fullfile(testCase.TestDir, 'plain');
+            mkdir(pkgDir);
+
+            [name, url] = mip.init.git_info(pkgDir);
+            testCase.verifyEqual(name, '');
+            testCase.verifyEqual(url, '');
+        end
+
         function testInit_PathsListMatchesAutoUtil(testCase)
             % The paths written into mip.yaml agree with what
             % mip.init.auto_add_paths returns for the same tree.
@@ -426,4 +591,17 @@ classdef TestInit < matlab.unittest.TestCase
         end
 
     end
+end
+
+
+function writeGitConfigOrigin(pkgDir, url)
+% Helper: write a minimal .git/config under pkgDir whose [remote "origin"]
+% has the given url.
+mkdir(fullfile(pkgDir, '.git'));
+fid = fopen(fullfile(pkgDir, '.git', 'config'), 'w');
+fprintf(fid, '[core]\n\trepositoryformatversion = 0\n');
+fprintf(fid, '[remote "origin"]\n');
+fprintf(fid, '\turl = %s\n', url);
+fprintf(fid, '\tfetch = +refs/heads/*:refs/remotes/origin/*\n');
+fclose(fid);
 end


### PR DESCRIPTION
## Summary
- When `mip init` runs in a directory that contains a `.git/config`, parse the file directly and use the `[remote "origin"]` URL (or the first remote, if origin is absent) to default the package name and fill in the `repository` field.
- The repo name is derived from the URL: strip a trailing `.git`, then take the last `/`- or `:`-delimited segment, so `https://`, `ssh://`, and `git@host:owner/repo` forms all work. The name is lowercased to produce a canonical package name.
- `--name` and `--repository` continue to override the auto-detected values.

Closes #190.

## Test plan
- [x] New tests in `tests/TestInit.m` cover https/ssh URLs, `.git`-suffix handling, lowercasing, override precedence for both flags, the no-remote fallback, origin-preferred selection, and the helper's empty return when there is no `.git/`.
- [x] Full suite (`run_tests`) passes: 641/641.