### PR TITLE
Add `mip.build.{list_mex,has_mex,effective_arch}` and `mip.test.get_fqn`

### DIFF
--- a/+mip/+build/effective_arch.m
+++ b/+mip/+build/effective_arch.m
@@ -1,0 +1,35 @@
+function arch = effective_arch(fqn)
+%EFFECTIVE_ARCH   Effective architecture of an installed package.
+%
+% Usage:
+%   arch = mip.build.effective_arch(fqn)
+%
+% Returns the *effective* architecture recorded in the package's mip.json:
+% the concrete arch a matching build was compiled for (macos_arm64,
+% linux_x86_64, windows_x86_64, ...), or 'any' for the pure-MATLAB fallback
+% build, which ships no compiled MEX.
+%
+% This is distinct from mip.build.arch(), the *current* architecture of the
+% machine MATLAB is running on. The current arch is always a concrete tag;
+% the effective arch may be 'any'. For example, an `any` build produced on a
+% macos_arm64 runner has current arch macos_arm64 but effective arch 'any'.
+% To decide whether a package actually ships MEX, use mip.build.has_mex,
+% which checks for the files themselves rather than the declared arch.
+%
+% fqn must be a fully-qualified name.
+
+r = mip.parse.parse_package_arg(fqn);
+if ~r.is_fqn
+    error('mip:invalidFqn', ...
+          'mip.build.effective_arch requires a fully qualified name; got "%s".', fqn);
+end
+
+pkgDir  = mip.paths.get_package_dir(fqn);
+pkgInfo = mip.config.read_package_json(pkgDir);
+if ~isfield(pkgInfo, 'architecture') || isempty(pkgInfo.architecture)
+    error('mip:build:noArchitecture', ...
+          'mip.json for "%s" has no architecture field.', fqn);
+end
+arch = pkgInfo.architecture;
+
+end

--- a/+mip/+build/has_mex.m
+++ b/+mip/+build/has_mex.m
@@ -1,0 +1,28 @@
+function tf = has_mex(fqn)
+%HAS_MEX   True if an installed package ships compiled MEX for this machine.
+%
+% Usage:
+%   tf = mip.build.has_mex(fqn)
+%
+% True iff the package ships at least one MEX matching the current
+% architecture's extension. Thin wrapper over mip.build.list_mex -- the file
+% scan, not the package's declared architecture (mip.build.effective_arch),
+% decides whether there is anything to call. Use it to gate the MEX portion
+% of a test script:
+%
+%   if ~mip.build.has_mex(fqn)
+%       fprintf('SUCCESS\n');
+%       return
+%   end
+%
+% fqn must be a fully-qualified name.
+
+r = mip.parse.parse_package_arg(fqn);
+if ~r.is_fqn
+    error('mip:invalidFqn', ...
+          'mip.build.has_mex requires a fully qualified name; got "%s".', fqn);
+end
+
+tf = ~isempty(mip.build.list_mex(fqn));
+
+end

--- a/+mip/+build/list_mex.m
+++ b/+mip/+build/list_mex.m
@@ -1,0 +1,33 @@
+function names = list_mex(fqn)
+%LIST_MEX   Base names of the compiled MEX an installed package ships.
+%
+% Usage:
+%   names = mip.build.list_mex(fqn)
+%
+% Returns a cell array of the unique base names (no extension) of MEX
+% binaries matching the current architecture's extension (mexext) found in
+% the package's own source directory -- the MEX it ships for this machine.
+% Empty when the package ships none (e.g. a pure-MATLAB build).
+%
+% This is the shared "what MEX does this package ship" primitive:
+% mip.build.has_mex is ~isempty(mip.build.list_mex(fqn)), and a channel test
+% runner can diff this list against what `inmem` shows was loaded to enforce
+% that the test exercised every shipped MEX. Only the package's own source
+% dir is scanned -- MEX from dependencies are not counted.
+%
+% fqn must be a fully-qualified name.
+
+r = mip.parse.parse_package_arg(fqn);
+if ~r.is_fqn
+    error('mip:invalidFqn', ...
+          'mip.build.list_mex requires a fully qualified name; got "%s".', fqn);
+end
+
+pkgDir  = mip.paths.get_package_dir(fqn);
+pkgInfo = mip.config.read_package_json(pkgDir);
+srcDir  = mip.paths.get_source_dir(pkgDir, pkgInfo);
+
+info  = dir(fullfile(srcDir, '**', ['*.' mexext]));
+names = unique(erase({info.name}, ['.' mexext]));
+
+end

