### PR TITLE
mip test: prefer loaded package over installed-but-unloaded

### DIFF
--- a/+mip/test.m
+++ b/+mip/test.m
@@ -11,7 +11,11 @@ function test(varargin)
 %
 % The test script should error on failure and print 'SUCCESS' on success.
 %
-% Accepts both bare package names and fully qualified names.
+% Accepts both bare package names and fully qualified names. Bare-name
+% resolution prefers a currently loaded package over an installed-but-
+% unloaded one; if multiple loaded packages share the bare name, the most
+% recently loaded one wins. Otherwise, falls back to the installed-package
+% priority (gh/mip-org/core first, then alphabetical).
 
 if nargin < 1
     error('mip:test:noPackage', 'Package name is required for test command.');
@@ -19,8 +23,7 @@ end
 
 packageArg = varargin{1};
 
-% Resolve to installed FQN
-r = mip.resolve.resolve_to_installed(packageArg);
+r = resolveTestTarget(packageArg);
 if isempty(r)
     error('mip:test:notInstalled', ...
           'Package "%s" is not installed.', packageArg);
@@ -90,4 +93,38 @@ catch ME
 end
 cd(originalDir);
 
+end
+
+function r = resolveTestTarget(packageArg)
+% Resolve a test argument to an installed package. For bare names,
+% search loaded packages first and pick the most recently loaded match;
+% otherwise fall back to mip.resolve.resolve_to_installed (which applies
+% the gh/mip-org/core-first / alphabetical priority).
+
+    if isstring(packageArg)
+        packageArg = char(packageArg);
+    end
+
+    parsed = mip.parse.parse_package_arg(packageArg);
+
+    if parsed.is_fqn
+        r = mip.resolve.resolve_to_installed(packageArg);
+        return
+    end
+
+    loadedPackages = mip.state.key_value_get('MIP_LOADED_PACKAGES');
+    matchIdx = [];
+    for i = 1:length(loadedPackages)
+        loadedInfo = mip.parse.parse_package_arg(loadedPackages{i});
+        if loadedInfo.is_fqn && mip.name.match(loadedInfo.name, parsed.name)
+            matchIdx(end+1) = i; %#ok<AGROW>
+        end
+    end
+
+    if ~isempty(matchIdx)
+        r = mip.resolve.resolve_to_installed(loadedPackages{matchIdx(end)});
+        return
+    end
+
+    r = mip.resolve.resolve_to_installed(packageArg);
 end

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -219,6 +219,17 @@ Used by: the install process when building the dependency graph from channel ind
 
 This is consistent with the general dependency resolution rule (2.4.4).
 
