### PR TITLE
load: move re-loaded package to most-recent in MIP_DIRECTLY_LOADED_PACKAGES too

### DIFF
--- a/+mip/load.m
+++ b/+mip/load.m
@@ -198,16 +198,22 @@ function matched = loadSingle(packageArg, installIfMissing, stickyPackage, chann
         % be a no-op for ordering.
         mip.state.key_value_remove('MIP_LOADED_PACKAGES', fqn);
         mip.state.key_value_append('MIP_LOADED_PACKAGES', fqn);
-        % If this is a direct load and the package was previously
-        % loaded as a dependency, mark it as direct now
-        if isDirect && ~mip.state.is_directly_loaded(fqn)
+        % A direct re-load refreshes recency in MIP_DIRECTLY_LOADED_PACKAGES
+        % the same way (move to end), and promotes the package if it was
+        % previously loaded only as a transitive dependency. A transitive
+        % re-load (isDirect false) leaves the directly-loaded list untouched.
+        if isDirect
+            wasDirect = mip.state.is_directly_loaded(fqn);
+            mip.state.key_value_remove('MIP_DIRECTLY_LOADED_PACKAGES', fqn);
             mip.state.key_value_append('MIP_DIRECTLY_LOADED_PACKAGES', fqn);
-            fprintf('Package "%s" is already loaded (now marked as direct)\n', displayFqn);
+            mip.state.add_directly_installed(fqn);
+            if ~wasDirect
+                fprintf('Package "%s" is already loaded (now marked as direct)\n', displayFqn);
+            else
+                fprintf('Package "%s" is already loaded\n', displayFqn);
+            end
         else
             fprintf('Package "%s" is already loaded\n', displayFqn);
-        end
-        if isDirect
-            mip.state.add_directly_installed(fqn);
         end
         % If --sticky was specified, add to sticky packages
         if stickyPackage

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -452,7 +452,7 @@ Validation happens *before* extraction so that a malicious entry can never write
 4. Look up the package directory. If it doesn't exist, raise `mip:packageNotFound`.
 5. If already loaded:
    - Move the package to the end of `MIP_LOADED_PACKAGES` so it becomes the **most recently loaded** entry. Re-loading an already-loaded package is therefore not an ordering no-op: it refreshes recency, which is the tiebreaker used by bare-name resolution ([§2.4.1](#241-resolving-a-bare-name-among-installed-packages-resolve_bare_name)), ambiguous unload ([§5.2](#52-bare-name-disambiguation-for-unload)), and the default `mip list` sort ([§9.1](#91-mip-list)).
-   - If this is a direct load and the package was previously loaded as a dependency, promote it to "directly loaded".
+   - If this is a direct load, move the package to the end of `MIP_DIRECTLY_LOADED_PACKAGES` as well — promoting it if it was previously loaded only as a dependency — so that list's recency tracks `MIP_LOADED_PACKAGES`. A transitive re-load (`--transitive`) leaves `MIP_DIRECTLY_LOADED_PACKAGES` untouched.
    - If this is a direct load, also mark the package as directly installed (idempotent; promotes a previously transitive install).
    - If `--sticky` is specified, add to sticky packages.
    - Return early.

--- a/tests/TestLoadPackage.m
+++ b/tests/TestLoadPackage.m
@@ -68,6 +68,52 @@ classdef TestLoadPackage < matlab.unittest.TestCase
             testCase.verifyEqual(sum(strcmp(loaded, 'gh/mip-org/core/pkgA')), 1);
         end
 
+        function testLoadPackage_AlreadyLoaded_MovesDirectlyLoadedToMostRecent(testCase)
+            % A direct re-load must also move the package to the end of
+            % MIP_DIRECTLY_LOADED_PACKAGES so that list's recency tracks
+            % MIP_LOADED_PACKAGES (issue #267).
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgA');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgB');
+            mip.load('mip-org/core/pkgA');
+            mip.load('mip-org/core/pkgB');
+            direct = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
+            testCase.verifyEqual(direct{end}, 'gh/mip-org/core/pkgB');
+
+            % Re-load pkgA directly: it should now be the most recent.
+            mip.load('mip-org/core/pkgA');
+            direct = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
+            testCase.verifyEqual(direct{end}, 'gh/mip-org/core/pkgA');
+            % No duplicate entry was introduced.
+            testCase.verifyEqual(sum(strcmp(direct, 'gh/mip-org/core/pkgA')), 1);
+        end
+
+        function testLoadPackage_TransitiveReloadDoesNotReorderDirectlyLoaded(testCase)
+            % A transitive re-load (isDirect false) must move the package to
+            % the end of MIP_LOADED_PACKAGES but must NOT reorder
+            % MIP_DIRECTLY_LOADED_PACKAGES. The --transitive flag forces
+            % re-entry into loadSingle for an already-loaded package; the
+            % normal deps loop short-circuits on is_loaded and would never
+            % exercise this branch otherwise.
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgA');
+            createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgB');
+            mip.load('mip-org/core/pkgA');
+            mip.load('mip-org/core/pkgB');
+            testCase.verifyEqual( ...
+                mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES'), ...
+                {'gh/mip-org/core/pkgA', 'gh/mip-org/core/pkgB'});
+
+            % Force a transitive re-load of pkgA (already directly loaded).
+            mip.load('mip-org/core/pkgA', '--transitive');
+
+            loaded = mip.state.key_value_get('MIP_LOADED_PACKAGES');
+            direct = mip.state.key_value_get('MIP_DIRECTLY_LOADED_PACKAGES');
+            % MIP_LOADED_PACKAGES: pkgA moved to the end.
+            testCase.verifyEqual(loaded{end}, 'gh/mip-org/core/pkgA');
+            % MIP_DIRECTLY_LOADED_PACKAGES: order unchanged -- pkgB still last.
+            testCase.verifyEqual(direct{end}, 'gh/mip-org/core/pkgB');
+            testCase.verifyTrue(ismember('gh/mip-org/core/pkgA', direct));
+        end
+
         function testLoadPackage_WithStickyFlag(testCase)
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'testpkg');
             mip.load('mip-org/core/testpkg', '--sticky');


### PR DESCRIPTION
## Summary
Completes issue #267. `c6126a2` ("Move already-loaded package to most-recent on re-load") refreshes recency in `MIP_LOADED_PACKAGES` on a re-load, but leaves `MIP_DIRECTLY_LOADED_PACKAGES` unchanged when the package is already directly loaded. Issue #267's title explicitly asks for **both** lists to track recency.

- On a **direct** re-load, `+mip/load.m` now also moves the FQN to the end of `MIP_DIRECTLY_LOADED_PACKAGES` (inline `key_value_remove` + `key_value_append`, matching the existing `MIP_LOADED_PACKAGES` idiom). This promotes a package that was previously loaded only as a transitive dependency, and reorders one that was already direct.
- A **transitive** re-load (`--transitive`, `isDirect == false`) still leaves `MIP_DIRECTLY_LOADED_PACKAGES` untouched.
- The "now marked as direct" vs "is already loaded" messaging is preserved exactly (via a `wasDirect` snapshot taken before the move).
- `docs/specification.md` §4 step 5 updated to match.

## Tests
- `TestLoadPackage_AlreadyLoaded_MovesDirectlyLoadedToMostRecent` — direct re-load moves to end of the direct list, no duplicate.
- `TestLoadPackage_TransitiveReloadDoesNotReorderDirectlyLoaded` — transitive re-load moves `MIP_LOADED_PACKAGES` but not the direct list.
- Full `TestLoadPackage` (27/27) and `TestPackageDiscovery`/`TestResetCommand`/`TestUnloadPackage` (56/56) pass locally on R2025b.

## Context
This supersedes the stale PR #270, whose `MIP_LOADED_PACKAGES` half was independently implemented in `c6126a2`. This PR carries the remaining unimplemented half (the `MIP_DIRECTLY_LOADED_PACKAGES` reorder) without #270's `key_value_move_to_end` helper, keeping the change minimal.

Closes #267.