### PR TITLE
Fix mip version to read from mip.json, not mip.yaml

### DIFF
--- a/+mip/version.m
+++ b/+mip/version.m
@@ -6,15 +6,27 @@ function v = version()
 %
 % Returns the version string for mip.
 
+% Reads mip.json (the metadata file written at install/build time, which
+% records the resolved version) when present. Falls back to mip.yaml when
+% running mip directly from a source checkout, which has no mip.json.
+
 thisDir = fileparts(mfilename('fullpath'));  % +mip directory
-pkgRoot = fileparts(thisDir);  % package root (contains mip.yaml)
-mipYamlPath = fullfile(pkgRoot, 'mip.yaml');
-if ~exist(mipYamlPath, 'file')
-    error('mip:version:noMipYaml', ...
-          'mip.yaml not found at %s. Is mip installed correctly?', pkgRoot);
+pkgRoot = fileparts(thisDir);  % package root (contains mip.json or mip.yaml)
+
+mipJsonPath = fullfile(pkgRoot, 'mip.json');
+if exist(mipJsonPath, 'file')
+    pkgInfo = mip.config.read_package_json(pkgRoot);
+    v = pkgInfo.version;
+else
+    mipYamlPath = fullfile(pkgRoot, 'mip.yaml');
+    if ~exist(mipYamlPath, 'file')
+        error('mip:version:noMetadata', ...
+              'Neither mip.json nor mip.yaml found at %s. Is mip installed correctly?', pkgRoot);
+    end
+    mipConfig = mip.config.read_mip_yaml(pkgRoot);
+    v = mipConfig.version;
 end
-mipConfig = mip.config.read_mip_yaml(pkgRoot);
-v = mipConfig.version;
+
 if isnumeric(v)
     v = num2str(v);
 end

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -817,7 +817,7 @@ Lists packages available in the channel index. Uses `--channel` to specify which
 
 ### 9.4 `mip version`
 
-Prints the mip version string, read from `mip.yaml` in the package root. If `mip.yaml`'s `version` is blank or missing, an empty string is printed (see [§11.2](#112-mipyaml-schema)).
+Prints the mip version string. Reads `mip.json` (the authoritative version written at install/build time) when present in the package root, and falls back to `mip.yaml` for source checkouts that have no `mip.json`. If neither file's `version` is set, an empty string is printed (see [§11.2](#112-mipyaml-schema)).
 
 ### 9.5 `mip index`
 
@@ -1142,7 +1142,7 @@ Channel index downloads are cached on disk under `<root>/cache/index/<org>/<chan
 | `mip:yamlParseFailed` | `mip.yaml` could not be parsed (see `mip:parse_yaml:*` for the low-level cause) |
 | `mip:parse_yaml:*` | Low-level YAML parser errors: `type`, `trailing`, `unterminatedString`, `noProgress`, `expectColon`, `expectKey`, `keyNewline`, `unterminatedFlow`, `flowSeparator`, `badEscape` |
 | `mip:name:invalidInput` | Input passed to `mip.name.normalize` / `mip.name.match` is not a valid string |
-| `mip:version:noMipYaml` | `mip version` cannot locate `mip.yaml` in the package root |
+| `mip:version:noMetadata` | `mip version` cannot locate either `mip.json` or `mip.yaml` in the package root |
 | `mip:install:invalidPackageSpec` | Install argument has 2 or 4+ slash-separated parts (see [§3.0](#30-argument-categorization)) |
 | `mip:install:notADirectory` | Local install target exists but is not a directory |
 | `mip:update:noPackage` | `mip update` called with no arguments and no `--all` |


### PR DESCRIPTION
## Summary
- `mip version` now reads the resolved version from `mip.json` (written at install/build time) instead of `mip.yaml`, whose `version` field is blank in source checkouts.
- Falls back to `mip.yaml` when `mip.json` is absent so running mip directly from a source checkout still works.

Closes #246

## Test plan
- [x] Manually verified `mip.version()` returns the json version when `mip.json` is present.
- [x] Manually verified `mip.version()` falls back to `mip.yaml` (blank) in a source checkout with no `mip.json`.