+#### 2.4.6 Resolving a Bare Name for Test (`mip test`)
+
+Used by: `mip test` (when given a bare name)
+
+Loaded packages take priority over installed-but-unloaded ones, so that `mip load --channel <other> <name>` followed by `mip test <name>` exercises the freshly loaded package rather than the unrelated installed copy under `gh/mip-org/core`:
+
+1. Search **loaded** packages for a name match. If one or more match, use the **most recently loaded** match (last in the `MIP_LOADED_PACKAGES` list).
+2. If no loaded package matches, fall back to `resolve_bare_name` ([§2.4.1](#241-resolving-a-bare-name-among-installed-packages-resolve_bare_name)) — `gh/mip-org/core` first, then alphabetical.
+
+FQN arguments to `mip test` bypass this and resolve directly against installed packages.
+
 ### 2.5 Resolving a Package Name with Channel Context (`resolve_package_name`)
 
 Used by: `mip install` for remote packages
@@ -845,6 +856,8 @@ Output filename: `<name>-<version>-<architecture>.mhl`. Because `-` is the field
 ### 9.7 `mip test <package>`
 
 Loads the package (if not already loaded) and runs its `test_script` (defined in `mip.yaml`). If no test script is defined, prints a message and returns.
+
+Bare-name resolution is loaded-first: a currently loaded package wins over an installed-but-unloaded copy of the same name, and among multiple loaded matches the most recently loaded one is used. See [§2.4.6](#246-resolving-a-bare-name-for-test-mip-test) for the full rule. FQN arguments are resolved directly against installed packages.
 
 ### 9.8 `mip init`
 

--- a/tests/TestTestCommand.m
+++ b/tests/TestTestCommand.m
@@ -70,6 +70,63 @@ classdef TestTestCommand < matlab.unittest.TestCase
             testCase.verifyTrue(contains(output, 'Running test script'));
         end
 
+        function testTest_PrefersLoadedOverInstalledCore(testCase)
+            % Both core and staging install a package called "shared".
+            % The core copy passes, the staging copy fails. After loading
+            % the staging copy, "mip test shared" must run the loaded
+            % staging copy (and therefore fail), not the unloaded core
+            % copy that resolve_bare_name would prefer.
+            createTestPackageWithTestScript(testCase.TestRoot, ...
+                'mip-org', 'core', 'shared', 'run_test.m', false);
+            createTestPackageWithTestScript(testCase.TestRoot, ...
+                'mip-org', 'staging', 'shared', 'run_test.m', true);
+            evalc('mip.load(''mip-org/staging/shared'')');
+            testCase.verifyError(@() mip.test('shared'), 'mip:test:failed');
+        end
+
+        function testTest_MostRecentlyLoadedAmongMultiple(testCase)
+            % Three installed copies of "shared". core passes, alpha
+            % passes, beta fails. Loading core then alpha then beta means
+            % beta is the most recently loaded — "mip test shared" must
+            % run beta and fail.
+            createTestPackageWithTestScript(testCase.TestRoot, ...
+                'mip-org', 'core', 'shared', 'run_test.m', false);
+            createTestPackageWithTestScript(testCase.TestRoot, ...
+                'mip-org', 'alpha', 'shared', 'run_test.m', false);
+            createTestPackageWithTestScript(testCase.TestRoot, ...
+                'mip-org', 'beta', 'shared', 'run_test.m', true);
+            evalc('mip.load(''mip-org/core/shared'')');
+            evalc('mip.load(''mip-org/alpha/shared'')');
+            evalc('mip.load(''mip-org/beta/shared'')');
+            testCase.verifyError(@() mip.test('shared'), 'mip:test:failed');
+        end
+
+        function testTest_FallsBackToCoreWhenNoneLoaded(testCase)
+            % With nothing loaded, bare-name "mip test shared" falls back
+            % to resolve_bare_name which prefers gh/mip-org/core. The
+            % core copy passes; the staging copy would fail.
+            createTestPackageWithTestScript(testCase.TestRoot, ...
+                'mip-org', 'core', 'shared', 'run_test.m', false);
+            createTestPackageWithTestScript(testCase.TestRoot, ...
+                'mip-org', 'staging', 'shared', 'run_test.m', true);
+            output = evalc('mip.test(''shared'')');
+            testCase.verifyTrue(contains(output, 'mip-org/core/shared'));
+            testCase.verifyTrue(contains(output, 'Running test script'));
+        end
+
+        function testTest_FqnIgnoresLoadedPriority(testCase)
+            % Even when a non-core copy is loaded, an explicit FQN must
+            % resolve to that exact FQN — not the most recently loaded.
+            createTestPackageWithTestScript(testCase.TestRoot, ...
+                'mip-org', 'core', 'shared', 'run_test.m', false);
+            createTestPackageWithTestScript(testCase.TestRoot, ...
+                'mip-org', 'staging', 'shared', 'run_test.m', true);
+            evalc('mip.load(''mip-org/staging/shared'')');
+            output = evalc('mip.test(''mip-org/core/shared'')');
+            testCase.verifyTrue(contains(output, 'mip-org/core/shared'));
+            testCase.verifyTrue(contains(output, 'Running test script'));
+        end
+
     end
 end
 


### PR DESCRIPTION
## Summary

Closes #260.

`mip test <X>` previously resolved bare names via the installed-package priority (gh/mip-org/core first, then alphabetical), so

```
mip load --channel mip-org/staging chebfun
mip test chebfun
```

would test the unrelated installed `mip-org/core/chebfun` instead of the chebfun the user just loaded.

Bare-name resolution for `mip test` now:

1. Searches `MIP_LOADED_PACKAGES` first; among multiple loaded matches, the **most recently loaded** wins.
2. Falls back to `resolve_bare_name` (gh/mip-org/core first, then alphabetical) when nothing matching is loaded.

FQN args (`mip test mip-org/core/chebfun`) bypass the loaded-priority logic and resolve directly against installed packages.

Spec: new §2.4.6 in the resolution-context catalog; §9.7 cross-references it.