### PR TITLE
Fix: mip update --no-compile mip must error instead of self-updating

### DIFF
--- a/+mip/update.m
+++ b/+mip/update.m
@@ -118,16 +118,17 @@ function update(varargin)
         items{i} = classifyArg(args{i});
     end
 
-    % --no-compile only applies to editable local installs. Validate
-    % across all actionable items before any destructive action. The mip
-    % self-update (kind 'self-update') is never an editable local install,
-    % so it must be rejected here too rather than silently hot-swapping mip.
+    % --no-compile only applies to editable local installs. Validate every
+    % actionable item before any destructive action; the mip self-update is
+    % never an editable local install, so it is rejected here rather than
+    % falling through to the destructive updateSelf hot-swap. Restricting to
+    % the actionable kinds matters: the skip kinds carry no .pkg (pin-skip)
+    % or are not going to be built anyway (no-source-skip), so they must not
+    % gate --no-compile.
     if noCompile
         for i = 1:length(items)
             it = items{i};
-            isEditableLocal = strcmp(it.kind, 'process') && it.pkg.isLocal && it.pkg.editable;
-            isActionable = ismember(it.kind, {'process', 'self-update'});
-            if isActionable && ~isEditableLocal
+            if any(strcmp(it.kind, {'process', 'self-update'})) && ~(it.pkg.isLocal && it.pkg.editable)
                 error('mip:update:noCompileRequiresEditable', ...
                       '--no-compile can only be used when all updated packages are editable local installs (offending package: "%s").', ...
                       mip.parse.display_fqn(it.pkg.fqn));

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -119,11 +119,15 @@ function update(varargin)
     end
 
     % --no-compile only applies to editable local installs. Validate
-    % across all "process" items before any destructive action.
+    % across all actionable items before any destructive action. The mip
+    % self-update (kind 'self-update') is never an editable local install,
+    % so it must be rejected here too rather than silently hot-swapping mip.
     if noCompile
         for i = 1:length(items)
             it = items{i};
-            if strcmp(it.kind, 'process') && ~(it.pkg.isLocal && it.pkg.editable)
+            isEditableLocal = strcmp(it.kind, 'process') && it.pkg.isLocal && it.pkg.editable;
+            isActionable = ismember(it.kind, {'process', 'self-update'});
+            if isActionable && ~isEditableLocal
                 error('mip:update:noCompileRequiresEditable', ...
                       '--no-compile can only be used when all updated packages are editable local installs (offending package: "%s").', ...
                       mip.parse.display_fqn(it.pkg.fqn));

--- a/tests/TestUpdateLocal.m
+++ b/tests/TestUpdateLocal.m
@@ -190,6 +190,44 @@ classdef TestUpdateLocal < matlab.unittest.TestCase
                 'compile_script should NOT run when update uses --no-compile --force');
         end
 
+        function testUpdateLocalPackage_NoCompileMipSelfRejectedUntouched(testCase)
+            % The mip identity (gh/mip-org/core/mip) is classified as a
+            % self-update, not a process item, and is never an editable
+            % local install. Per specification §7.6, `--no-compile` must
+            % reject it during pre-pass validation -- BEFORE any destructive
+            % action -- rather than falling through to the updateSelf
+            % hot-swap (issue #303). The guard fires before any network
+            % access, so a fake mip seeded in the isolated root suffices and
+            % this belongs here with the other offline --no-compile cases,
+            % not in the network-gated TestUpdateSelf.
+            pkgDir = createTestPackage(testCase.TestRoot, ...
+                'mip-org', 'core', 'mip', 'version', '0.0.0');
+
+            testCase.verifyError( ...
+                @() mip.update('--no-compile', 'mip'), ...
+                'mip:update:noCompileRequiresEditable');
+            % Rejecting BEFORE any destructive action means the fake mip is
+            % left exactly as seeded: directory present, version unchanged.
+            % (Merely checking that an error is raised would not catch a
+            % regression that hot-swaps first and errors afterward.)
+            testCase.verifyTrue(exist(pkgDir, 'dir') > 0, ...
+                'mip install must survive a rejected --no-compile update');
+            info = mip.config.read_package_json(pkgDir);
+            testCase.verifyEqual(info.version, '0.0.0', ...
+                'mip must not be hot-swapped by a rejected --no-compile update');
+
+            % --force must not bypass the guard either: the destructive
+            % hot-swap still has to be blocked up front, leaving mip intact.
+            testCase.verifyError( ...
+                @() mip.update('--no-compile', '--force', 'mip'), ...
+                'mip:update:noCompileRequiresEditable');
+            testCase.verifyTrue(exist(pkgDir, 'dir') > 0, ...
+                'mip install must survive a rejected --no-compile --force update');
+            info = mip.config.read_package_json(pkgDir);
+            testCase.verifyEqual(info.version, '0.0.0', ...
+                'mip must not be hot-swapped by a rejected --no-compile --force update');
+        end
+
         %% --- Load state preserved across update ---
 
         function testUpdateLocalPackage_PreservesLoadState(testCase)

--- a/tests/TestUpdateSelf.m
+++ b/tests/TestUpdateSelf.m
@@ -82,29 +82,5 @@ classdef TestUpdateSelf < matlab.unittest.TestCase
                 'downloaded mip payload should expose mip.json "paths"');
         end
 
