### PR TITLE
mip load: move already-loaded package to end of load order

### DIFF
--- a/+mip/+state/key_value_move_to_end.m
+++ b/+mip/+state/key_value_move_to_end.m
@@ -1,0 +1,12 @@
+function key_value_move_to_end(key, value)
+%KEY_VALUE_MOVE_TO_END   Move a value to the end of a key's list.
+%
+% If the value is not present, it is appended. If it is present, it is
+% removed and re-appended so it ends up at the end of the list.
+
+values = mip.state.key_value_get(key);
+values(ismember(values, value)) = [];
+values{end+1} = value;
+mip.state.key_value_set(key, values);
+
+end

--- a/+mip/load.m
+++ b/+mip/load.m
@@ -191,16 +191,23 @@ function matched = loadSingle(packageArg, installIfMissing, stickyPackage, chann
 
     % Check if package is already loaded
     if mip.state.is_loaded(fqn)
-        % If this is a direct load and the package was previously
-        % loaded as a dependency, mark it as direct now
-        if isDirect && ~mip.state.is_directly_loaded(fqn)
-            mip.state.key_value_append('MIP_DIRECTLY_LOADED_PACKAGES', fqn);
-            fprintf('Package "%s" is already loaded (now marked as direct)\n', displayFqn);
+        % Re-loading an already-loaded package moves it to the end of
+        % MIP_LOADED_PACKAGES so the load order reflects the most recent
+        % load. Direct re-loads do the same for MIP_DIRECTLY_LOADED_PACKAGES,
+        % which also covers the case where the package was previously loaded
+        % only as a transitive dependency and is now being promoted.
+        wasDirect = mip.state.is_directly_loaded(fqn);
+        mip.state.key_value_move_to_end('MIP_LOADED_PACKAGES', fqn);
+        if isDirect
+            mip.state.key_value_move_to_end('MIP_DIRECTLY_LOADED_PACKAGES', fqn);
+            mip.state.add_directly_installed(fqn);
+            if ~wasDirect
+                fprintf('Package "%s" is already loaded (now marked as direct)\n', displayFqn);
+            else
+                fprintf('Package "%s" is already loaded\n', displayFqn);
+            end
         else
             fprintf('Package "%s" is already loaded\n', displayFqn);
-        end
-        if isDirect
-            mip.state.add_directly_installed(fqn);
         end
         % If --sticky was specified, add to sticky packages
         if stickyPackage

--- a/tests/TestKeyValueStorage.m
+++ b/tests/TestKeyValueStorage.m
@@ -82,5 +82,32 @@ classdef TestKeyValueStorage < matlab.unittest.TestCase
             testCase.verifyEqual(val, {'new1', 'new2'});
         end
 
+        function testMoveToEndAppendsWhenAbsent(testCase)
+            mip.state.key_value_set(testCase.TestKey, {'a', 'b'});
+            mip.state.key_value_move_to_end(testCase.TestKey, 'c');
+            val = mip.state.key_value_get(testCase.TestKey);
+            testCase.verifyEqual(val, {'a', 'b', 'c'});
+        end
+
+        function testMoveToEndOnEmpty(testCase)
+            mip.state.key_value_move_to_end(testCase.TestKey, 'x');
+            val = mip.state.key_value_get(testCase.TestKey);
+            testCase.verifyEqual(val, {'x'});
+        end
+
+        function testMoveToEndRepositionsExisting(testCase)
+            mip.state.key_value_set(testCase.TestKey, {'a', 'b', 'c'});
+            mip.state.key_value_move_to_end(testCase.TestKey, 'a');
+            val = mip.state.key_value_get(testCase.TestKey);
+            testCase.verifyEqual(val, {'b', 'c', 'a'});
+        end
+
+        function testMoveToEndAlreadyLast(testCase)
+            mip.state.key_value_set(testCase.TestKey, {'a', 'b', 'c'});
+            mip.state.key_value_move_to_end(testCase.TestKey, 'c');
+            val = mip.state.key_value_get(testCase.TestKey);
+            testCase.verifyEqual(val, {'a', 'b', 'c'});
+        end
+
     end
 end

--- a/tests/TestLoadPackage.m
+++ b/tests/TestLoadPackage.m
@@ -275,27 +275,31 @@ classdef TestLoadPackage < matlab.unittest.TestCase
         end
 
         function testLoadPackage_TransitiveReloadDoesNotMoveDirectlyLoaded(testCase)
-            % A transitive re-load (e.g. as a dependency of another load)
-            % must NOT move the package within MIP_DIRECTLY_LOADED_PACKAGES,
-            % because the load was not direct.
+            % A transitive re-load must move the package to the end of
+            % MIP_LOADED_PACKAGES but must NOT reorder
+            % MIP_DIRECTLY_LOADED_PACKAGES, because the load was not direct.
+            % The --transitive flag forces re-entry into loadSingle for an
+            % already-loaded package; the normal deps loop short-circuits on
+            % is_loaded and would never exercise this branch otherwise.
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'depA');
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgB');
-            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'mainpkg', ...
-                'dependencies', {'depA'});
             mip.load('mip-org/core/depA');
             mip.load('mip-org/core/pkgB');
-            % depA was directly loaded first; pkgB should now be at the end
+            loaded = mip.state.key_value_get('MIP_LOADED_PACKAGES');
             direct = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
