### PR TITLE
read_mip_yaml: decode mip.yaml as UTF-8 via native2unicode

### DIFF
--- a/+mip/+config/read_mip_yaml.m
+++ b/+mip/+config/read_mip_yaml.m
@@ -17,18 +17,21 @@ if ~exist(mipYamlPath, 'file')
 end
 
 try
-    % Open as UTF-8 explicitly. mip.yaml is UTF-8, but MATLAB's default
-    % file encoding is platform-dependent (UTF-8 on Linux/macOS, the locale
-    % code page — typically windows-1252 — on Windows). Without this, a
-    % non-ASCII byte such as an em-dash (U+2014) in e.g. `description:` is
-    % decoded as cp1252 on Windows and mangled into mojibake, which then
-    % differs from the channel's mip.yaml and retriggers the build forever.
-    fid = fopen(mipYamlPath, 'r', 'n', 'UTF-8');
+    % Read raw bytes and decode as UTF-8 explicitly. mip.yaml is UTF-8, but
+    % fread('*char') decodes using MATLAB's platform-default encoding and
+    % IGNORES the encoding passed to fopen on some releases (e.g. R2023a on
+    % Windows, where the default is windows-1252). That mangles non-ASCII
+    % metadata such as an em-dash (U+2014) in `description:` into mojibake
+    % ('â€"'), so the bundled .mip.json stops matching the channel mip.yaml
+    % and the scheduled build rebuilds the package forever. native2unicode
+    % does the decode in-process, independent of the platform default.
+    fid = fopen(mipYamlPath, 'r');
     if fid == -1
         error('mip:fileError', 'Could not open file: %s', mipYamlPath);
     end
-    yamlText = fread(fid, '*char')';
+    rawBytes = fread(fid, Inf, '*uint8')';
     fclose(fid);
+    yamlText = native2unicode(rawBytes, 'UTF-8');
     mipConfig = mip.parse.parse_yaml(yamlText);
 catch ME
     error('mip:yamlParseFailed', ...

--- a/tests/TestReadMipYaml.m
+++ b/tests/TestReadMipYaml.m
@@ -164,19 +164,30 @@ classdef TestReadMipYaml < matlab.unittest.TestCase
 
         function testReadYamlUtf8NonAsciiDescription(testCase)
             % Regression: a non-ASCII description (em-dash, U+2014) must
-            % round-trip as UTF-8 on every platform. On Windows, fopen
-            % without an explicit UTF-8 encoding decoded the bytes as
-            % windows-1252, expanding the em-dash into three characters
-            % ('â€"') and breaking the scheduled-build metadata comparison.
+            % round-trip as UTF-8 on every platform and MATLAB release.
+            % read_mip_yaml must decode the bytes itself rather than rely on
+            % the platform default, because fread('*char') ignores fopen's
+            % encoding on some releases (R2023a on Windows defaults to
+            % windows-1252), mangling the em-dash into mojibake ('â€"') and
+            % breaking the scheduled-build metadata comparison.
             emDash = char(8212);  % U+2014 EM DASH
             content = ['name: mypkg' newline ...
                        'version: "1.0.0"' newline ...
                        'description: "A ' emDash ' B"' newline];
             % Write deterministic UTF-8 bytes, independent of the platform's
             % default file-write encoding.
+            utf8Bytes = unicode2native(content, 'UTF-8');
             fid = fopen(fullfile(testCase.TestDir, 'mip.yaml'), 'w');
-            fwrite(fid, unicode2native(content, 'UTF-8'), 'uint8');
+            fwrite(fid, utf8Bytes, 'uint8');
             fclose(fid);
+
+            % Sanity-check that this content actually exercises the bug:
+            % decoding the same bytes as windows-1252 (what the broken
+            % Windows read did) must corrupt the single em-dash into the
+            % three-character mojibake, so a correct decode is a real signal.
+            mojibake = native2unicode(utf8Bytes, 'windows-1252');
+            testCase.verifyTrue(contains(mojibake, ['A ' char([226 8364 8221]) ' B']), ...
+                'test fixture should reproduce the windows-1252 mojibake');
 
             cfg = mip.config.read_mip_yaml(testCase.TestDir);
             testCase.verifyEqual(cfg.description, ['A ' emDash ' B']);


### PR DESCRIPTION
#295 set a UTF-8 encoding on `fopen` but kept `fread(fid, '*char')`. That does **not** fix the Windows build: a windows_x86_64 rebuild on mip@main (verified: build checked out `af22298`, which includes #295) still stored the em-dash mojibake `â€"` in its `.mip.json`, so sedumi/spm/jigsaw_matlab keep retriggering.

Root cause: `fread('*char')` ignores fopen's `encodingScheme` on some MATLAB releases — the Windows build uses **R2023a**, whose default is windows-1252 — and decodes with the platform default regardless. Linux/macOS escape it only because their default is already UTF-8. (On R2025b `fread` does honor the arg, which is why a local round-trip test passed and masked the problem.)

Fix: read raw bytes with `fread('*uint8')` and decode with `native2unicode(...,'UTF-8')`, which decodes in-process independent of the platform default. The test now also asserts the fixture reproduces the windows-1252 mojibake, so it genuinely exercises the corruption.

Note: R2025b can't reproduce R2023a's `fread` behavior, so the definitive check is a windows_x86_64 rebuild after merge — the published `.mip.json` description should contain the em-dash, not `â€"`.