### PR TITLE
Print per-package output blocks for mip update and mip uninstall

### DIFF
--- a/+mip/uninstall.m
+++ b/+mip/uninstall.m
@@ -80,26 +80,25 @@ function uninstall(varargin)
         return
     end
 
-    % Unload any packages that are currently loaded
-    for i = 1:length(resolvedPackages)
-        fqn = resolvedPackages{i};
-        if mip.state.is_loaded(fqn)
-            mip.unload(fqn);
-        end
-    end
-
-    % Uninstall each requested package
+    % Run each package's full lifecycle (unload, then uninstall) in
+    % argument order so the output for one package is not interleaved
+    % with the next.
     for i = 1:length(resolvedPackages)
         fqn = resolvedPackages{i};
         pkgDir = mip.paths.get_package_dir(fqn);
+        displayFqn = mip.parse.display_fqn(fqn);
+
+        if mip.state.is_loaded(fqn)
+            mip.unload(fqn);
+        end
 
         try
-            fprintf('Uninstalling "%s"...\n', mip.parse.display_fqn(fqn));
+            fprintf('Uninstalling "%s"...\n', displayFqn);
             rmdir(pkgDir, 's');
-            fprintf('Uninstalled package "%s"\n', mip.parse.display_fqn(fqn));
+            fprintf('Uninstalled package "%s"\n', displayFqn);
         catch ME
             error('mip:uninstallFailed', ...
-                  'Failed to uninstall package "%s": %s', mip.parse.display_fqn(fqn), ME.message);
+                  'Failed to uninstall package "%s": %s', displayFqn, ME.message);
         end
 
         % Remove from directly installed and pinned packages

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -63,7 +63,12 @@ function update(varargin)
         end
     end
 
-    % --all: update all installed packages
+    % --all: expand to all installed packages. Pinned packages are
+    % filtered up-front for --all (the user did not specify an explicit
+    % order, so there is no per-arg position to anchor the skip messages
+    % to). Explicitly named pinned packages are handled inside the main
+    % per-package loop below so their skip messages appear in argument
+    % order, interleaved with the unpinned packages' update output.
     if updateAll
         if ~isempty(args)
             error('mip:update:allWithPackages', ...
@@ -89,22 +94,6 @@ function update(varargin)
             return
         end
         args = filtered;
-    else
-        % Explicitly named packages: skip pinned packages with a
-        % "Skipping" message rather than erroring on the whole batch,
-        % so that "mip update X Y Z" with Y pinned still updates X and
-        % Z. The user must "mip unpin Y" first to update it; --force
-        % does not override the pin.
-        filtered = {};
-        for i = 1:length(args)
-            if ~warnIfPinned(args{i})
-                filtered{end+1} = args{i}; %#ok<AGROW>
-            end
-        end
-        if isempty(filtered)
-            return
-        end
-        args = filtered;
     end
 
     if isempty(args)
@@ -117,83 +106,28 @@ function update(varargin)
         args = expandWithDeps(args);
     end
 
-    % Resolve and validate each argument. Any error here (not installed,
-    % missing source dir) is raised before we touch anything on disk.
-    resolved = cell(1, length(args));
+    % Pre-pass: classify each argument into a single per-arg item so the
+    % main loop below can walk in argument order without revalidating.
+    % Validation errors (not installed, missing source dir) are raised
+    % here, before any destructive action — but the per-arg user-facing
+    % messages (pin skip, no-source skip, "Checking for updates", etc.)
+    % are deferred to the main loop so that one package's full lifecycle
+    % output is not interleaved with the next.
+    items = cell(1, length(args));
     for i = 1:length(args)
-        resolved{i} = resolvePackage(args{i});
+        items{i} = classifyArg(args{i});
     end
 
-    % Skip local packages with no available source (e.g. URL installs).
-    % They cannot be reinstalled, so update them is a no-op with a message.
-    toProcess = {};
-    for i = 1:length(resolved)
-        p = resolved{i};
-        if p.noSource
-            fprintf('Skipping "%s": no local source to update from.\n', mip.parse.display_fqn(p.fqn));
-        else
-            toProcess{end+1} = p; %#ok<AGROW>
-        end
-    end
-    if isempty(toProcess)
-        return
-    end
-
-    % --no-compile only applies to editable local installs. Error if any
-    % package in the batch is not an editable local install.
+    % --no-compile only applies to editable local installs. Validate
+    % across all "process" items before any destructive action.
     if noCompile
-        for i = 1:length(toProcess)
-            p = toProcess{i};
-            if ~(p.isLocal && p.editable)
+        for i = 1:length(items)
+            it = items{i};
+            if strcmp(it.kind, 'process') && ~(it.pkg.isLocal && it.pkg.editable)
                 error('mip:update:noCompileRequiresEditable', ...
                       '--no-compile can only be used when all updated packages are editable local installs (offending package: "%s").', ...
-                      mip.parse.display_fqn(p.fqn));
+                      mip.parse.display_fqn(it.pkg.fqn));
             end
