### PR TITLE
Collapse <owner>/<owner>/<pkg> to <owner>/<pkg> in display and accept it as input

### DIFF
--- a/+mip/+parse/display_fqn.m
+++ b/+mip/+parse/display_fqn.m
@@ -6,8 +6,11 @@ function out = display_fqn(fqn)
 % is always stripped for display. For personal channels — where the
 % channel name equals the owner (e.g. 'gh/magland/magland/chunkie') —
 % the duplicated owner segment is collapsed, yielding the 2-part form
-% '<owner>/<pkg>'. Other source types ('local/mypkg', 'fex/some_pkg',
-% etc.) are returned unchanged.
+% '<owner>/<pkg>'. The collapse is skipped when the owner matches a
+% reserved source-type prefix (mip.parse.reserved_types), since the
+% collapsed form would be parsed back as a non-gh FQN rather than
+% round-tripping to the original. Other source types ('local/mypkg',
+% 'fex/some_pkg', etc.) are returned unchanged.
 %
 % Args:
 %   fqn - Internal fully qualified name
@@ -23,7 +26,8 @@ function out = display_fqn(fqn)
 if startsWith(fqn, 'gh/')
     rest = fqn(4:end);
     parts = strsplit(rest, '/');
-    if numel(parts) == 3 && strcmp(parts{1}, parts{2})
+    if numel(parts) == 3 && strcmp(parts{1}, parts{2}) && ...
+            ~ismember(parts{1}, mip.parse.reserved_types())
         out = [parts{1} '/' parts{3}];
     else
         out = rest;

--- a/+mip/+parse/display_fqn.m
+++ b/+mip/+parse/display_fqn.m
@@ -2,19 +2,32 @@ function out = display_fqn(fqn)
 %DISPLAY_FQN   Convert an internal FQN to its user-facing display form.
 %
 % GitHub channel packages are stored internally with a leading 'gh/'
-% source-type prefix (e.g. 'gh/mip-org/core/chebfun'). Users see and
-% type the shortened 3-part form ('mip-org/core/chebfun'). Other
-% source types (e.g. 'local/mypkg', 'fex/some_pkg') are returned
-% unchanged.
+% source-type prefix (e.g. 'gh/mip-org/core/chebfun'). The 'gh/' prefix
+% is always stripped for display. For personal channels — where the
+% channel name equals the owner (e.g. 'gh/magland/magland/chunkie') —
+% the duplicated owner segment is collapsed, yielding the 2-part form
+% '<owner>/<pkg>'. Other source types ('local/mypkg', 'fex/some_pkg',
+% etc.) are returned unchanged.
 %
 % Args:
 %   fqn - Internal fully qualified name
 %
 % Returns:
 %   out - User-facing display form
+%
+% Examples:
+%   display_fqn('gh/mip-org/core/chebfun')    -> 'mip-org/core/chebfun'
+%   display_fqn('gh/magland/magland/chunkie') -> 'magland/chunkie'
+%   display_fqn('local/mypkg')                -> 'local/mypkg'
 
 if startsWith(fqn, 'gh/')
-    out = fqn(4:end);
+    rest = fqn(4:end);
+    parts = strsplit(rest, '/');
+    if numel(parts) == 3 && strcmp(parts{1}, parts{2})
+        out = [parts{1} '/' parts{3}];
+    else
+        out = rest;
+    end
 else
     out = fqn;
 end

--- a/+mip/+parse/parse_channel_flag.m
+++ b/+mip/+parse/parse_channel_flag.m
@@ -8,8 +8,9 @@ function [channel, remainingArgs] = parse_channel_flag(args)
 %   channel       - Channel string in '<owner>/<channel>' form, or '' if not
 %                   specified. A bare single name '<owner>' is expanded to
 %                   '<owner>/<owner>' as shorthand for a user's personal channel