--- a/+mip/+test/get_fqn.m
+++ b/+mip/+test/get_fqn.m
@@ -1,0 +1,28 @@
+function fqn = get_fqn()
+%GET_FQN   Fully-qualified name of the package currently under `mip test`.
+%
+% Usage:
+%   fqn = mip.test.get_fqn()
+%
+% `mip test` publishes the fully-qualified name of the package it is testing
+% for the duration of the run, so a test script can identify itself without
+% resolving its own (possibly ambiguous) bare name. Pass the result to
+% mip.build.effective_arch / mip.build.has_mex to gate the MEX portion of a
+% test on a pure-MATLAB `any` build:
+%
+%   if ~mip.build.has_mex(mip.test.get_fqn())
+%       fprintf('SUCCESS\n');
+%       return
+%   end
+%
+% Errors when called outside a `mip test` run, where no package is under
+% test.
+
+fqn = mip.state.key_value_get('MIP_TEST_CONTEXT');
+if isempty(fqn)
+    error('mip:test:noContext', ...
+          ['mip.test.get_fqn() is only valid inside a test script run by ' ...
+           '`mip test`.']);
+end
+
+end

--- a/+mip/reset.m
+++ b/+mip/reset.m
@@ -11,7 +11,8 @@ function reset()
 mip.unload('--all', '--force');
 
 % Remove all MIP key-value stores
-keys = {'MIP_LOADED_PACKAGES', 'MIP_DIRECTLY_LOADED_PACKAGES', 'MIP_STICKY_PACKAGES'};
+keys = {'MIP_LOADED_PACKAGES', 'MIP_DIRECTLY_LOADED_PACKAGES', ...
+        'MIP_STICKY_PACKAGES', 'MIP_TEST_CONTEXT'};
 for i = 1:length(keys)
     if isappdata(0, keys{i})
         rmappdata(0, keys{i});

--- a/+mip/test.m
+++ b/+mip/test.m
@@ -60,6 +60,14 @@ if ~exist(scriptPath, 'file')
           'Test script not found: %s', scriptPath);
 end
 
+% Publish the fully-qualified name of the package under test so the test
+% script can identify itself via mip.test.get_fqn() (and from there query
+% mip.build.effective_arch / mip.build.has_mex, e.g. to skip MEX checks on a
+% pure-MATLAB `any` build) without resolving its own ambiguous bare name.
+% Cleared when this function returns, whether the test passes or errors.
+mip.state.key_value_set('MIP_TEST_CONTEXT', r.fqn);
+testCtxCleanup = onCleanup(@() mip.state.key_value_set('MIP_TEST_CONTEXT', {})); %#ok<NASGU>
+
 fprintf('Running test script for "%s": %s\n', displayFqn, testScript);
 originalDir = pwd;
 try

--- a/tests/TestResetCommand.m
+++ b/tests/TestResetCommand.m
@@ -45,12 +45,15 @@ classdef TestResetCommand < matlab.unittest.TestCase
         function testReset_ClearsAllKeyValueStores(testCase)
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgA');
             mip.load('mip-org/core/pkgA', '--sticky');
+            % Stand in for a test context that outlived its `mip test` run.
+            mip.state.key_value_set('MIP_TEST_CONTEXT', 'gh/mip-org/core/pkgA');
 
             mip.reset();
 
             testCase.verifyFalse(isappdata(0, 'MIP_LOADED_PACKAGES'));
             testCase.verifyFalse(isappdata(0, 'MIP_DIRECTLY_LOADED_PACKAGES'));
             testCase.verifyFalse(isappdata(0, 'MIP_STICKY_PACKAGES'));