-        end
-    end
-
-    % Handle self-update (`gh/mip-org/core/mip`) separately and remove it
-    % from the batch. mip cannot be uninstalled through the normal flow.
-    keepMask = true(1, length(toProcess));
-    for i = 1:length(toProcess)
-        if strcmp(toProcess{i}.fqn, 'gh/mip-org/core/mip')
-            updateSelf(toProcess{i}, force);
-            keepMask(i) = false;
-        end
-    end
-    toProcess = toProcess(keepMask);
-    if isempty(toProcess)
-        return
-    end
-
-    % Determine which of the remaining packages actually need updating.
-    % For remote packages, also fetch the latest channel info (needed for
-    % downloading the new version).
-    needsUpdate = false(1, length(toProcess));
-    for i = 1:length(toProcess)
-        p = toProcess{i};
-        if p.isLocal
-            % Local packages are always reinstalled from source.
-            needsUpdate(i) = true;
-        else
-            [needsUpdate(i), latestInfo] = checkRemoteNeedsUpdate(p, force);
-            toProcess{i}.latestInfo = latestInfo;
-        end
-    end
-    toProcess = toProcess(needsUpdate);
-
-    if isempty(toProcess)
-        return
-    end
-
-    % Split into local and remote sets
-    localPkgs = {};
-    remotePkgs = {};
-    for i = 1:length(toProcess)
-        if toProcess{i}.isLocal
-            localPkgs{end+1} = toProcess{i}; %#ok<AGROW>
-        else
-            remotePkgs{end+1} = toProcess{i}; %#ok<AGROW>
         end
     end
 
@@ -202,72 +136,48 @@ function update(varargin)
     loadedBefore = mip.state.key_value_get('MIP_LOADED_PACKAGES');
     directlyLoadedBefore = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
 
-    % Wrap the update loops in try-catch so that reloadPreviouslyLoaded
+    % Wrap the per-package loop in try-catch so that reloadPreviouslyLoaded
     % always runs. Without this, a failure mid-batch would leave
     % already-updated packages unloaded for the rest of the session.
+    updatedRemoteFqns = {};
     updateError = [];
     try