-        function testUpdateSelf_NoCompileMipErrors(testCase)
-            % --no-compile only applies to editable local installs. The
-            % mip identity (gh/mip-org/core/mip) is classified as a
-            % self-update, not a process item, and is never an editable
-            % local install. Per specification §7.6 the guard must reject
-            % it BEFORE any destructive action rather than falling through
-            % to the updateSelf hot-swap, so "mip update --no-compile mip"
-            % must raise mip:update:noCompileRequiresEditable. The guard
-            % runs during pre-pass validation, so this errors without any
-            % network access.
-            createTestPackage(testCase.TestRoot, ...
-                'mip-org', 'core', 'mip', 'version', '0.0.0');
-
-            testCase.verifyError( ...
-                @() mip.update('--no-compile', 'mip'), ...
-                'mip:update:noCompileRequiresEditable');
-
-            % --force must not bypass the guard either: the destructive
-            % hot-swap still has to be blocked up front.
-            testCase.verifyError( ...
-                @() mip.update('--no-compile', '--force', 'mip'), ...
-                'mip:update:noCompileRequiresEditable');
-        end
-
     end
 end

--- a/tests/TestUpdateSelf.m
+++ b/tests/TestUpdateSelf.m
@@ -82,5 +82,29 @@ classdef TestUpdateSelf < matlab.unittest.TestCase
                 'downloaded mip payload should expose mip.json "paths"');
         end
 
+        function testUpdateSelf_NoCompileMipErrors(testCase)
+            % --no-compile only applies to editable local installs. The
+            % mip identity (gh/mip-org/core/mip) is classified as a
+            % self-update, not a process item, and is never an editable
+            % local install. Per specification §7.6 the guard must reject
+            % it BEFORE any destructive action rather than falling through
+            % to the updateSelf hot-swap, so "mip update --no-compile mip"
+            % must raise mip:update:noCompileRequiresEditable. The guard
+            % runs during pre-pass validation, so this errors without any
+            % network access.
+            createTestPackage(testCase.TestRoot, ...
+                'mip-org', 'core', 'mip', 'version', '0.0.0');
+
+            testCase.verifyError( ...
+                @() mip.update('--no-compile', 'mip'), ...
+                'mip:update:noCompileRequiresEditable');
+
+            % --force must not bypass the guard either: the destructive
+            % hot-swap still has to be blocked up front.
+            testCase.verifyError( ...
+                @() mip.update('--no-compile', '--force', 'mip'), ...
+                'mip:update:noCompileRequiresEditable');
+        end
+
     end
 end


### PR DESCRIPTION
The `--no-compile` guard in `+mip/update.m` only checked `kind=='process'` items, so `mip update --no-compile mip` (classified `kind=='self-update'`) skipped validation and fell through to the destructive `updateSelf` hot-swap.

The guard now rejects every actionable item (both `process` and `self-update`) that is not an editable local install, raising `mip:update:noCompileRequiresEditable` before any destructive action per spec §7.6, while still leaving `pin-skip`/`no-source-skip` items untouched.

Adds a `TestUpdateSelf` case asserting both `mip update --no-compile mip` and the `--force` variant raise the error before any network or destructive action.

Closes #303