### PR TITLE
Skip MATLAB BLAS/LAPACK libs when bundling MEX runtime deps

### DIFF
--- a/+mip/+build/bundle_runtime_libs.m
+++ b/+mip/+build/bundle_runtime_libs.m
@@ -60,7 +60,7 @@ for i = 1:numel(m)
     resolved(m{i}{1}) = m{i}{2};
 end
 
-skip = linux_skip_set();
+skip = mip.build.runtime_skip_libs();
 bundled = false;
 for i = 1:numel(needed)
     so = needed{i};
@@ -89,7 +89,7 @@ function bundle_macos(mexFile, outDir)
 
 [~, out] = system(sprintf('otool -L "%s"', mexFile));
 lines = splitlines(out);
-skipPats = macos_skip_patterns();
+[~, skipPats] = mip.build.runtime_skip_libs();
 bundled = false;
 % Line 1 is "<mexFile>:" — skip.
 for i = 2:numel(lines)
@@ -120,32 +120,4 @@ if bundled
     end
 end
 
-end
-
-% -------------------------------------------------------------------------
-function s = linux_skip_set()
-% SONAMEs we never bundle: OS-guaranteed system libs, and libs MATLAB
-% resolves at runtime via its own LD_LIBRARY_PATH (sys/os/glnxa64).
-%
-% libgfortran.so.5 is skipped: Linux MATLAB ships it, it is on MATLAB's
-% LD_LIBRARY_PATH (searched before the MEX's $ORIGIN RPATH), and the build
-% toolchain is pinned so our symbol requirements stay within MATLAB's copy.
-% libgomp is deliberately NOT here: Linux MATLAB does NOT ship it, so its
-% bundled copy is load-bearing.
-s = { ...
-    'linux-vdso.so.1', 'ld-linux-x86-64.so.2', ...
-    'libc.so.6', 'libm.so.6', 'libpthread.so.0', 'libdl.so.2', 'librt.so.1', ...
-    'libstdc++.so.6', 'libgcc_s.so.1', 'libgfortran.so.5', ...
-    'libmx.so', 'libmex.so', 'libmat.so', ...
-    'libMatlabDataArray.so', 'libMatlabEngine.so'};
-end
-
-function s = macos_skip_patterns()
-% Path prefixes we never bundle: OS framework / system libs, and any dylib
-% MATLAB resolves via @rpath in its own rpath chain.
-s = { ...
-    '/usr/lib/', ...
-    '/System/Library/', ...
-    '@rpath/libmx.', '@rpath/libmex.', '@rpath/libmat.', ...
-    '@rpath/libMatlabDataArray.', '@rpath/libMatlabEngine.'};
 end

--- a/+mip/+build/runtime_skip_libs.m
+++ b/+mip/+build/runtime_skip_libs.m
@@ -1,0 +1,39 @@
+function [linuxSonames, macPrefixes] = runtime_skip_libs()
+%RUNTIME_SKIP_LIBS   Libraries bundle_runtime_libs must never vendor.
+%
+% Returns the deny-lists used when scanning a MEX's dynamic dependencies:
+%   linuxSonames - exact SONAMEs (Linux NEEDED entries) to skip.
+%   macPrefixes  - install-path prefixes (macOS LC_LOAD_DYLIB) to skip.
+%
+% Two classes of library are skipped:
+%   1. OS-guaranteed system libraries (libc, libm, the loader, libstdc++, ...).
+%   2. Libraries MATLAB itself provides and resolves at runtime via its own
+%      library path -- libmx/libmex/libmat/..., and the MATLAB BLAS/LAPACK
+%      (libmwblas/libmwlapack). These must NOT be vendored: on Linux they are
+%      simply unresolvable at bundle time (MATLAB clears them off the loader
+%      path), and on macOS their LC_LOAD_DYLIB is `@rpath/libmwblas.dylib`,
+%      which has no on-disk path to copy -- so bundling them would either warn
+%      and skip (Linux) or hard-fail the copy (macOS). MATLAB always ships
+%      them, so the MEX finds them at load time regardless.
+%
+% libgfortran.so.5 is skipped on Linux: MATLAB ships it on its own loader path
+% (searched before the MEX's $ORIGIN rpath) and the build toolchain is pinned
+% so our symbol requirements stay within MATLAB's copy. libgomp is deliberately
+% NOT skipped: Linux MATLAB does not ship it, so its bundled copy is load-bearing.
+
+linuxSonames = { ...
+    'linux-vdso.so.1', 'ld-linux-x86-64.so.2', ...
+    'libc.so.6', 'libm.so.6', 'libpthread.so.0', 'libdl.so.2', 'librt.so.1', ...
+    'libstdc++.so.6', 'libgcc_s.so.1', 'libgfortran.so.5', ...
+    'libmx.so', 'libmex.so', 'libmat.so', ...
+    'libmwblas.so', 'libmwlapack.so', ...
+    'libMatlabDataArray.so', 'libMatlabEngine.so'};
+
+macPrefixes = { ...
+    '/usr/lib/', ...
+    '/System/Library/', ...
+    '@rpath/libmx.', '@rpath/libmex.', '@rpath/libmat.', ...
+    '@rpath/libmwblas.', '@rpath/libmwlapack.', ...
+    '@rpath/libMatlabDataArray.', '@rpath/libMatlabEngine.'};
+
+end

--- a/tests/TestRuntimeSkipLibs.m
+++ b/tests/TestRuntimeSkipLibs.m
@@ -1,0 +1,52 @@
+classdef TestRuntimeSkipLibs < matlab.unittest.TestCase
+%TESTRUNTIMESKIPLIBS   Tests for mip.build.runtime_skip_libs.
+%
+% The deny-lists decide which of a MEX's dynamic dependencies
+% bundle_runtime_libs vendors. MATLAB-provided libraries (libmx/libmex and
+% the MATLAB BLAS/LAPACK) must be skipped: vendoring libmwblas/libmwlapack
+% warns-and-skips on Linux but hard-fails the copy on macOS (their
+% LC_LOAD_DYLIB is @rpath/libmwblas.dylib, with no on-disk path).
+
+    methods (Test)
+        function returnsBothLists(testCase)
+            [linuxSonames, macPrefixes] = mip.build.runtime_skip_libs();
+            testCase.verifyClass(linuxSonames, 'cell');
+            testCase.verifyClass(macPrefixes, 'cell');
+            testCase.verifyNotEmpty(linuxSonames);
+            testCase.verifyNotEmpty(macPrefixes);
+        end
+
+        function skipsMatlabBlasLapackLinux(testCase)
+            linuxSonames = mip.build.runtime_skip_libs();
+            testCase.verifyTrue(ismember('libmwblas.so', linuxSonames));
+            testCase.verifyTrue(ismember('libmwlapack.so', linuxSonames));
+        end
+
+        function skipsMatlabBlasLapackMacos(testCase)
+            [~, macPrefixes] = mip.build.runtime_skip_libs();
+            testCase.verifyTrue(ismember('@rpath/libmwblas.', macPrefixes));
+            testCase.verifyTrue(ismember('@rpath/libmwlapack.', macPrefixes));
+        end
+
+        function stillSkipsCoreMatlabAndSystemLibs(testCase)
+            % Guard against accidental removal of the pre-existing entries.
+            [linuxSonames, macPrefixes] = mip.build.runtime_skip_libs();
+            for so = {'libc.so.6', 'libstdc++.so.6', 'libgfortran.so.5', ...
+                      'libmx.so', 'libmex.so'}
+                testCase.verifyTrue(ismember(so{1}, linuxSonames), ...
+                    sprintf('expected %s in Linux skip list', so{1}));
+            end
+            for p = {'/usr/lib/', '@rpath/libmx.', '@rpath/libmex.'}
+                testCase.verifyTrue(ismember(p{1}, macPrefixes), ...
+                    sprintf('expected %s in macOS skip prefixes', p{1}));
+            end
+        end
+
+        function doesNotSkipLoadBearingLibgomp(testCase)
+            % libgomp is intentionally NOT skipped on Linux (MATLAB does not
+            % ship it, so the bundled copy is load-bearing).
+            linuxSonames = mip.build.runtime_skip_libs();
+            testCase.verifyFalse(ismember('libgomp.so.1', linuxSonames));
+        end
+    end
+end


### PR DESCRIPTION
Extract the `bundle_runtime_libs` skip-lists into a shared `mip.build.runtime_skip_libs` helper and add `libmwblas`/`libmwlapack` to both the Linux SONAME list and the macOS install-path prefixes.

MATLAB ships and resolves these at runtime (like `libmx`/`libmex`), so they must never be vendored. On macOS their `LC_LOAD_DYLIB` is `@rpath/libmwblas.dylib`, which has no on-disk path, so the bundler would hard-fail trying to copy them — this broke any package that links MATLAB's BLAS (e.g. the new `fmm3dbie` package). Adds `tests/TestRuntimeSkipLibs.m`.