### PR TITLE
read_mip_yaml: read mip.yaml as UTF-8

### DIFF
--- a/+mip/+config/read_mip_yaml.m
+++ b/+mip/+config/read_mip_yaml.m
@@ -17,7 +17,13 @@ if ~exist(mipYamlPath, 'file')
 end
 
 try
-    fid = fopen(mipYamlPath, 'r');
+    % Open as UTF-8 explicitly. mip.yaml is UTF-8, but MATLAB's default
+    % file encoding is platform-dependent (UTF-8 on Linux/macOS, the locale
+    % code page — typically windows-1252 — on Windows). Without this, a
+    % non-ASCII byte such as an em-dash (U+2014) in e.g. `description:` is
+    % decoded as cp1252 on Windows and mangled into mojibake, which then
+    % differs from the channel's mip.yaml and retriggers the build forever.
+    fid = fopen(mipYamlPath, 'r', 'n', 'UTF-8');
     if fid == -1
         error('mip:fileError', 'Could not open file: %s', mipYamlPath);
     end


### PR DESCRIPTION
## Problem

The scheduled rebuild was retriggering some Windows package builds every morning even though nothing changed (e.g. `sedumi` windows_x86_64).

Root cause is an encoding bug on the read side. `read_mip_yaml` opened `mip.yaml` with `fopen(path, 'r')` — no encoding — so it used MATLAB's platform default: UTF-8 on Linux/macOS, but the locale code page (windows-1252) on Windows. A UTF-8 `mip.yaml` with a non-ASCII byte, such as the em-dash in `description:`, was decoded as cp1252 on Windows and turned into mojibake (`—` → `â€"`, i.e. `â€”`).

That mojibake got written into the published `mip.json` on Windows builds (linux/macos were fine). The daily `mip-channel scheduled-check` compares the published `mip.json` metadata against the channel `mip.yaml`; the corrupted `description` never matched, so it dispatched a rebuild — which re-wrote the same mojibake and never converged.

## Fix

Open `mip.yaml` as UTF-8 explicitly so reads are byte-identical on every platform:

```matlab
fid = fopen(mipYamlPath, 'r', 'n', 'UTF-8');
```

The write path is unaffected — `jsonencode` escapes non-ASCII to ASCII `\uXXXX`, so the corruption only ever happened on read.

## Impact

Once this is on `main`, the next scheduled run rebuilds the affected Windows packages (`gptoolbox`, `jigsaw_matlab`, `sedumi`, `spm`) one final time, writing a correct `mip.json`, after which they stop retriggering. No manual rebuild needed.