### PR TITLE
Store channels.txt in stack order (most recent last)

### DIFF
--- a/+mip/+state/get_channels.m
+++ b/+mip/+state/get_channels.m
@@ -9,7 +9,10 @@ function channels = get_channels()
 %              need not be listed.
 %
 % Channels are persisted at <root>/packages/channels.txt, one channel
-% per line, in priority order.
+% per line, in stack-like order: the most recently added channel is at
+% the END of the file (matching the append semantics of
+% MIP_LOADED_PACKAGES). The returned cell array reverses that so the
+% highest-priority channel is at index 1.
 
     channels = {};
 
@@ -37,4 +40,6 @@ function channels = get_channels()
             channels{end+1} = strtrim(line); %#ok<AGROW>
         end
     end
+
+    channels = fliplr(channels);
 end

--- a/+mip/+state/set_channels.m
+++ b/+mip/+state/set_channels.m
@@ -22,7 +22,11 @@ function set_channels(channels)
     end
 
     try
-        for i = 1:length(channels)
+        % Persist in stack-like order: highest-priority (most recently
+        % added) channel last, matching MIP_LOADED_PACKAGES semantics.
+        % Callers pass `channels` in priority order (highest first), so
+        % iterate in reverse when writing to disk.
+        for i = length(channels):-1:1
             fprintf(fid, '%s\n', channels{i});
         end
         fclose(fid);

--- a/tests/TestChannelSubscriptions.m
+++ b/tests/TestChannelSubscriptions.m
@@ -162,6 +162,19 @@ classdef TestChannelSubscriptions < matlab.unittest.TestCase
             testCase.verifyTrue(exist(channelsFile, 'file') > 0);
         end
 
+        function testChannelsFile_StoresMostRecentLast(testCase)
+            % channels.txt is stack-ordered: most recently added (highest
+            % priority) channel sits at the END of the file, matching the
+            % append semantics of MIP_LOADED_PACKAGES.
+            mip.state.add_channel('a/one');
+            mip.state.add_channel('b/two');
+            mip.state.add_channel('c/three');
+
+            channelsFile = fullfile(testCase.TestRoot, 'packages', 'channels.txt');
+            lines = splitlines(strtrim(fileread(channelsFile)));
+            testCase.verifyEqual(lines, {'a/one'; 'b/two'; 'c/three'});
+        end
+
         %% --- Command dispatch (mip channel add/remove/list) ---
 
         function testCmd_AddRemoveListViaTopLevel(testCase)


### PR DESCRIPTION
Closes #268.

## Summary

- `channels.txt` now persists with the most recently added (highest-priority) channel at the END of the file, matching the append semantics of `MIP_LOADED_PACKAGES`.
- `set_channels` writes the in-memory cell array in reverse; `get_channels` reverses on read. Callers and the user-facing `mip channel list` output are unchanged.
- Added a test that asserts the on-disk file order directly.

Targets the `add-channel-subscriptions` branch since #262 (which introduces `channels.txt`) is still open.