-        % --- Local packages: backup + install_local (no mip.uninstall) ---
-        % Local packages cannot go through mip.uninstall because that prunes
-        % orphaned deps, and install_local cannot re-fetch them from a channel.
-        % The old package is moved to a backup directory before reinstalling so
-        % that a failure in install_local does not destroy the installed copy.
-        for i = 1:length(localPkgs)
-            p = localPkgs{i};
-            displayFqn = mip.parse.display_fqn(p.fqn);
-            fprintf('Updating local package "%s"...\n', displayFqn);
-
-            if mip.state.is_loaded(p.fqn)
-                fprintf('Unloading "%s" before update...\n', displayFqn);
-                mip.unload(p.fqn);
-            end
-
-            % Move old package to backup before reinstalling
-            backupDir = [tempname '_mip_backup'];
-            movefile(p.pkgDir, backupDir);
-            mip.state.remove_directly_installed(p.fqn);
-            packagesDir = mip.paths.get_packages_dir();
-            mip.paths.cleanup_empty_dirs(fullfile(packagesDir, p.type));
-
-            fprintf('Reinstalling "%s" from %s...\n', displayFqn, p.sourcePath);
-            try
-                mip.build.install_local(p.sourcePath, p.editable, noCompile, p.type);
-            catch ME
-                % Restore old package on failure
-                parentDir = fileparts(p.pkgDir);
-                if ~exist(parentDir, 'dir')
-                    mkdir(parentDir);
-                end
-                movefile(backupDir, p.pkgDir);
-                mip.state.add_directly_installed(p.fqn);
-                rethrow(ME);
-            end
-            if exist(backupDir, 'dir')
-                rmdir(backupDir, 's');
+        for i = 1:length(items)
+            it = items{i};
+            switch it.kind
+                case 'pin-skip'
+                    fprintf(['Skipping pinned package "%s". ' ...
+                             'Run "mip unpin %s" first to allow updates.\n'], ...
+                            it.displayFqn, it.displayFqn);
+                case 'no-source-skip'
+                    fprintf('Skipping "%s": no local source to update from.\n', ...
+                            mip.parse.display_fqn(it.pkg.fqn));
+                case 'self-update'
+                    updateSelf(it.pkg, force);
+                case 'process'
+                    p = it.pkg;
+                    if p.isLocal
+                        updateLocalPackage(p, noCompile);
+                    else
+                        [needs, latestInfo] = checkRemoteNeedsUpdate(p, force);
+                        if ~needs
+                            continue
+                        end
+                        p.latestInfo = latestInfo;
+                        if mip.state.is_loaded(p.fqn)
+                            fprintf('Unloading "%s" before update...\n', mip.parse.display_fqn(p.fqn));
+                            mip.unload(p.fqn);
+                        end
+                        downloadAndReplace(p);
+                        updatedRemoteFqns{end+1} = p.fqn; %#ok<AGROW>
+                    end
             end
         end
 
-        % --- Remote packages: update via staging, install missing deps, prune ---
-        % Each package is replaced on disk with the latest version from the
-        % channel. Existing dependencies are left alone. After all packages are
-        % updated, any missing dependencies are installed and orphaned packages
-        % are pruned.
-        if ~isempty(remotePkgs)
-            for i = 1:length(remotePkgs)
-                p = remotePkgs{i};
-                displayFqn = mip.parse.display_fqn(p.fqn);
-                if mip.state.is_loaded(p.fqn)
-                    fprintf('Unloading "%s" before update...\n', displayFqn);
-                    mip.unload(p.fqn);
-                end
-                downloadAndReplace(p);
-            end
-
-            % Install any missing dependencies that the updated packages require
-            remoteFqns = cellfun(@(p) p.fqn, remotePkgs, 'UniformOutput', false);
-            installMissingDeps(remoteFqns);
-
-            % Prune packages that are no longer needed
+        % Whole-batch operations: install any missing dependencies that
+        % the updated remote packages now require, and prune orphans.
+        if ~isempty(updatedRemoteFqns)
+            installMissingDeps(updatedRemoteFqns);
             mip.state.prune_unused_packages();
         end
     catch ME
@@ -281,6 +191,75 @@ function update(varargin)
 
     if ~isempty(updateError)
         rethrow(updateError);
+    end
+end
+
+function item = classifyArg(packageArg)
+% Classify a single argument into one of:
+%   - pin-skip       : installed and pinned (named-explicit only; --all
+%                      pre-filters, so reaching this branch implies the
+%                      user named the package explicitly)
+%   - self-update    : the gh/mip-org/core/mip identity
+%   - no-source-skip : local install with no recoverable source path
+%   - process        : full update lifecycle should run
+%
+% Validation errors (not installed, missing source dir) are raised here.
+%
+% The pin check resolves silently against installed packages — if the
+% package is not installed, we fall through to resolvePackage so the
+% standard mip:update:notInstalled error is raised.
+
+    r = mip.resolve.resolve_to_installed(packageArg);
+    if ~isempty(r) && mip.state.is_pinned(r.fqn)
+        item = struct('kind', 'pin-skip', 'displayFqn', mip.parse.display_fqn(r.fqn));
+        return
+    end
+
+    p = resolvePackage(packageArg);
+    if strcmp(p.fqn, 'gh/mip-org/core/mip')
+        item = struct('kind', 'self-update', 'pkg', p);
+    elseif p.noSource
+        item = struct('kind', 'no-source-skip', 'pkg', p);
+    else
+        item = struct('kind', 'process', 'pkg', p);
+    end
+end
+
+function updateLocalPackage(p, noCompile)
+% Update a local package: backup, remove from directly_installed, then
+% install_local from the original source path. Restore the backup if
+% install_local fails. Local packages do NOT go through mip.uninstall
+% because that would prune orphaned deps, which install_local cannot
+% re-fetch from a channel.
+
+    displayFqn = mip.parse.display_fqn(p.fqn);
+    fprintf('Updating local package "%s"...\n', displayFqn);
+
+    if mip.state.is_loaded(p.fqn)
+        fprintf('Unloading "%s" before update...\n', displayFqn);
+        mip.unload(p.fqn);
+    end
+
+    backupDir = [tempname '_mip_backup'];
+    movefile(p.pkgDir, backupDir);
+    mip.state.remove_directly_installed(p.fqn);
+    packagesDir = mip.paths.get_packages_dir();
+    mip.paths.cleanup_empty_dirs(fullfile(packagesDir, p.type));
+
+    fprintf('Reinstalling "%s" from %s...\n', displayFqn, p.sourcePath);
+    try
+        mip.build.install_local(p.sourcePath, p.editable, noCompile, p.type);
+    catch ME
+        parentDir = fileparts(p.pkgDir);
+        if ~exist(parentDir, 'dir')
+            mkdir(parentDir);
+        end
+        movefile(backupDir, p.pkgDir);
+        mip.state.add_directly_installed(p.fqn);
+        rethrow(ME);
+    end
+    if exist(backupDir, 'dir')
+        rmdir(backupDir, 's');
     end
 end
 