-%                   repo (github.com/<owner>/mip-<owner>). This shorthand
-%                   applies only to --channel, not to FQNs.
+%                   repo (github.com/<owner>/mip-<owner>). The same personal-
+%                   channel shorthand is also accepted for positional FQN
+%                   arguments — see mip.parse.parse_package_arg.
 %   remainingArgs - Cell array with --channel and its value removed
 
 channel = '';

--- a/+mip/+parse/parse_package_arg.m
+++ b/+mip/+parse/parse_package_arg.m
@@ -64,10 +64,7 @@ function result = parse_package_arg(arg)
 %   parse_package_arg('fex/some_pkg@1.0')
 %     -> name='some_pkg', type='fex', fqn='fex/some_pkg', version='1.0'
 
-% Reserved source-type prefixes for non-gh FQNs. A 2-part '<a>/<b>' input
-% whose first segment matches one of these is parsed as a non-gh FQN; any
-% other first segment is treated as the owner of a personal channel.
-reservedTypes = {'gh', 'local', 'fex', 'web', 'mhl'};
+reservedTypes = mip.parse.reserved_types();
 
 % Extract @version suffix if present
 atIdx = strfind(arg, '@');

--- a/+mip/+parse/parse_package_arg.m
+++ b/+mip/+parse/parse_package_arg.m
@@ -12,14 +12,19 @@ function result = parse_package_arg(arg)
 %   mhl/<name>                    - .mhl install with no --channel given
 %
 % On input, the 'gh/' prefix may be omitted: a 3-part '<owner>/<channel>/<name>'
-% input is treated as 'gh/<owner>/<channel>/<name>'. Non-gh source types must be
-% written explicitly ('local/<name>', 'fex/<name>', 'mhl/<name>', etc.).
+% input is treated as 'gh/<owner>/<channel>/<name>'. As a further shorthand
+% for personal channels (where channel == owner), a 2-part '<owner>/<name>'
+% input is treated as 'gh/<owner>/<owner>/<name>' when '<owner>' is not a
+% reserved source-type prefix. Non-gh source types must be written
+% explicitly ('local/<name>', 'fex/<name>', 'mhl/<name>', etc.).
 %
 % Args:
 %   arg - Package string. One of:
 %           '<name>'                         (bare name)
 %           '<name>@<version>'               (bare name with version)
 %           '<category>/<name>'              (2-part non-gh FQN, e.g. 'local/foo')
+%           '<owner>/<name>'                 (2-part personal-channel shorthand
+%                                             for 'gh/<owner>/<owner>/<name>')
 %           '<owner>/<channel>/<name>'       (3-part, implicit gh/)
 %           'gh/<owner>/<channel>/<name>'    (4-part, explicit gh/)
 %         Any of the FQN forms may include an @version suffix on the last
@@ -47,12 +52,22 @@ function result = parse_package_arg(arg)
 %   parse_package_arg('gh/mip-org/core/chebfun')
 %     -> same as above (explicit form)
 %
+%   parse_package_arg('magland/chunkie')
+%     -> name='chunkie', type='gh', owner='magland', channel='magland',
+%        fqn='gh/magland/magland/chunkie', is_fqn=true
+%        (2-part personal-channel shorthand)
+%
 %   parse_package_arg('local/mypkg')
 %     -> name='mypkg', type='local', owner='', channel='',
 %        fqn='local/mypkg', is_fqn=true
 %
 %   parse_package_arg('fex/some_pkg@1.0')
 %     -> name='some_pkg', type='fex', fqn='fex/some_pkg', version='1.0'
+
+% Reserved source-type prefixes for non-gh FQNs. A 2-part '<a>/<b>' input
+% whose first segment matches one of these is parsed as a non-gh FQN; any
+% other first segment is treated as the owner of a personal channel.
+reservedTypes = {'gh', 'local', 'fex', 'web', 'mhl'};
 
 % Extract @version suffix if present
 atIdx = strfind(arg, '@');
