### PR TITLE
Add regression test for UTF-8 mip.yaml reading

### DIFF
--- a/tests/TestReadMipYaml.m
+++ b/tests/TestReadMipYaml.m
@@ -162,6 +162,26 @@ classdef TestReadMipYaml < matlab.unittest.TestCase
             testCase.verifyEqual(cfg.dependencies, {});
         end
 
+        function testReadYamlUtf8NonAsciiDescription(testCase)
+            % Regression: a non-ASCII description (em-dash, U+2014) must
+            % round-trip as UTF-8 on every platform. On Windows, fopen
+            % without an explicit UTF-8 encoding decoded the bytes as
+            % windows-1252, expanding the em-dash into three characters
+            % ('â€"') and breaking the scheduled-build metadata comparison.
+            emDash = char(8212);  % U+2014 EM DASH
+            content = ['name: mypkg' newline ...
+                       'version: "1.0.0"' newline ...
+                       'description: "A ' emDash ' B"' newline];
+            % Write deterministic UTF-8 bytes, independent of the platform's
+            % default file-write encoding.
+            fid = fopen(fullfile(testCase.TestDir, 'mip.yaml'), 'w');
+            fwrite(fid, unicode2native(content, 'UTF-8'), 'uint8');
+            fclose(fid);
+
+            cfg = mip.config.read_mip_yaml(testCase.TestDir);
+            testCase.verifyEqual(cfg.description, ['A ' emDash ' B']);
+        end
+
     end
 end
 


### PR DESCRIPTION
Follow-up to #295, which fixed read_mip_yaml to open mip.yaml as UTF-8 but shipped without a test.

This adds `testReadYamlUtf8NonAsciiDescription`: it writes a mip.yaml whose `description` contains an em-dash (U+2014) as deterministic UTF-8 bytes and asserts read_mip_yaml returns the single em-dash rather than the windows-1252 mojibake `â€"`. Guards against the windows-only false rebuild (sedumi, spm) regressing.