### PR TITLE
Disambiguate unload-time cascade messages from on-disk pruning

### DIFF
--- a/+mip/unload.m
+++ b/+mip/unload.m
@@ -253,13 +253,13 @@ function pruneUnusedPackages()
     % Prune each unnecessary package
     if ~isempty(packagesToPrune)
         displayPrune = cellfun(@mip.parse.display_fqn, packagesToPrune, 'UniformOutput', false);
-        fprintf('Pruning unnecessary packages: %s\n', strjoin(displayPrune, ', '));
+        fprintf('Unloading transitive dependencies: %s\n', strjoin(displayPrune, ', '));
         for i = 1:length(packagesToPrune)
             pkg = packagesToPrune{i};
             packageDir = mip.paths.get_package_dir(pkg);
             executeUnload(packageDir, pkg);
             mip.state.key_value_remove('MIP_LOADED_PACKAGES', pkg);
-            fprintf('  Pruned package "%s"\n', mip.parse.display_fqn(pkg));
+            fprintf('  Unloaded transitive dependency "%s"\n', mip.parse.display_fqn(pkg));
         end
     end
 


### PR DESCRIPTION
Closes #255

## Summary
- `+mip/unload.m`'s post-unload cascade rmpaths transitive deps and clears them from `MIP_LOADED_PACKAGES`, but leaves packages on disk. It previously printed "Pruning unnecessary packages …" / "Pruned package X" — the same wording as `+mip/+state/prune_unused_packages.m`, which actually `rmdir`s orphans. The shared wording made the unload output read as destructive (and triggered #254).
- Renamed the unload-time messages so the operation is unambiguous:
  - `Pruning unnecessary packages: …` → `Unloading transitive dependencies: …`
  - `  Pruned package "X"` → `  Unloaded transitive dependency "X"`
- `+mip/+state/prune_unused_packages.m` is unchanged — that one really does prune.
- No tests assert on the old wording (`grep -rn "Pruning unnecessary\|Pruned package" tests/` finds nothing).