### PR TITLE
resolve_dependency: prefer depending package's own channel before core

### DIFF
--- a/+mip/+dependency/find_all_dependencies.m
+++ b/+mip/+dependency/find_all_dependencies.m
@@ -2,8 +2,9 @@ function deps = find_all_dependencies(fqn, visited)
 %FIND_ALL_DEPENDENCIES   Recursively collect all transitive dependencies of an installed package.
 %
 % Reads mip.json from the installed package directory and resolves bare
-% dependency names to mip-org/core/<name>. Cycles are tolerated: a package
-% already in `visited` is not re-entered.
+% dependency names via mip.resolve.resolve_dependency, which prefers the
+% depending package's own channel before falling back to mip-org/core.
+% Cycles are tolerated: a package already in `visited` is not re-entered.
 %
 % Args:
 %   fqn     - Fully qualified package name (<owner>/<channel>/<name>)
@@ -44,7 +45,7 @@ try
     for i = 1:length(depNames)
         dep = depNames{i};
         try
-            depFqn = mip.resolve.resolve_dependency(dep);
+            depFqn = mip.resolve.resolve_dependency(dep, fqn);
         catch
             continue
         end

--- a/+mip/+resolve/resolve_dependency.m
+++ b/+mip/+resolve/resolve_dependency.m
@@ -1,15 +1,23 @@
-function depFqn = resolve_dependency(depName)
+function depFqn = resolve_dependency(depName, dependingPkgFqn)
 %RESOLVE_DEPENDENCY   Resolve a dependency name to a fully qualified name.
 %
 % If depName is already a FQN, return as-is.
-% If bare, resolve to mip-org/core/<name>.
 %
-% Bare-name dependencies always resolve to mip-org/core. To depend on a
-% package from a different channel, use the fully qualified name in
-% mip.yaml.
+% If depName is a bare name, prefer the depending package's own channel:
+% if the dep is installed at gh/<owner>/<channel>/<name> for the same
+% <owner>/<channel> as the depending package, return that FQN. Otherwise
+% fall back to gh/mip-org/core/<name>.
+%
+% This lets a package on owner/chan list bare deps that today live on
+% owner/chan and tomorrow may move to mip-org/core — once the core
+% version is what's installed, bare names automatically retarget there.
 %
 % Args:
-%   depName - Dependency name (bare or FQN)
+%   depName         - Dependency name (bare or FQN)
+%   dependingPkgFqn - (Optional) FQN of the package whose mip.yaml lists
+%                     this dep. Used only for bare-name resolution; if
+%                     omitted or not a gh FQN, bare names resolve
+%                     directly to mip-org/core.
 %
 % Returns:
 %   depFqn - Fully qualified name
@@ -19,6 +27,18 @@ result = mip.parse.parse_package_arg(depName);
 if result.is_fqn
     depFqn = result.fqn;
     return
+end
+
+if nargin >= 2 && ~isempty(dependingPkgFqn)
+    parent = mip.parse.parse_package_arg(dependingPkgFqn);
+    if parent.is_fqn && strcmp(parent.type, 'gh') ...
+            && ~(strcmp(parent.owner, 'mip-org') && strcmp(parent.channel, 'core'))
+        sameChannelFqn = mip.parse.make_fqn(parent.owner, parent.channel, result.name);
+        if mip.state.is_installed(sameChannelFqn)
+            depFqn = sameChannelFqn;
+            return
+        end
+    end
 end
 
 depFqn = mip.parse.make_fqn('mip-org', 'core', result.name);

--- a/+mip/+state/check_broken_dependencies.m
+++ b/+mip/+state/check_broken_dependencies.m
@@ -45,9 +45,9 @@ for i = 1:length(packages)
         for j = 1:length(depNames)
             dep = depNames{j};
             if strcmp(mode, 'installed')
-                depMissing = isDependencyUninstalled(dep);
+                depMissing = isDependencyUninstalled(dep, pkg);
             else
-                depMissing = isDependencyUnloaded(dep);
+                depMissing = isDependencyUnloaded(dep, pkg);
             end
             if depMissing
                 brokenDeps{end+1} = sprintf('Package "%s" depends on "%s" which is %s', pkg, dep, missingVerb); %#ok<AGROW>
@@ -66,13 +66,13 @@ end
 
 end
 
-function tf = isDependencyUninstalled(dep)
-    depFqn = mip.resolve.resolve_dependency(dep);
+function tf = isDependencyUninstalled(dep, parentFqn)
+    depFqn = mip.resolve.resolve_dependency(dep, parentFqn);
     depDir = mip.paths.get_package_dir(depFqn);
     tf = ~exist(depDir, 'dir');
 end
 
-function tf = isDependencyUnloaded(dep)
-    depFqn = mip.resolve.resolve_dependency(dep);
+function tf = isDependencyUnloaded(dep, parentFqn)
+    depFqn = mip.resolve.resolve_dependency(dep, parentFqn);
     tf = ~mip.state.is_loaded(depFqn);
 end

--- a/+mip/load.m
+++ b/+mip/load.m
@@ -244,7 +244,7 @@ function matched = loadSingle(packageArg, installIfMissing, stickyPackage, chann
                 displayFqn, strjoin(deps, ', '));
         for i = 1:length(deps)
             dep = deps{i};