+            testCase.verifyFalse(isappdata(0, 'MIP_TEST_CONTEXT'));
         end
 
         function testReset_WorksWhenNothingLoaded(testCase)

--- a/tests/TestTestCommand.m
+++ b/tests/TestTestCommand.m
@@ -127,6 +127,73 @@ classdef TestTestCommand < matlab.unittest.TestCase
             testCase.verifyTrue(contains(output, 'Running test script'));
         end
 
+        function testTest_PublishesFqnContext(testCase)
+            % While the script runs, mip.test.get_fqn() names the package
+            % under test, and effective_arch/has_mex resolve it (architecture
+            % 'any' here, so no MEX). The script asserts this and errors --
+            % failing the test -- if the context is wrong.
+            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'ctxpkg');
+            writeTestScript(pkgDir, 'ctxpkg', 'run_test.m', { ...
+                'fqn = mip.test.get_fqn();', ...
+                'assert(~isempty(fqn));', ...
+                'assert(strcmp(mip.build.effective_arch(fqn), ''any''));', ...
+                'assert(~mip.build.has_mex(fqn));', ...
+                'fprintf(''ctx ok\n'');'});
+            output = evalc('mip.test(''mip-org/core/ctxpkg'')');
+            testCase.verifyTrue(contains(output, 'ctx ok'));
+        end
+
+        function testTest_ClearsContextAfterRun(testCase)
+            createTestPackageWithTestScript(testCase.TestRoot, ...
+                'mip-org', 'core', 'donepkg', 'run_test.m', false);
+            mip.test('mip-org/core/donepkg');
+            testCase.verifyError(@() mip.test.get_fqn(), 'mip:test:noContext');
+        end
+
+        function testTest_ClearsContextAfterFailure(testCase)
+            createTestPackageWithTestScript(testCase.TestRoot, ...
+                'mip-org', 'core', 'failctx', 'run_test.m', true);
+            testCase.verifyError(@() mip.test('mip-org/core/failctx'), 'mip:test:failed');
+            testCase.verifyError(@() mip.test.get_fqn(), 'mip:test:noContext');
+        end
+
+        function testTest_GetFqnErrorsOutsideTest(testCase)
+            testCase.verifyError(@() mip.test.get_fqn(), 'mip:test:noContext');
+        end
+
+        function testTest_EffectiveArchExplicitFqn(testCase)
+            % No `mip test` needed: resolve a package's effective arch by name.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'archpkg');
+            testCase.verifyEqual(mip.build.effective_arch('mip-org/core/archpkg'), 'any');
+            testCase.verifyFalse(mip.build.has_mex('mip-org/core/archpkg'));
+        end
+
+        function testTest_ListMexEmptyWhenNoMex(testCase)
+            % A package that ships no MEX -> empty list, has_mex false.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'nomexpkg');
+            testCase.verifyEmpty(mip.build.list_mex('mip-org/core/nomexpkg'));
+            testCase.verifyFalse(mip.build.has_mex('mip-org/core/nomexpkg'));
+        end
+
+        function testTest_ListMexFindsMexFiles(testCase)
+            % A fake MEX (current-arch extension) in the source dir is listed
+            % by base name, and has_mex is then true.
+            pkgDir = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'mexpkg');
+            fid = fopen(fullfile(pkgDir, 'mexpkg', ['foo.' mexext]), 'w');
+            fclose(fid);
+            built = mip.build.list_mex('mip-org/core/mexpkg');
+            testCase.verifyTrue(ismember('foo', built));
+            testCase.verifyTrue(mip.build.has_mex('mip-org/core/mexpkg'));
+        end
+
+        function testTest_BuildHelpersRejectBareName(testCase)
+            % Downstream utilities require an fqn; a bare name is rejected so a
+            % call site can't silently pick the wrong package among duplicates.
+            testCase.verifyError(@() mip.build.list_mex('barepkg'), 'mip:invalidFqn');
+            testCase.verifyError(@() mip.build.has_mex('barepkg'), 'mip:invalidFqn');
+            testCase.verifyError(@() mip.build.effective_arch('barepkg'), 'mip:invalidFqn');
+        end
+
     end
 end
 
