### PR TITLE
Atomically write functionSignatures.json (fixes #266)

### DIFF
--- a/+mip/+state/update_function_signatures.m
+++ b/+mip/+state/update_function_signatures.m
@@ -45,13 +45,38 @@ function update_function_signatures(targetResourcesDir)
 
     json = build_signatures(installed, loadable, loaded, pinned);
 
+    % Validate before writing: tab completion reads this file
+    % asynchronously, and a malformed file produces a "Failed to parse
+    % JSON" error in the Command Window.
+    try
+        jsondecode(json);
+    catch
+        return
+    end
+
+    % Write atomically. fopen(..., 'w') truncates the destination
+    % immediately, leaving a window where a concurrent reader sees an
+    % empty file. Stage to a sibling temp file and rename into place.
     jsonPath = fullfile(targetResourcesDir, 'functionSignatures.json');
-    fid = fopen(jsonPath, 'w');
+    tmpPath  = [jsonPath '.tmp'];
+
+    fid = fopen(tmpPath, 'w');
     if fid == -1
         return
     end
-    cleaner = onCleanup(@() fclose(fid));
-    fwrite(fid, json);
+    nWritten = fwrite(fid, json);
+    fclose(fid);
+    if nWritten ~= numel(json)
+        if exist(tmpPath, 'file')
+            delete(tmpPath);
+        end
+        return
+    end
+
+    [ok, ~, ~] = movefile(tmpPath, jsonPath, 'f');
+    if ~ok && exist(tmpPath, 'file')
+        delete(tmpPath);
+    end
 end
 
 

--- a/tests/TestFunctionSignatures.m
+++ b/tests/TestFunctionSignatures.m
@@ -158,6 +158,50 @@ classdef TestFunctionSignatures < matlab.unittest.TestCase
             testCase.verifyTrue(contains(updateSig, '''mip'''));
         end
 
+        function testGeneratedFileIsValidJson(testCase)
+            % Regression for issue #266: tab completion reported
+            % "Failed to parse JSON file ... expected value" because a
+            % concurrent reader sometimes saw the file mid-write. The
+            % file we leave on disk must always be valid JSON.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'beta');
+            mip.state.key_value_append('MIP_LOADED_PACKAGES', 'gh/mip-org/core/alpha');
+            mip.state.add_pinned('gh/mip-org/core/beta');
+
+            mip.state.update_function_signatures(testCase.ResourcesDir);
+
+            jsonPath = fullfile(testCase.ResourcesDir, 'functionSignatures.json');
+            content = readJson(testCase.ResourcesDir);
+            testCase.verifyNotEmpty(strtrim(content), ...
+                'Generated functionSignatures.json must not be empty');
+            try
+                jsondecode(content);
+            catch err
+                testCase.verifyFail(sprintf( ...
+                    'Generated functionSignatures.json failed to parse: %s', err.message));
+            end
+
+            % No temp file should be left behind after a successful write.
+            testCase.verifyFalse(exist([jsonPath '.tmp'], 'file') == 2, ...
+                'Temp file should not remain after atomic rename');
+        end
+
+        function testRepeatedRegenerationStaysValid(testCase)
+            % Each call must leave the file in a valid state, even if
+            % invoked many times in quick succession.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'alpha');
+            for k = 1:5
+                mip.state.update_function_signatures(testCase.ResourcesDir);
+                content = readJson(testCase.ResourcesDir);
+                try
+                    jsondecode(content);
+                catch err
+                    testCase.verifyFail(sprintf( ...
+                        'JSON invalid after iteration %d: %s', k, err.message));
+                end
+            end
+        end
+
         function testDuplicateBareNamesAreDeduplicated(testCase)
             % Same bare name on two different channels should appear once
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkg');


### PR DESCRIPTION
## Summary

Fixes #266 — `mip` tab completion intermittently failed with:

```
Unable to load signatures for 'mip'. Failed to parse JSON file
'.../mip/resources/functionSignatures.json': <unspecified file>(1): expected value
```

`fopen(jsonPath, 'w')` truncates the destination file the moment it's opened, leaving a window where MATLAB's tab-completion reader can see an empty file before `fwrite` finishes. The "expected value" error at line 1 is exactly what an empty file produces.

## Changes

- `+mip/+state/update_function_signatures.m`: validate the generated JSON in memory with `jsondecode`, then write to a sibling `.tmp` file and `movefile` it into place. The destination is never truncated; readers either see the previous valid file or the new one.
- `tests/TestFunctionSignatures.m`: two regression tests — one verifies the generated file always parses as JSON, the other verifies repeated regeneration stays valid and leaves no `.tmp` debris.