### PR TITLE
Auto-bundle MEX runtime libraries after compile

### DIFF
--- a/+mip/+build/bundle_mex_libs.m
+++ b/+mip/+build/bundle_mex_libs.m
@@ -1,0 +1,28 @@
+function bundle_mex_libs(pkgDir)
+%BUNDLE_MEX_LIBS   Vendor runtime-library dependencies for compiled MEX files.
+%
+% After a package's compile script runs, each MEX file it produced may depend
+% on non-system shared libraries (e.g. libgfortran, libgomp) that are not
+% guaranteed to exist on end-user machines. This scans <pkgDir> (recursively)
+% for compiled MEX files and bundles those dependencies next to each one so the
+% packaged result is self-contained.
+%
+% The platform-specific bundling is delegated to `bundle_runtime_libs`, which
+% is provided by the channel build environment -- the build workflow adds
+% mip_channel_tools/scripts to the MATLAB path. When that function is not on
+% the path (e.g. a standalone `mip bundle` outside a channel build), this is a
+% no-op, so the package manager carries no hard dependency on the channel
+% tooling. This is the counterpart to the pre-compile strip_prebuilt_binaries
+% step: strip stale binaries before, vendor freshly built ones after.
+
+if exist('bundle_runtime_libs', 'file') ~= 2
+    return
+end
+
+mexFiles = dir(fullfile(pkgDir, '**', '*.mex*'));
+mexFiles = mexFiles(~[mexFiles.isdir]);
+for i = 1:numel(mexFiles)
+    bundle_runtime_libs(fullfile(mexFiles(i).folder, mexFiles(i).name));
+end
+
+end

--- a/+mip/+build/prepare_package.m
+++ b/+mip/+build/prepare_package.m
@@ -84,6 +84,10 @@ if isfield(resolvedConfig, 'compile_script') && ...
         ~isempty(resolvedConfig.compile_script)
     fprintf('Compiling...\n');
     mip.build.run_compile(pkgSubdir, resolvedConfig.compile_script);
+    % Vendor runtime-library deps (libgfortran, libgomp, ...) next to any
+    % freshly built MEX files so the bundle is self-contained. No-op outside
+    % a channel build (see mip.build.bundle_mex_libs).
+    mip.build.bundle_mex_libs(pkgSubdir);
 end
 
 % Create mip.json


### PR DESCRIPTION
`prepare_package` now vendors each compiled MEX file's runtime-library dependencies (e.g. `libgfortran`, `libgomp`) automatically after the compile script runs, via the new `mip.build.bundle_mex_libs`. Previously each package's `compile.m` had to discover its MEX files and call the bundler itself.

The platform-specific work is delegated to `bundle_runtime_libs`, which the channel build environment puts on the MATLAB path (`mip_channel_tools/scripts`). When that function is absent — e.g. a standalone `mip bundle` outside a channel build — `bundle_mex_libs` is a no-op, so the package manager keeps no hard dependency on the channel tooling. This is the post-compile counterpart to the existing pre-compile `strip_prebuilt_binaries` step.

Channel `compile.m` scripts that currently call `bundle_runtime_libs` directly can drop those calls (separate channel-repo changes).