### PR TITLE
Move already-loaded package to most-recent on re-load

### DIFF
--- a/+mip/load.m
+++ b/+mip/load.m
@@ -191,6 +191,13 @@ function matched = loadSingle(packageArg, installIfMissing, stickyPackage, chann
 
     % Check if package is already loaded
     if mip.state.is_loaded(fqn)
+        % Move to the end of MIP_LOADED_PACKAGES so a re-load refreshes
+        % the package's recency. "Most recently loaded" (last in the
+        % list) is the tiebreaker used by bare-name resolution, ambiguous
+        % unload, and the default `mip list` sort, so re-loading must not
+        % be a no-op for ordering.
+        mip.state.key_value_remove('MIP_LOADED_PACKAGES', fqn);
+        mip.state.key_value_append('MIP_LOADED_PACKAGES', fqn);
         % If this is a direct load and the package was previously
         % loaded as a dependency, mark it as direct now
         if isDirect && ~mip.state.is_directly_loaded(fqn)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -451,6 +451,7 @@ Validation happens *before* extraction so that a malicious entry can never write
 3. Check for circular dependencies in the loading stack.
 4. Look up the package directory. If it doesn't exist, raise `mip:packageNotFound`.
 5. If already loaded:
+   - Move the package to the end of `MIP_LOADED_PACKAGES` so it becomes the **most recently loaded** entry. Re-loading an already-loaded package is therefore not an ordering no-op: it refreshes recency, which is the tiebreaker used by bare-name resolution ([§2.4.1](#241-resolving-a-bare-name-among-installed-packages-resolve_bare_name)), ambiguous unload ([§5.2](#52-bare-name-disambiguation-for-unload)), and the default `mip list` sort ([§9.1](#91-mip-list)).
    - If this is a direct load and the package was previously loaded as a dependency, promote it to "directly loaded".
    - If this is a direct load, also mark the package as directly installed (idempotent; promotes a previously transitive install).
    - If `--sticky` is specified, add to sticky packages.

--- a/tests/TestLoadPackage.m
+++ b/tests/TestLoadPackage.m
@@ -50,6 +50,24 @@ classdef TestLoadPackage < matlab.unittest.TestCase
             testCase.verifyTrue(mip.state.is_loaded('mip-org/core/testpkg'));
         end
 
+        function testLoadPackage_AlreadyLoaded_MovesToMostRecent(testCase)
+            % Re-loading an already-loaded package must move it to the end
+            % of MIP_LOADED_PACKAGES (most recently loaded), not be a no-op.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgA');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgB');
+            mip.load('mip-org/core/pkgA');
+            mip.load('mip-org/core/pkgB');
+            loaded = mip.state.key_value_get('MIP_LOADED_PACKAGES');
+            testCase.verifyEqual(loaded{end}, 'gh/mip-org/core/pkgB');
+
+            % Re-load pkgA: it should now be the most recent.
+            mip.load('mip-org/core/pkgA');
+            loaded = mip.state.key_value_get('MIP_LOADED_PACKAGES');
+            testCase.verifyEqual(loaded{end}, 'gh/mip-org/core/pkgA');
+            % No duplicate entry was introduced.
+            testCase.verifyEqual(sum(strcmp(loaded, 'gh/mip-org/core/pkgA')), 1);
+        end
+
         function testLoadPackage_WithStickyFlag(testCase)
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'testpkg');
             mip.load('mip-org/core/testpkg', '--sticky');


### PR DESCRIPTION
`mip load <pkg>` on an already-loaded package previously left its position in `MIP_LOADED_PACKAGES` unchanged. Since "most recently loaded" (last in the list) is the tiebreaker for bare-name resolution, ambiguous unload, and the default `mip list` sort, re-loading should refresh recency rather than be an ordering no-op.

This moves the package to the end of `MIP_LOADED_PACKAGES` in the already-loaded branch of `load.m`, updates the spec (§4.1 step 5), and adds a test.