@@ -80,13 +95,26 @@ switch length(parts)
         if strcmp(parts{1}, 'gh')
             error('mip:invalidPackageSpec', ...
                   ['Invalid package spec "%s". A gh FQN must have the form ' ...
-                   '"gh/<owner>/<channel>/<name>" (or the 3-part shorthand ' ...
-                   '"<owner>/<channel>/<name>").'], arg);
+                   '"gh/<owner>/<channel>/<name>" (or the shorthand forms ' ...
+                   '"<owner>/<channel>/<name>" or "<owner>/<name>" for the ' ...
+                   'personal channel <owner>/<owner>).'], arg);
         end
-        result.type = parts{1};
-        result.name = parts{2};
-        result.fqn = [result.type '/' result.name];
-        result.is_fqn = true;
+        if ismember(parts{1}, reservedTypes)
+            % Non-gh source-type FQN (local, fex, web, mhl).
+            result.type = parts{1};
+            result.name = parts{2};
+            result.fqn = [result.type '/' result.name];
+            result.is_fqn = true;
+        else
+            % Personal-channel shorthand: '<owner>/<name>' expands to
+            % 'gh/<owner>/<owner>/<name>'.
+            result.type = 'gh';
+            result.owner = parts{1};
+            result.channel = parts{1};
+            result.name = parts{2};
+            result.fqn = ['gh/' result.owner '/' result.channel '/' result.name];
+            result.is_fqn = true;
+        end
     case 3
         result.type = 'gh';
         result.owner = parts{1};

--- a/+mip/+parse/reserved_types.m
+++ b/+mip/+parse/reserved_types.m
@@ -1,0 +1,14 @@
+function types = reserved_types()
+%RESERVED_TYPES   Source-type prefixes reserved for non-gh FQNs.
+%
+% A 2-part '<a>/<b>' input whose first segment matches one of these is
+% parsed as a non-gh FQN (or, for 'gh', rejected as malformed); any
+% other first segment is treated as the owner of a personal channel.
+% The same list is consulted by display_fqn to decide whether the
+% personal-channel collapse is safe (collapsing 'gh/<r>/<r>/<pkg>'
+% when <r> is reserved would produce '<r>/<pkg>', which round-trips
+% as a non-gh FQN rather than back to the original).
+
+types = {'gh', 'local', 'fex', 'web', 'mhl'};
+
+end

--- a/+mip/install.m
+++ b/+mip/install.m
@@ -7,6 +7,7 @@ function install(varargin)
 %   mip install --channel <owner>/<channel> <package>
 %   mip install --channel <owner> <package>                        - Shorthand for --channel <owner>/<owner>
 %   mip install <owner>/<channel>/<package>
+%   mip install <owner>/<package>                                  - Shorthand for <owner>/<owner>/<package>
 %   mip install /path/to/package.mhl                               - Install under mhl/<name>
 %   mip install https://example.com/package.mhl                    - Install under mhl/<name>
 %   mip install --channel <owner>/<channel> /path/to/package.mhl   - Install under gh/<owner>/<channel>/<name>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ A package manager for MATLAB/MEX. Handles installing, updating, loading, and unl
   - Local directory / editable installs: `local/<package>`
   - File Exchange installs: `fex/<package>`
   - Generic remote .zip installs: `web/<package>`