@@ -158,6 +225,28 @@ function pkgDir = createTestPackageWithTestScript(rootDir, owner, channel, pkgNa
         fprintf(fid, 'error(''test:intentionalFail'', ''Test intentionally failed'');\n');
     else
         fprintf(fid, 'fprintf(''Tests passed.\\n'');\n');
+    end
+    fclose(fid);
+end
+
+function writeTestScript(pkgDir, pkgName, scriptName, lines)
+%WRITETESTSCRIPT   Point a package's mip.json at a test_script and write its
+% body from a cell array of source lines.
+
+    jsonPath = fullfile(pkgDir, 'mip.json');
+    jsonData = jsondecode(fileread(jsonPath));
+    jsonData.test_script = scriptName;
+    fid = fopen(jsonPath, 'w');
+    fwrite(fid, jsonencode(jsonData));
+    fclose(fid);
+
+    srcDir = fullfile(pkgDir, pkgName);
+    if ~exist(srcDir, 'dir')
+        mkdir(srcDir);
+    end
+    fid = fopen(fullfile(srcDir, scriptName), 'w');
+    for i = 1:numel(lines)
+        fprintf(fid, '%s\n', lines{i});
     end
     fclose(fid);
 end

--- a/tests/helpers/clearMipState.m
+++ b/tests/helpers/clearMipState.m
@@ -1,7 +1,8 @@
 function clearMipState()
 %CLEARMIPSTATE   Clear all mip-related persistent state from appdata.
 
-keys = {'MIP_LOADED_PACKAGES', 'MIP_DIRECTLY_LOADED_PACKAGES', 'MIP_STICKY_PACKAGES'};
+keys = {'MIP_LOADED_PACKAGES', 'MIP_DIRECTLY_LOADED_PACKAGES', ...
+        'MIP_STICKY_PACKAGES', 'MIP_TEST_CONTEXT'};
 for i = 1:length(keys)
     if isappdata(0, keys{i})
         rmappdata(0, keys{i});


### PR DESCRIPTION
## What

Adds three `+build` package-query utilities plus a test-context accessor, so a package's test script can gate its MEX checks on whether the package actually ships MEX.

- `mip.build.list_mex(fqn)` — unique base names of the MEX a package ships for the current arch (scans its own source dir; dependencies excluded).
- `mip.build.has_mex(fqn)` — boolean wrapper over `list_mex`.
- `mip.build.effective_arch(fqn)` — the architecture recorded in the package's `mip.json` (`any` for a pure-MATLAB build), distinct from `mip.build.arch()` (the host arch).
- `mip.test.get_fqn()` — fqn of the package currently under `mip test`.

`mip test` publishes that fqn to `MIP_TEST_CONTEXT` for the duration of the run (cleared via `onCleanup`, pass or fail), and `mip reset` clears it. The `+build` helpers are fqn-only and reject bare names (`mip:invalidFqn`), so a call site can't silently resolve to the wrong package among duplicates.

## Why

A package test (e.g. gptoolbox's) should run its MEX suite only when MEX are present — and skip it on the pure-MATLAB `any` build. Keying off `mip.build.arch()` (the host arch) is wrong for an `any` build produced on a compiled-arch runner: the host arch is concrete, so the MEX sweep would run against a package with no MEX. `has_mex` checks for the files themselves; `list_mex` is the shared primitive a channel's MEX-coverage gate can use too.

## Tests

- `TestTestCommand`: context publish, clear-on-pass and clear-on-failure, `list_mex` empty + finds-files, bare-name rejection across all three helpers, `get_fqn` outside a run.
- `TestResetCommand`: `reset` clears the new key.
- Full local suite green (681/681, remote skipped).