@@ -350,8 +329,7 @@ function [tf, latestInfo] = checkRemoteNeedsUpdate(p, force)
     installedVersion = p.pkgInfo.version;
     channelStr = [p.org '/' p.channel];
 
-    fprintf('Checking for updates to "%s" (installed: %s, channel: %s)...\n', ...
-            displayFqn, installedVersion, channelStr);
+    fprintf('Checking for updates to "%s"...\n', displayFqn);
 
     index = mip.channel.fetch_index(channelStr);
 
@@ -416,7 +394,6 @@ function downloadAndReplace(p)
 % so a failure at any point does not destroy the installed copy.
 
     displayFqn = mip.parse.display_fqn(p.fqn);
-    fprintf('Downloading %s %s...\n', displayFqn, p.latestInfo.version);
 
     tempDir = tempname;
     mkdir(tempDir);
@@ -545,7 +522,7 @@ function updateSelf(p, force)
     installedVersion = pkgInfo.version;
     channelStr = 'mip-org/core';
 
-    fprintf('Checking for updates to mip (installed: %s)...\n', installedVersion);
+    fprintf('Checking for updates to "mip-org/core/mip"...\n');
 
     index = mip.channel.fetch_index(channelStr);
     requestedVersions = containers.Map('KeyType', 'char', 'ValueType', 'any');
@@ -572,11 +549,15 @@ function updateSelf(p, force)
     latestInfo = packageInfoMap(fqn);
 
     if ~force && ~mip.state.check_needs_update(pkgInfo, latestInfo)
-        fprintf('mip is already up to date (%s)\n', installedVersion);
+        fprintf('Package "mip-org/core/mip" is already up to date (%s)\n', installedVersion);
         return
     end
 
-    fprintf('Updating mip: %s -> %s\n', installedVersion, latestInfo.version);
+    if force
+        fprintf('Force updating "mip-org/core/mip" (%s)\n', installedVersion);
+    else
+        fprintf('Updating "mip-org/core/mip": %s -> %s\n', installedVersion, latestInfo.version);
+    end
 
     tempDir = tempname;
     mkdir(tempDir);
@@ -624,7 +605,7 @@ function updateSelf(p, force)
         for k = 1:length(newPathsToAdd)
             addpath(newPathsToAdd{k});
         end
-        fprintf('Successfully updated mip to %s\n', latestInfo.version);
+        fprintf('Successfully updated "mip-org/core/mip" to %s\n', latestInfo.version);
     catch ME
         if exist(tempDir, 'dir')
             rmdir(tempDir, 's');
@@ -635,7 +616,6 @@ function updateSelf(p, force)
     if exist(tempDir, 'dir')
         rmdir(tempDir, 's');
     end
-    fprintf('\nmip has been updated to %s.\n', latestInfo.version);
 end
 
 function out = resolvePathList(srcDir, relPaths)
