### PR TITLE
Revert read_mip_yaml UTF-8 changes (#295, #297) — wrong diagnosis

### DIFF
--- a/+mip/+config/read_mip_yaml.m
+++ b/+mip/+config/read_mip_yaml.m
@@ -17,21 +17,12 @@ if ~exist(mipYamlPath, 'file')
 end
 
 try
-    % Read raw bytes and decode as UTF-8 explicitly. mip.yaml is UTF-8, but
-    % fread('*char') decodes using MATLAB's platform-default encoding and
-    % IGNORES the encoding passed to fopen on some releases (e.g. R2023a on
-    % Windows, where the default is windows-1252). That mangles non-ASCII
-    % metadata such as an em-dash (U+2014) in `description:` into mojibake
-    % ('â€"'), so the bundled .mip.json stops matching the channel mip.yaml
-    % and the scheduled build rebuilds the package forever. native2unicode
-    % does the decode in-process, independent of the platform default.
     fid = fopen(mipYamlPath, 'r');
     if fid == -1
         error('mip:fileError', 'Could not open file: %s', mipYamlPath);
     end
-    rawBytes = fread(fid, Inf, '*uint8')';
+    yamlText = fread(fid, '*char')';
     fclose(fid);
-    yamlText = native2unicode(rawBytes, 'UTF-8');
     mipConfig = mip.parse.parse_yaml(yamlText);
 catch ME
     error('mip:yamlParseFailed', ...

--- a/tests/TestReadMipYaml.m
+++ b/tests/TestReadMipYaml.m
@@ -162,37 +162,6 @@ classdef TestReadMipYaml < matlab.unittest.TestCase
             testCase.verifyEqual(cfg.dependencies, {});
         end
 
-        function testReadYamlUtf8NonAsciiDescription(testCase)
-            % Regression: a non-ASCII description (em-dash, U+2014) must
-            % round-trip as UTF-8 on every platform and MATLAB release.
-            % read_mip_yaml must decode the bytes itself rather than rely on
-            % the platform default, because fread('*char') ignores fopen's
-            % encoding on some releases (R2023a on Windows defaults to
-            % windows-1252), mangling the em-dash into mojibake ('â€"') and
-            % breaking the scheduled-build metadata comparison.
-            emDash = char(8212);  % U+2014 EM DASH
-            content = ['name: mypkg' newline ...
-                       'version: "1.0.0"' newline ...
-                       'description: "A ' emDash ' B"' newline];
-            % Write deterministic UTF-8 bytes, independent of the platform's
-            % default file-write encoding.
-            utf8Bytes = unicode2native(content, 'UTF-8');
-            fid = fopen(fullfile(testCase.TestDir, 'mip.yaml'), 'w');
-            fwrite(fid, utf8Bytes, 'uint8');
-            fclose(fid);
-
-            % Sanity-check that this content actually exercises the bug:
-            % decoding the same bytes as windows-1252 (what the broken
-            % Windows read did) must corrupt the single em-dash into the
-            % three-character mojibake, so a correct decode is a real signal.
-            mojibake = native2unicode(utf8Bytes, 'windows-1252');
-            testCase.verifyTrue(contains(mojibake, ['A ' char([226 8364 8221]) ' B']), ...
-                'test fixture should reproduce the windows-1252 mojibake');
-
-            cfg = mip.config.read_mip_yaml(testCase.TestDir);
-            testCase.verifyEqual(cfg.description, ['A ' emDash ' B']);
-        end
-
     end
 end
 


### PR DESCRIPTION
PRs #295 and #297 changed `read_mip_yaml` to read mip.yaml as UTF-8, on the theory that MATLAB on the Windows build runner mangled the em-dash. A diagnostic on a real **Windows R2023a** runner disproved that:

- R2023a's default encoding is **UTF-8**; every read method (including the original `fread('*char')`) returns the em-dash correctly, and MATLAB's `jsonencode`+`fwrite` produce correct UTF-8 bytes.
- The real corruption is Python's `open()` defaulting to windows-1252 when the `.mip.json` is re-read to inject `mhl_sha256` on the Windows upload runner — fixed in mip-org/mip_channel_tools#11.

So these read changes are unnecessary and their comments are factually wrong. This restores the original read and removes the misleading comment and test.