-- **Display form**: strips the `gh/` prefix only (`mip-org/core/chebfun`, `local/foo`, `fex/bar`, `web/baz`). See `mip.parse.display_fqn`.
-- **User input**: `gh/` is optional. The parser accepts bare names, `<category>/<name>` (non-gh), `<owner>/<channel>/<name>` (implicit gh), and `gh/<owner>/<channel>/<name>` (explicit).
+- **Display form**: strips the `gh/` prefix (`mip-org/core/chebfun`, `local/foo`, `fex/bar`, `web/baz`). For personal channels (channel name == owner), the duplicated owner segment is collapsed: `gh/magland/magland/chunkie` → `magland/chunkie`. See `mip.parse.display_fqn`.
+- **User input**: `gh/` is optional. The parser accepts bare names, `<category>/<name>` (non-gh), `<owner>/<name>` (2-part personal-channel shorthand for `gh/<owner>/<owner>/<name>` when `<owner>` is not a reserved source-type prefix), `<owner>/<channel>/<name>` (implicit gh), and `gh/<owner>/<channel>/<name>` (explicit).
 - **Bare name**: Just `package` — resolved via priority: `gh/mip-org/core` first, then alphabetical
 - **Channels**: Package repositories hosted on GitHub Pages (e.g., `mip-org/mip-core`). Channel identifiers remain 2-part `<owner>/<channel>` — `gh/` is a source-type prefix in FQNs, not part of the channel.
 - **Packages installed at**:

--- a/tests/TestInstallLocal.m
+++ b/tests/TestInstallLocal.m
@@ -228,29 +228,9 @@ classdef TestInstallLocal < matlab.unittest.TestCase
 
         %% --- Path-vs-name dispatch (issue #107) ---
 
-        function testInstall_TwoPartSpecRaisesInvalidPackageSpec(testCase)
-            % "foo/bar" is neither a bare name nor a FQN; it should be
-            % rejected with a parse error before any channel fetch.
-            testCase.verifyError(@() mip.install('foo/bar'), ...
-                'mip:install:invalidPackageSpec');
-        end
-
         function testInstall_FourPartSpecRaisesInvalidPackageSpec(testCase)
             testCase.verifyError(@() mip.install('a/b/c/d'), ...
                 'mip:install:invalidPackageSpec');
-        end
-
-        function testInstall_TwoPartSpecHintsAtSlashPrefix(testCase)
-            % The error message for an invalid spec should hint at './foo/bar'
-            % so the user knows how to install it as a local package.
-            try
-                mip.install('foo/bar');
-                testCase.verifyFail('Expected mip.install to error');
-            catch ME
-                testCase.verifyEqual(ME.identifier, 'mip:install:invalidPackageSpec');
-                testCase.verifyTrue(contains(ME.message, './foo/bar'), ...
-                    'Error message should hint at ./foo/bar');
-            end
         end
 
         function testInstall_RelativeDotPathInstallsLocally(testCase)

--- a/tests/TestUtilsParsing.m
+++ b/tests/TestUtilsParsing.m
@@ -232,16 +232,40 @@ classdef TestUtilsParsing < matlab.unittest.TestCase
             testCase.verifyEqual(remaining, {'pkg1'});
         end
 
-        function testParseChannelShorthandDoesNotApplyToFqn(testCase)
-            % The bare-name shorthand is exclusive to --channel. A 2-part
-            % positional arg like 'foo/pkg1' must NOT be expanded to
-            % 'foo/foo/pkg1' — it parses as a non-gh FQN with type='foo'.
+        function testParseChannelShorthandAppliesToFqn(testCase)
+            % A 2-part positional arg '<owner>/<pkg>' (where <owner> is not
+            % a reserved source-type prefix) is shorthand for the personal
+            % channel form 'gh/<owner>/<owner>/<pkg>'.
             r = mip.parse.parse_package_arg('foo/pkg1');
             testCase.verifyTrue(r.is_fqn);
-            testCase.verifyEqual(r.type, 'foo');
+            testCase.verifyEqual(r.type, 'gh');
             testCase.verifyEqual(r.name, 'pkg1');
-            testCase.verifyEqual(r.owner, '');
-            testCase.verifyEqual(r.channel, '');
+            testCase.verifyEqual(r.owner, 'foo');
+            testCase.verifyEqual(r.channel, 'foo');
+            testCase.verifyEqual(r.fqn, 'gh/foo/foo/pkg1');
+        end
+
+        function testParsePersonalChannelShorthandWithVersion(testCase)
+            r = mip.parse.parse_package_arg('magland/chunkie@1.2.0');
+            testCase.verifyTrue(r.is_fqn);
+            testCase.verifyEqual(r.type, 'gh');
+            testCase.verifyEqual(r.owner, 'magland');
+            testCase.verifyEqual(r.channel, 'magland');
+            testCase.verifyEqual(r.name, 'chunkie');
+            testCase.verifyEqual(r.fqn, 'gh/magland/magland/chunkie');
+            testCase.verifyEqual(r.version, '1.2.0');
+        end
+
+        function testParsePersonalShorthandReservedTypesUnchanged(testCase)
+            % Reserved source-type prefixes still parse as non-gh FQNs.
+            for prefix = {'local', 'fex', 'web', 'mhl'}
+                r = mip.parse.parse_package_arg([prefix{1} '/pkg1']);
+                testCase.verifyEqual(r.type, prefix{1});
+                testCase.verifyEqual(r.name, 'pkg1');
+                testCase.verifyEqual(r.owner, '');
+                testCase.verifyEqual(r.channel, '');
+                testCase.verifyEqual(r.fqn, [prefix{1} '/pkg1']);
+            end
         end
 
         function testParseChannelFlagMissingValue(testCase)
@@ -312,6 +336,20 @@ classdef TestUtilsParsing < matlab.unittest.TestCase
             testCase.verifyEqual( ...
                 mip.parse.display_fqn('gh/mip-org/core/chebfun'), ...
                 'mip-org/core/chebfun');
+        end
+
+        function testDisplayFqnCollapsesPersonalChannel(testCase)
+            % Personal channels (owner == channel) collapse to <owner>/<pkg>.
+            testCase.verifyEqual( ...
+                mip.parse.display_fqn('gh/magland/magland/chunkie'), ...
+                'magland/chunkie');
+        end
+
+        function testDisplayFqnDoesNotCollapseDistinctChannel(testCase)
+            % owner != channel: keep the 3-part form.
+            testCase.verifyEqual( ...
+                mip.parse.display_fqn('gh/mip-org/dev/chebfun'), ...
+                'mip-org/dev/chebfun');
         end
 
         function testDisplayFqnLocalUnchanged(testCase)

--- a/tests/TestUtilsParsing.m
+++ b/tests/TestUtilsParsing.m
@@ -367,5 +367,20 @@ classdef TestUtilsParsing < matlab.unittest.TestCase
                 mip.parse.display_fqn('web/bar'), 'web/bar');
         end
 
