### PR TITLE
Move bundle staging dir aside on Windows when rmdir is blocked by a held MEX

### DIFF
--- a/+mip/bundle.m
+++ b/+mip/bundle.m
@@ -70,6 +70,10 @@ function bundle(varargin)
     end
     outputDir = mip.paths.get_absolute_path(outputDir);
 
+    % Opportunistically remove staging dirs that an earlier Windows bundle
+    % could only move aside (a MEX built in that session was still loaded).
+    purgeBundleTrash();
+
     % Prepare in a staging directory
     stagingDir = tempname;
 
@@ -114,16 +118,85 @@ function bundle(varargin)
         fprintf('Metadata written to %s\n', mipJsonOutputPath);
 
     catch ME
-        % Clean up staging dir on failure
-        if exist(stagingDir, 'dir')
-            rmdir(stagingDir, 's');
-        end
+        % Clean up staging dir on failure (best-effort: must not mask ME).
+        removeStagingDir(stagingDir);
         rethrow(ME);
     end
 
     % Clean up staging dir
-    if exist(stagingDir, 'dir')
+    removeStagingDir(stagingDir);
+
+end
+
+function removeStagingDir(stagingDir)
+% Remove the bundle staging directory.
+%
+% On Windows a native binary built during bundling can end up loaded in
+% this MATLAB session (or held by the OS file scanner just after it is
+% written), and a held .mexw64 cannot be deleted, so rmdir fails. Windows
+% still allows renaming such a file, so move the staging dir into a trash
+% area on the same volume -- a metadata-only rename that succeeds even while
+% the binary is held -- and let purgeBundleTrash() delete it on a later
+% bundle once nothing has it open. The .mhl is already written by this
+% point, so cleanup never fails the bundle. Non-Windows does a plain rmdir.
+    if ~exist(stagingDir, 'dir')
+        return
+    end
+    try
         rmdir(stagingDir, 's');
+        return
+    catch rmErr
+        if ~ispc
+            rethrow(rmErr);
+        end
     end
 
+    trashDir = bundleTrashRoot();
+    if ~exist(trashDir, 'dir')
+        mkdir(trashDir);
+    end
+    % tempname(trashDir) is on the same volume as stagingDir (both under
+    % tempdir), so the move is a rename, not a copy+delete that would trip
+    % over the held file.
+    [moved, msg] = movefile(stagingDir, tempname(trashDir), 'f');
+    if ~moved
+        warning('mip:bundle:stagingNotRemoved', ...
+                'Could not remove or move aside staging dir "%s": %s', ...
+                stagingDir, msg);
+    end
+end
+
+function purgeBundleTrash()
+% Best-effort deletion of staging dirs left by a previous Windows bundle
+% that could only be moved aside (a binary built then was still held).
+% Entries still held stay locked and are left for a later run.
+    trashDir = bundleTrashRoot();
+    if ~exist(trashDir, 'dir')
+        return
+    end
+    entries = dir(trashDir);
+    for i = 1:numel(entries)
+        nm = entries(i).name;
+        if strcmp(nm, '.') || strcmp(nm, '..')
+            continue
+        end
+        target = fullfile(trashDir, nm);
+        try
+            if entries(i).isdir
+                rmdir(target, 's');
+            else
+                delete(target);
+            end
+        catch
+            % Still held; leave it for a later run.
+        end
+    end
+end
+
+function d = bundleTrashRoot()
+% Trash area for staging dirs that could not be removed in-session. Kept
+% under tempdir so a move from a tempname() staging dir is a same-volume
+% rename (cross-volume movefile would copy the held file and then fail to
+% delete the source).
+    d = fullfile(tempdir, '.mip-trash');
 end


### PR DESCRIPTION
## Problem

`mip.bundle` finishes by deleting its staging directory with `rmdir(stagingDir, 's')`. On Windows this fails for packages that build **many** MEX files: a freshly written `.mexw64` is still held — by the OS file scanner that runs on every newly written PE/DLL, or by a binary loaded into the MATLAB session — and Windows refuses to delete a held file. The `.mhl` is already written by this point, so the artifact is fine, but the bundle errors out on cleanup and the build job fails.

Single-MEX packages (`fmm2d`, `fmmlib2d`) don't hit it: the lone DLL is released before `rmdir` runs. A 34-MEX package (`sedumi`) hits it **deterministically** (original run and a clean rerun failed identically at `bundle.m` line 126). `clear mex` does not release the handle, confirming the holder isn't MATLAB's own MEX loader. The failure is Windows-only — on Linux/macOS a held file can still be unlinked, so `rmdir` never blocks.

## Fix

Windows allows **renaming** a file whose deletion is blocked by a sharing violation. So on `rmdir` failure, move the staging dir into a trash area under `tempdir` (a same-volume, metadata-only rename that succeeds even while the file is held) and let `purgeBundleTrash()` — run at the start of each bundle — delete it on a later run once nothing holds it. This mirrors the move-aside pattern already used in `uninstall.m` (commit 8865341).

- The trash root is under `tempdir`, not `MIP_ROOT`, so the move from a `tempname()` staging dir is guaranteed same-volume (a cross-volume `movefile` would copy the held file and then fail to delete the source).
- Cleanup is now best-effort and never masks a real bundle error: the failure-path `catch` calls the same helper, which warns rather than throwing.
- Non-Windows behavior is unchanged — a failed `rmdir` still rethrows.

## Testing

- `TestBundleCommand` passes (11/11).
- `checkcode` clean.
- The Windows-specific held-file branch can't be exercised on Linux/macOS (POSIX unlink doesn't block), so it's validated by the real `sedumi` Windows build in the mip-dev channel.