+            testCase.verifyEqual(loaded{end}, 'gh/mip-org/core/pkgB');
             testCase.verifyEqual(direct{end}, 'gh/mip-org/core/pkgB');
 
-            % Loading mainpkg pulls in depA as a transitive dep.
-            mip.load('mip-org/core/mainpkg');
+            % Force a transitive re-load of depA (already directly loaded).
+            mip.load('mip-org/core/depA', '--transitive');
+
+            loaded = mip.state.key_value_get('MIP_LOADED_PACKAGES');
             direct = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
-            % mainpkg is now at the end; depA should stay where it was
-            % (NOT moved to the end), since the transitive re-load is not direct.
-            testCase.verifyEqual(direct{end}, 'gh/mip-org/core/mainpkg');
+            % MIP_LOADED_PACKAGES: depA moved to the end.
+            testCase.verifyEqual(loaded{end}, 'gh/mip-org/core/depA');
+            % MIP_DIRECTLY_LOADED_PACKAGES: depA NOT moved -- pkgB is still last.
+            testCase.verifyEqual(direct{end}, 'gh/mip-org/core/pkgB');
             testCase.verifyTrue(ismember('gh/mip-org/core/depA', direct));
-            testCase.verifyTrue(ismember('gh/mip-org/core/pkgB', direct));
         end
 
         function testLoadPackage_LoadedDepSurvivesParentUninstall(testCase)

--- a/tests/TestLoadPackage.m
+++ b/tests/TestLoadPackage.m
@@ -232,6 +232,72 @@ classdef TestLoadPackage < matlab.unittest.TestCase
                 ismember('gh/mip-org/core/depA', mip.state.get_directly_installed()));
         end
 
+        %% Reloading moves the package to the end of the load order
+
+        function testLoadPackage_ReloadMovesToEndOfLoadedPackages(testCase)
+            % Re-loading an already-loaded package must move its FQN to the
+            % end of MIP_LOADED_PACKAGES so the order reflects the most
+            % recent load.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgA');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgB');
+            mip.load('mip-org/core/pkgA');
+            mip.load('mip-org/core/pkgB');
+            loaded = mip.state.key_value_get('MIP_LOADED_PACKAGES');
+            testCase.verifyEqual(loaded{end}, 'gh/mip-org/core/pkgB');
+
+            mip.load('mip-org/core/pkgA');
+            loaded = mip.state.key_value_get('MIP_LOADED_PACKAGES');
+            testCase.verifyEqual(loaded{end}, 'gh/mip-org/core/pkgA');
+        end
+
+        function testLoadPackage_ReloadMovesToEndOfDirectlyLoaded(testCase)
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgA');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgB');
+            mip.load('mip-org/core/pkgA');
+            mip.load('mip-org/core/pkgB');
+            direct = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
+            testCase.verifyEqual(direct{end}, 'gh/mip-org/core/pkgB');
+
+            mip.load('mip-org/core/pkgA');
+            direct = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
+            testCase.verifyEqual(direct{end}, 'gh/mip-org/core/pkgA');
+        end
+
+        function testLoadPackage_ReloadDoesNotDuplicate(testCase)
+            % Re-loading must not introduce duplicate entries in the state lists.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgA');
+            mip.load('mip-org/core/pkgA');
+            mip.load('mip-org/core/pkgA');
+            loaded = mip.state.key_value_get('MIP_LOADED_PACKAGES');
+            direct = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
+            testCase.verifyEqual(sum(strcmp(loaded, 'gh/mip-org/core/pkgA')), 1);
+            testCase.verifyEqual(sum(strcmp(direct, 'gh/mip-org/core/pkgA')), 1);
+        end
+
+        function testLoadPackage_TransitiveReloadDoesNotMoveDirectlyLoaded(testCase)
+            % A transitive re-load (e.g. as a dependency of another load)
+            % must NOT move the package within MIP_DIRECTLY_LOADED_PACKAGES,
+            % because the load was not direct.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'depA');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgB');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'mainpkg', ...
+                'dependencies', {'depA'});
+            mip.load('mip-org/core/depA');
+            mip.load('mip-org/core/pkgB');
+            % depA was directly loaded first; pkgB should now be at the end
+            direct = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
+            testCase.verifyEqual(direct{end}, 'gh/mip-org/core/pkgB');
+
+            % Loading mainpkg pulls in depA as a transitive dep.
+            mip.load('mip-org/core/mainpkg');
+            direct = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
+            % mainpkg is now at the end; depA should stay where it was
+            % (NOT moved to the end), since the transitive re-load is not direct.
+            testCase.verifyEqual(direct{end}, 'gh/mip-org/core/mainpkg');
+            testCase.verifyTrue(ismember('gh/mip-org/core/depA', direct));
+            testCase.verifyTrue(ismember('gh/mip-org/core/pkgB', direct));
+        end
+
         function testLoadPackage_LoadedDepSurvivesParentUninstall(testCase)
             % Full issue #224 scenario: install mainpkg (which pulls in
             % depA as a transitive dep), then `mip load depA`, then


### PR DESCRIPTION
## Summary
- `mip load` on an already-loaded package now moves its FQN to the end of `MIP_LOADED_PACKAGES`.
- Direct re-loads also move it to the end of `MIP_DIRECTLY_LOADED_PACKAGES` (this subsumes the prior transitive→direct promotion path).
- New `mip.state.key_value_move_to_end` helper does remove + append so callers don't duplicate the logic.

Closes #267