-            depFqn = mip.resolve.resolve_dependency(dep);
+            depFqn = mip.resolve.resolve_dependency(dep, fqn);
             if ~mip.state.is_loaded(depFqn)
                 loadSingle(depFqn, installIfMissing, false, channel, false, loadingStack, {}, {}, {});
             else

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -448,7 +448,7 @@ function installMissingDeps(remoteFqns)
             continue
         end
         for j = 1:length(deps)
-            depFqn = mip.resolve.resolve_dependency(deps{j});
+            depFqn = mip.resolve.resolve_dependency(deps{j}, fqn);
             depDir = mip.paths.get_package_dir(depFqn);
             if ~exist(depDir, 'dir')
                 missingDeps{end+1} = deps{j}; %#ok<AGROW>

--- a/tests/TestLoadPackage.m
+++ b/tests/TestLoadPackage.m
@@ -90,6 +90,28 @@ classdef TestLoadPackage < matlab.unittest.TestCase
             testCase.verifyFalse(mip.state.is_directly_loaded('mip-org/core/depA'));
         end
 
+        function testLoadPackage_BareDepPrefersOwnChannel(testCase)
+            % A package on owner/chan with a bare-name dep should load
+            % the dep from its own channel if that's where it's installed.
+            createTestPackage(testCase.TestRoot, 'mylab', 'custom', 'depA');
+            createTestPackage(testCase.TestRoot, 'mylab', 'custom', 'mainpkg', ...
+                'dependencies', {'depA'});
+            mip.load('mylab/custom/mainpkg');
+            testCase.verifyTrue(mip.state.is_loaded('mylab/custom/mainpkg'));
+            testCase.verifyTrue(mip.state.is_loaded('mylab/custom/depA'));
+        end
+
+        function testLoadPackage_BareDepFallsBackToCore(testCase)
+            % If the bare-name dep is not installed on the depending
+            % package's own channel, fall back to mip-org/core.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'depA');
+            createTestPackage(testCase.TestRoot, 'mylab', 'custom', 'mainpkg', ...
+                'dependencies', {'depA'});
+            mip.load('mylab/custom/mainpkg');
+            testCase.verifyTrue(mip.state.is_loaded('mylab/custom/mainpkg'));
+            testCase.verifyTrue(mip.state.is_loaded('mip-org/core/depA'));
+        end
+
         function testLoadPackage_ChainedDependencies(testCase)
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'depB');
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'depA', ...

--- a/tests/TestPackageDiscovery.m
+++ b/tests/TestPackageDiscovery.m
@@ -81,11 +81,30 @@ classdef TestPackageDiscovery < matlab.unittest.TestCase
             testCase.verifyEqual(fqn, 'gh/mip-org/core/chebfun');
         end
 
-        function testResolveDependency_BareNameIgnoresSameChannel(testCase)
-            % Even when a package with the same name exists on a non-core
-            % channel, bare-name deps always resolve to gh/mip-org/core.
+        function testResolveDependency_BareNamePrefersSameChannel(testCase)
+            % When the depending package lives on owner/chan and the dep
+            % is installed there, bare-name resolution prefers that
+            % channel over mip-org/core.
+            createTestPackage(testCase.TestRoot, 'mylab', 'custom', 'parentpkg');
             createTestPackage(testCase.TestRoot, 'mylab', 'custom', 'somepkg');
-            fqn = mip.resolve.resolve_dependency('somepkg');
+            fqn = mip.resolve.resolve_dependency('somepkg', 'gh/mylab/custom/parentpkg');
+            testCase.verifyEqual(fqn, 'gh/mylab/custom/somepkg');
+        end
+
+        function testResolveDependency_BareNameFallsBackToCore(testCase)
+            % If the dep isn't installed on the depending package's
+            % channel, fall back to mip-org/core.
+            createTestPackage(testCase.TestRoot, 'mylab', 'custom', 'parentpkg');
+            fqn = mip.resolve.resolve_dependency('somepkg', 'gh/mylab/custom/parentpkg');
+            testCase.verifyEqual(fqn, 'gh/mip-org/core/somepkg');
+        end
+
+        function testResolveDependency_BareNameFromCoreParent(testCase)
+            % A core-channel parent has no preferred non-core channel —
+            % bare names go straight to mip-org/core regardless of what
+            % is installed on other channels.
+            createTestPackage(testCase.TestRoot, 'mylab', 'custom', 'somepkg');
+            fqn = mip.resolve.resolve_dependency('somepkg', 'gh/mip-org/core/parentpkg');
             testCase.verifyEqual(fqn, 'gh/mip-org/core/somepkg');
         end
 


### PR DESCRIPTION
## Summary
- For bare-name deps, `mip.resolve.resolve_dependency` now takes the depending package's FQN as context. If the parent lives on `<owner>/<channel>` (non-core) and the dep is installed there, resolution returns that FQN; otherwise it falls back to `gh/mip-org/core/<name>`.
- Fully qualified deps still pass through unchanged.
- Callers updated to pass the parent FQN: `+mip/load.m`, `+mip/update.m`, `+mip/+dependency/find_all_dependencies.m`, `+mip/+state/check_broken_dependencies.m`.

This lets a package on `owner/chan` list bare deps for things that today live on `owner/chan` and tomorrow may move to `mip-org/core` — once the core version is what's installed, bare names automatically retarget there. Reviewers should manually load the core versions before approving the move (per the tradeoff acknowledged in the issue).

Out of scope (per the issue's touches list): the install-time path in `+mip/+dependency/build_dependency_graph.m` is tracked by #259.

Closes #264.