### PR TITLE
Upgrade GitHub Actions to Node 24-native versions and pin MATLAB release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: matlab-actions/setup-matlab@v3
+        with:
+          # Pin the release: the unset/`latest` default resolves to R2026a,
+          # which mpm currently refuses to install (see setup-matlab#199).
+          release: R2025b
 
       - uses: matlab-actions/run-command@v3
         with:
@@ -28,6 +32,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: matlab-actions/setup-matlab@v3
+        with:
+          # Pin the release: the unset/`latest` default resolves to R2026a,
+          # which mpm currently refuses to install (see setup-matlab#199).
+          release: R2025b
 
       - uses: matlab-actions/run-command@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,22 +14,22 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: matlab-actions/setup-matlab@v2
+      - uses: matlab-actions/setup-matlab@v3
 
-      - uses: matlab-actions/run-command@v2
+      - uses: matlab-actions/run-command@v3
         with:
           command: "addpath('tests'); addpath('tests/helpers'); results = run_tests(); assert(all([results.Passed]), 'Some tests failed');"
 
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: matlab-actions/setup-matlab@v2
+      - uses: matlab-actions/setup-matlab@v3
 
-      - uses: matlab-actions/run-command@v2
+      - uses: matlab-actions/run-command@v3
         with:
           command: "addpath('tests'); addpath('tests/helpers'); results = run_tests('Coverage', true); assert(all([results.Passed]), 'Some tests failed');"
 


### PR DESCRIPTION
Updates `tests.yml`: bumps the actions to their latest Node 24-native major versions **and** pins the MATLAB release, mirroring the pin-the-release pattern mip-dev already uses.

## Action version bumps

| action | before | after |
| --- | --- | --- |
| `actions/checkout` | v4 | v5 |
| `matlab-actions/setup-matlab` | v2 | v3 |
| `matlab-actions/run-command` | v2 | v3 |

`codecov/codecov-action@v5` is already current (composite action). All three bumped actions declare `using: node24`, clearing the Node 20 deprecation warnings (which named `checkout@v4` and `setup-matlab@v2`).

## Pin `release: R2025b`

The jobs are currently red, but **not** because of the action version — it's a MathWorks-side inconsistency:

- `setup-matlab`'s "latest" resolver (`.../ci/matlab-release/v0/latest`) returns **r2026a**.
- The `mpm` it downloads (**2026.4**) rejects R2026a: `Unsupported release version: R2026a`.

Reproduced off-CI with local `mpm` 2026.4, and confirmed the same action SHA installed R2026a fine at 16:44Z then failed from 17:12Z on — i.e. R2026a was pulled from `mpm`'s catalog without reverting the `latest` pointer. Filed upstream as [matlab-actions/setup-matlab#199](https://github.com/matlab-actions/setup-matlab/issues/199).

Pinning `release: R2025b` (newest GA before R2026a; still offered by `mpm`; mip's tests pass on it) stops CI depending on the broken `latest` path. We can revert to `latest`/R2026a once upstream is fixed.