+        function testDisplayFqnDoesNotCollapseReservedOwner(testCase)
+            % If the owner matches a reserved source-type prefix, the
+            % personal-channel collapse is skipped: the collapsed form
+            % '<reserved>/<pkg>' would be re-parsed as a non-gh FQN
+            % (e.g. 'local/foo' is a local install), breaking the
+            % display→parse round-trip.
+            for owner = {'local', 'fex', 'web', 'mhl', 'gh'}
+                fqn = ['gh/' owner{1} '/' owner{1} '/foo'];
+                expected = [owner{1} '/' owner{1} '/foo'];
+                testCase.verifyEqual( ...
+                    mip.parse.display_fqn(fqn), expected, ...
+                    sprintf('owner=%s should not collapse', owner{1}));
+            end
+        end
+
     end
 end


### PR DESCRIPTION
## Summary
- `mip.parse.display_fqn` collapses `gh/<owner>/<owner>/<pkg>` → `<owner>/<pkg>`; other source types still strip only `gh/`.
- `mip.parse.parse_package_arg` accepts the 2-part `<owner>/<pkg>` form and expands it to `gh/<owner>/<owner>/<pkg>` when `<owner>` is not in the reserved set `{gh, local, fex, web, mhl}`.
- `parse_channel_flag` docstring updated; the personal-channel shorthand now applies to FQNs as well.
- Canonical/internal FQNs and on-disk layout are unchanged.

Closes #265