@@ -664,6 +644,12 @@ function expanded = expandWithDeps(args)
             % Not installed — will error later in resolvePackage; skip here
             continue
         end
+        % Pinned explicit packages are dropped in the per-package loop
+        % (with a "Skipping pinned package" message). Their dependencies
+        % are not expanded — see spec §7.11.3.
+        if mip.state.is_pinned(r.fqn)
+            continue
+        end
         deps = mip.dependency.find_all_dependencies(r.fqn);
         for j = 1:length(deps)
             if ~mip.state.is_installed(deps{j}) || any(strcmp(expanded, deps{j}))
@@ -676,21 +662,4 @@ function expanded = expandWithDeps(args)
             expanded{end+1} = deps{j}; %#ok<AGROW>
         end
     end
-end
-
-function tf = warnIfPinned(packageArg)
-% If the given package is installed and pinned, print a "Skipping pinned
-% package" message and return true (caller should drop it from the
-% batch). Otherwise return false. Users must "mip unpin <pkg>" first;
-% --force does not override the pin.
-    r = mip.resolve.resolve_to_installed(packageArg);
-    if isempty(r) || ~mip.state.is_pinned(r.fqn)
-        tf = false;
-        return
-    end
-    displayFqn = mip.parse.display_fqn(r.fqn);
-    fprintf(['Skipping pinned package "%s". ' ...
-             'Run "mip unpin %s" first to allow updates.\n'], ...
-            displayFqn, displayFqn);
-    tf = true;
 end

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -587,12 +587,13 @@ After unloading (and pruning), the system checks all still-loaded packages. If a
    - FQN arguments: used directly.
    - Bare names: uses `find_all_installed_by_name` (section 2.4.3). If ambiguous, refuses.
 2. If `mip-org/core/mip` is among the resolved packages, dispatch to the self-uninstall flow ([§6.4](#64-self-uninstall-mip-uninstall-mip)). If the user confirms, that flow tears down the entire mip root (removing all installed packages along with mip itself) and returns; no further per-package processing happens. If the user declines, `mip-org/core/mip` is dropped from the list and normal uninstallation continues for any other packages.
-3. Unload any packages that are currently loaded.
-4. Remove each package directory (`rmdir`).
-5. Remove from `directly_installed.txt`.
-6. Clear the pin entry for the package, if any (so a reinstall starts unpinned -- see [§7.11](#711-pinned-packages)).
-7. Clean up empty parent directories (channel dir, then org dir).
-8. **Prune** packages that are no longer needed.
+3. Walk the resolved packages in argument order, running each package's full lifecycle before moving on to the next. The per-package output for one package therefore appears as a contiguous block, not interleaved with the next:
+   - Unload it if it is currently loaded.
+   - Remove its directory (`rmdir`).
+   - Remove it from `directly_installed.txt`.
+   - Clear its pin entry, if any (so a reinstall starts unpinned -- see [§7.11](#711-pinned-packages)).
+   - Clean up empty parent directories (channel dir, then org dir).
+4. After the per-package walk, **prune** packages that are no longer needed and check for broken dependencies among the remaining installed packages. These two operations are batched at the end because they depend on the post-uninstall on-disk state of every package in the batch.
 
 ### 6.2 Dependency Pruning After Uninstall
 
@@ -649,12 +650,16 @@ Packages can be **pinned** to block all `mip update` paths from upgrading them; 
      - Same version **and** same commit hash (or no hash available): "already up to date", skip.
      - Same version but different commit hash: update (content changed within the same version).
      - Different version: update.
-7. If no packages need updating, return. Otherwise:
-   - Snapshot `MIP_LOADED_PACKAGES` and `MIP_DIRECTLY_LOADED_PACKAGES`.
+7. Snapshot `MIP_LOADED_PACKAGES` and `MIP_DIRECTLY_LOADED_PACKAGES`, then walk the batch in argument order, running each package's full lifecycle (skip messages, "Checking for updates" output, download/replace, etc.) before moving on to the next package. The per-package output for one package therefore appears as a contiguous block, not interleaved with the next.
+   - **Pinned packages** (named explicitly): print "Skipping pinned package …" and continue.
+   - **No-source local packages** (`source_path` absent or empty): print "Skipping … no local source to update from." and continue.
    - **Local packages** are updated via backup-and-restore: unload if loaded, move the old directory to a temporary backup, `remove_directly_installed`, then `mip.build.install_local(sourcePath, editable, noCompile)`. If `install_local` fails, the backup is moved back and `directly_installed` is restored. They do **not** go through `mip.uninstall` because the prune step would remove their deps, which `install_local` cannot re-fetch from a channel.
-   - **Remote packages** are updated via staging: unload if loaded, download and extract the new version to a temporary staging directory, then move the old directory to a backup and move the staged version into place. If the swap fails, the backup is restored. The old package is never destroyed until the new version is fully in place. The `directly_installed.txt` entry is preserved (no removal/re-addition). Then install any missing dependencies that the updated packages require, and prune any orphaned packages.
+   - **Remote packages** are updated via staging: fetch the channel index and run the up-to-date check ([§7.1.1](#711-target-version-selection-for-update)); if the package is up to date, continue. Otherwise unload if loaded, download and extract the new version to a temporary staging directory, then move the old directory to a backup and move the staged version into place. If the swap fails, the backup is restored. The old package is never destroyed until the new version is fully in place. The `directly_installed.txt` entry is preserved (no removal/re-addition).
+   - After the per-package walk, install any missing dependencies that the updated remote packages now require, and prune any orphaned packages. These two operations are batched at the end of the walk because they depend on the post-update on-disk state of every updated package.
    - Reload every package in the pre-update `MIP_LOADED_PACKAGES` snapshot that is not currently loaded and whose directory exists. Packages that were in the snapshot but are no longer installed are skipped with a warning.
    - Restore `MIP_DIRECTLY_LOADED_PACKAGES` to the pre-update snapshot (filtered to entries that are actually loaded now) so that packages which were only transitively loaded before the update remain only transitively loaded after.
+
+Because the up-to-date check now runs inside the per-package walk, a `mip:update:notInIndex`, `mip:update:unavailable`, or `mip:update:versionNotInChannel` failure raised for a later package no longer short-circuits the whole batch — earlier packages may already have been replaced on disk. The `try/catch` + reload safety net (see [§7.8](#78-load-state-preservation)) still guarantees that successfully-updated packages are reloaded before the original error is re-raised.
 
 #### 7.1.1 Target Version Selection for Update
 

--- a/tests/TestPinPackage.m
+++ b/tests/TestPinPackage.m
@@ -224,6 +224,38 @@ classdef TestPinPackage < matlab.unittest.TestCase
             testCase.verifyTrue(mip.state.is_pinned('mip-org/core/beta'));
         end
 
+        function testUpdateNamed_PreservesArgumentOrderInterleaved(testCase)
+            % Mixed pinned and unpinned packages: pin-skip messages must
+            % appear at their argument-order slot, interleaved with the
+            % unpinned packages' update output -- not batched at the top.
+            % Uses local installs without source_path so the unpinned
+            % packages reach the "no local source" skip line, which is
+            % deterministic without network access.
+            createTestPackage(testCase.TestRoot, '', '', 'alpha', 'type', 'local');
+            createTestPackage(testCase.TestRoot, '', '', 'beta',  'type', 'local');
+            createTestPackage(testCase.TestRoot, '', '', 'gamma', 'type', 'local');
+            createTestPackage(testCase.TestRoot, '', '', 'delta', 'type', 'local');
+            mip.pin('local/beta');
+            mip.pin('local/delta');
+
+            output = evalc(['mip.update(''local/alpha'', ''local/beta'', ' ...
+                            '''local/gamma'', ''local/delta'')']);
+
+            posAlpha = strfind(output, 'Skipping "local/alpha":');
+            posBeta  = strfind(output, 'Skipping pinned package "local/beta"');
+            posGamma = strfind(output, 'Skipping "local/gamma":');
+            posDelta = strfind(output, 'Skipping pinned package "local/delta"');
+
+            testCase.verifyNotEmpty(posAlpha, 'no-source skip line for alpha missing');
+            testCase.verifyNotEmpty(posBeta,  'pin-skip line for beta missing');
+            testCase.verifyNotEmpty(posGamma, 'no-source skip line for gamma missing');
+            testCase.verifyNotEmpty(posDelta, 'pin-skip line for delta missing');
+
+            testCase.verifyTrue(posAlpha(1) < posBeta(1),  'alpha must precede beta');
+            testCase.verifyTrue(posBeta(1)  < posGamma(1), 'beta must precede gamma');
+            testCase.verifyTrue(posGamma(1) < posDelta(1), 'gamma must precede delta');
+        end
+
         %% --- --deps drops pinned deps ---
 
         function testUpdateDeps_PinnedDependencyIsSkipped(testCase)

--- a/tests/TestUninstallPackage.m
+++ b/tests/TestUninstallPackage.m
@@ -67,6 +67,37 @@ classdef TestUninstallPackage < matlab.unittest.TestCase
             testCase.verifyFalse(exist(pkgDir, 'dir') > 0);
         end
 
+        function testUninstall_PerPackageOrderInterleaving(testCase)
+            % Multi-package uninstall: each package's full lifecycle
+            % (Unloaded / Uninstalling / Uninstalled) must appear in
+            % argument order before the next package starts, not batched
+            % across phases.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'beta');
+            mip.state.add_directly_installed('mip-org/core/alpha');
+            mip.state.add_directly_installed('mip-org/core/beta');
+            mip.load('mip-org/core/alpha');
+            mip.load('mip-org/core/beta');
+
+            output = evalc('mip.uninstall(''mip-org/core/alpha'', ''mip-org/core/beta'')');
+
+            posAlphaUnloaded    = strfind(output, 'Unloaded package "mip-org/core/alpha"');
+            posAlphaUninstalled = strfind(output, 'Uninstalled package "mip-org/core/alpha"');
+            posBetaUnloaded     = strfind(output, 'Unloaded package "mip-org/core/beta"');
+            posBetaUninstalled  = strfind(output, 'Uninstalled package "mip-org/core/beta"');
+
+            testCase.verifyNotEmpty(posAlphaUnloaded);
+            testCase.verifyNotEmpty(posAlphaUninstalled);
+            testCase.verifyNotEmpty(posBetaUnloaded);
+            testCase.verifyNotEmpty(posBetaUninstalled);
+
+            % Alpha's full lifecycle must complete before beta's begins
+            testCase.verifyTrue(posAlphaUnloaded(1)    < posAlphaUninstalled(1));
+            testCase.verifyTrue(posAlphaUninstalled(1) < posBetaUnloaded(1), ...
+                'beta''s unload must come AFTER alpha''s uninstall completes');
+            testCase.verifyTrue(posBetaUnloaded(1)     < posBetaUninstalled(1));
+        end
+
         function testPackageNoLongerDiscoverableAfterRemoval(testCase)
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'testpkg');
             fqn = mip.resolve.resolve_bare_name('testpkg');


### PR DESCRIPTION
## Summary

- Walk the batch in argument order for both commands so each package's full lifecycle prints as a contiguous block instead of interleaving across batched phases.
- `mip update`: pre-pass `classifyArg` keeps validation errors (`notInstalled`, `sourceNotFound`, `noCompileRequiresEditable`) raising before any destructive action; per-package loop now interleaves pin-skip / no-source-skip / "Checking for updates" / download lines in argument order. `installMissingDeps` and `prune_unused_packages` stay batched at end-of-loop -- they are decisions about the post-batch graph state.
- `mip uninstall`: merged the unload loop and uninstall loop into one per-package walk.

### Trade-off

A `mip:update:notInIndex` / `mip:update:versionNotInChannel` failure raised on a later package in the batch no longer short-circuits the whole batch -- earlier packages may already have been replaced on disk. The existing `try/catch` + `reloadPreviouslyLoaded` safety net still guarantees successfully-updated packages are reloaded before the original error is re-raised. Spec §7.1 updated to describe this.

Closes #248

## Test plan

- [x] `run_tests()` passes (671/671).
- [x] New `testUpdateNamed_PreservesArgumentOrderInterleaved` in `TestPinPackage.m` -- pins beta and delta, runs `mip.update('local/alpha', 'local/beta', 'local/gamma', 'local/delta')`, asserts each package's skip line appears in argument order.
- [x] New `testUninstall_PerPackageOrderInterleaving` in `TestUninstallPackage.m` -- loads alpha + beta, runs `mip.uninstall(...)`, asserts alpha's full Unloaded/Uninstalled lifecycle precedes beta's Unloaded line.