### PR TITLE
Refactor: unify the three line-list state stores

### DIFF
--- a/+mip/+state/get_channels.m
+++ b/+mip/+state/get_channels.m
@@ -13,33 +13,11 @@ function channels = get_channels()
 % the END of the file (matching the append semantics of
 % MIP_LOADED_PACKAGES). The returned cell array reverses that so the
 % highest-priority channel is at index 1.
+%
+% An existing-but-unreadable channels file raises an error rather than
+% returning {}: silently dropping the list would let a subsequent
+% set_channels overwrite the file and lose the user's prior subscriptions.
 
-    channels = {};
-
-    packagesDir = mip.paths.get_packages_dir();
-    channelsFile = fullfile(packagesDir, 'channels.txt');
-
-    if ~exist(channelsFile, 'file')
-        return
-    end
-
-    fid = fopen(channelsFile, 'r');
-    if fid == -1
-        % File exists (checked above) but cannot be opened. Failing here
-        % rather than returning {} avoids set_channels later silently
-        % overwriting the file with a one-entry list, dropping the user's
-        % prior subscriptions.
-        error('mip:fileError', ...
-              'Could not read channels file: %s', channelsFile);
-    end
-
-    closer = onCleanup(@() fclose(fid));
-    while ~feof(fid)
-        line = fgetl(fid);
-        if ischar(line) && ~isempty(strtrim(line))
-            channels{end+1} = strtrim(line); %#ok<AGROW>
-        end
-    end
-
-    channels = fliplr(channels);
+    channelsFile = fullfile(mip.paths.get_packages_dir(), 'channels.txt');
+    channels = flip(mip.state.read_line_list(channelsFile, 'error'));
 end

--- a/+mip/+state/get_directly_installed.m
+++ b/+mip/+state/get_directly_installed.m
@@ -4,27 +4,6 @@ function packages = get_directly_installed()
 % Returns:
 %   packages - Cell array of package names that were directly installed
 
-    packagesDir = mip.paths.get_packages_dir();
-    directFile = fullfile(packagesDir, 'directly_installed.txt');
-    
-    packages = {};
-    if exist(directFile, 'file')
-        fid = fopen(directFile, 'r');
-        if fid == -1
-            return
-        end
-        
-        try
-            while ~feof(fid)
-                line = fgetl(fid);
-                if ischar(line) && ~isempty(strtrim(line))
-                    packages{end+1} = strtrim(line); %#ok<*AGROW>
-                end
-            end
-            fclose(fid);
-        catch ME
-            fclose(fid);
-            rethrow(ME);
-        end
-    end
+    directFile = fullfile(mip.paths.get_packages_dir(), 'directly_installed.txt');
+    packages = mip.state.read_line_list(directFile);
 end

--- a/+mip/+state/get_pinned.m
+++ b/+mip/+state/get_pinned.m
@@ -4,27 +4,6 @@ function packages = get_pinned()
 % Returns:
 %   packages - Cell array of FQNs that are pinned
 
-    packagesDir = mip.paths.get_packages_dir();
-    pinnedFile = fullfile(packagesDir, 'pinned.txt');
-
-    packages = {};
-    if exist(pinnedFile, 'file')
-        fid = fopen(pinnedFile, 'r');
-        if fid == -1
-            return
-        end
-
-        try
-            while ~feof(fid)
-                line = fgetl(fid);
-                if ischar(line) && ~isempty(strtrim(line))
-                    packages{end+1} = strtrim(line); %#ok<*AGROW>
-                end
-            end
-            fclose(fid);
-        catch ME
-            fclose(fid);
-            rethrow(ME);
-        end
-    end
+    pinnedFile = fullfile(mip.paths.get_packages_dir(), 'pinned.txt');
+    packages = mip.state.read_line_list(pinnedFile);
 end

--- a/+mip/+state/read_line_list.m
+++ b/+mip/+state/read_line_list.m
@@ -1,0 +1,43 @@
+function lines = read_line_list(file, onUnreadable)
+%READ_LINE_LIST   Read a text file into a cell array of non-empty lines.
+%
+% Shared reader for the line-per-entry state files under <root>/packages/
+% (directly_installed.txt, pinned.txt, channels.txt). Each line is trimmed
+% and blank lines are dropped.
+%
+% Args:
+%   file         - Absolute path to the file.
+%   onUnreadable - What to do when the file exists but cannot be opened:
+%                    'empty' (default) - return {}
+%                    'error'           - raise mip:fileError
+%                  A missing file always returns {} regardless.
+%
+% Returns:
+%   lines - Cell array of trimmed, non-empty lines in file order.
+
+if nargin < 2
+    onUnreadable = 'empty';
+end
+
+lines = {};
+if ~exist(file, 'file')
+    return
+end
+
+fid = fopen(file, 'r');
+if fid == -1
+    if strcmp(onUnreadable, 'error')
+        error('mip:fileError', 'Could not read file: %s', file);
+    end
+    return
+end
+closer = onCleanup(@() fclose(fid));
+
+while ~feof(fid)
+    line = fgetl(fid);
+    if ischar(line) && ~isempty(strtrim(line))
+        lines{end+1} = strtrim(line); %#ok<AGROW>
+    end
+end
+
+end

--- a/+mip/+state/set_channels.m
+++ b/+mip/+state/set_channels.m
@@ -6,43 +6,12 @@ function set_channels(channels)
 %              priority first). Each entry must be in '<owner>/<channel>'
 %              form; callers are responsible for normalizing shorthand
 %              inputs.
+%
+% Persisted in stack-like order: the highest-priority (most recently
+% added) channel is written last, matching MIP_LOADED_PACKAGES semantics.
+% Callers pass priority order (highest first), so the list is reversed
+% before writing. get_channels reverses it back on read.
 
-    packagesDir = mip.paths.get_packages_dir();
-
-    if ~exist(packagesDir, 'dir')
-        mkdir(packagesDir);
-    end
-
-    channelsFile = fullfile(packagesDir, 'channels.txt');
-    tmpFile = [channelsFile '.tmp'];
-
-    fid = fopen(tmpFile, 'w');
-    if fid == -1
-        error('mip:fileError', 'Could not write to channels.txt.tmp');
-    end
-
-    try
-        % Persist in stack-like order: highest-priority (most recently
-        % added) channel last, matching MIP_LOADED_PACKAGES semantics.
-        % Callers pass `channels` in priority order (highest first), so
-        % iterate in reverse when writing to disk.
-        for i = length(channels):-1:1
-            fprintf(fid, '%s\n', channels{i});
-        end
-        fclose(fid);
-    catch ME
-        fclose(fid);
-        if exist(tmpFile, 'file')
-            delete(tmpFile);
-        end
-        rethrow(ME);
-    end
-
-    [ok, msg] = movefile(tmpFile, channelsFile, 'f');
-    if ~ok
-        if exist(tmpFile, 'file')
-            delete(tmpFile);
-        end
-        error('mip:fileError', 'Could not rename tmp file into place: %s', msg);
-    end
+    channelsFile = fullfile(mip.paths.get_packages_dir(), 'channels.txt');
+    mip.state.write_line_list(channelsFile, flip(channels));
 end

--- a/+mip/+state/set_directly_installed.m
+++ b/+mip/+state/set_directly_installed.m
@@ -4,41 +4,7 @@ function set_directly_installed(packages)
 % Args:
 %   packages - Cell array of package names that are directly installed
 
-    packagesDir = mip.paths.get_packages_dir();
-
-    if ~exist(packagesDir, 'dir')
-        mkdir(packagesDir);
-    end
-
-    directFile = fullfile(packagesDir, 'directly_installed.txt');
-    tmpFile = [directFile '.tmp'];
-
-    % Sort packages for consistent ordering
-    packages = sort(packages);
-
-    fid = fopen(tmpFile, 'w');
-    if fid == -1
-        error('mip:fileError', 'Could not write to directly_installed.txt.tmp');
-    end
-
-    try
-        for i = 1:length(packages)
-            fprintf(fid, '%s\n', packages{i});
-        end
-        fclose(fid);
-    catch ME
-        fclose(fid);
-        if exist(tmpFile, 'file')
-            delete(tmpFile);
-        end
-        rethrow(ME);
-    end
-
-    [ok, msg] = movefile(tmpFile, directFile, 'f');
-    if ~ok
-        if exist(tmpFile, 'file')
-            delete(tmpFile);
-        end
-        error('mip:fileError', 'Could not rename tmp file into place: %s', msg);
-    end
+    directFile = fullfile(mip.paths.get_packages_dir(), 'directly_installed.txt');
+    % Sort for consistent on-disk ordering.
+    mip.state.write_line_list(directFile, sort(packages));
 end

--- a/+mip/+state/set_pinned.m
+++ b/+mip/+state/set_pinned.m
@@ -4,28 +4,7 @@ function set_pinned(packages)
 % Args:
 %   packages - Cell array of FQNs that are pinned
 
-    packagesDir = mip.paths.get_packages_dir();
-
-    if ~exist(packagesDir, 'dir')
-        mkdir(packagesDir);
-    end
-
-    pinnedFile = fullfile(packagesDir, 'pinned.txt');
-
-    packages = sort(packages);
-
-    fid = fopen(pinnedFile, 'w');
-    if fid == -1
-        error('mip:fileError', 'Could not write to pinned.txt');
-    end
-
-    try
-        for i = 1:length(packages)
-            fprintf(fid, '%s\n', packages{i});
-        end
-        fclose(fid);
-    catch ME
-        fclose(fid);
-        rethrow(ME);
-    end
+    pinnedFile = fullfile(mip.paths.get_packages_dir(), 'pinned.txt');
+    % Sort for consistent on-disk ordering.
+    mip.state.write_line_list(pinnedFile, sort(packages));
 end

--- a/+mip/+state/write_line_list.m
+++ b/+mip/+state/write_line_list.m
@@ -1,0 +1,48 @@
+function write_line_list(file, lines)
+%WRITE_LINE_LIST   Atomically write a cell array of lines to a text file.
+%
+% Shared writer for the line-per-entry state files under <root>/packages/
+% (directly_installed.txt, pinned.txt, channels.txt). Writes each entry on
+% its own line via a temp file that is renamed into place, so a reader
+% never observes a half-written file.
+%
+% The <root>/packages/ directory is created if it does not exist. Callers
+% are responsible for ordering `lines` as they should appear on disk.
+%
+% Args:
+%   file  - Absolute path to the destination file.
+%   lines - Cell array of strings, one per line, in on-disk order.
+
+packagesDir = fileparts(file);
+if ~exist(packagesDir, 'dir')
+    mkdir(packagesDir);
+end
+
+tmpFile = [file '.tmp'];
+fid = fopen(tmpFile, 'w');
+if fid == -1
+    error('mip:fileError', 'Could not write to %s', tmpFile);
+end
+
+try
+    for i = 1:length(lines)
+        fprintf(fid, '%s\n', lines{i});
+    end
+    fclose(fid);
+catch ME
+    fclose(fid);
+    if exist(tmpFile, 'file')
+        delete(tmpFile);
+    end
+    rethrow(ME);
+end
+
+[ok, msg] = movefile(tmpFile, file, 'f');
+if ~ok
+    if exist(tmpFile, 'file')
+        delete(tmpFile);
+    end
+    error('mip:fileError', 'Could not rename tmp file into place: %s', msg);
+end
+
+end


### PR DESCRIPTION
First pass of the readability refactor — the first in a stacked series. Targets `main`.

## What
`+mip/+state/` had three independent implementations of the same idea — *a list of strings persisted one-per-line in a `.txt` file under `packages/`*:

| Concept | File | Functions |
|---|---|---|
| directly-installed | `directly_installed.txt` | `get_/set_/add_/remove_/is_directly_installed` |
| pinned | `pinned.txt` | `get_/set_/add_/remove_/is_pinned` |
| channels | `channels.txt` | `get_/set_/add_/append_/remove_channel` |

The `get_*` readers were the same loop (open, `fgetl`, trim, drop blanks) and the `set_*` writers were the same atomic temp-file-then-`movefile` — **except `set_pinned`, which had drifted to a non-atomic direct write.**

## Change
Extract the mechanical file I/O into two shared helpers:
- `mip.state.read_line_list(file, onUnreadable)`
- `mip.state.write_line_list(file, lines)` (atomic)

Each store's `get_/set_` now reduces to a filename plus its own distinct semantics: sorting (directly-installed, pinned) vs. priority-order reversal (channels), and error-on-unreadable (channels only).

## Behavior
Preserved. Two incidental, behavior-preserving wins fell out: `set_pinned` is now atomic like its siblings, and the orientation-assuming `fliplr` is replaced by `flip`. The `add_/remove_/is_` wrappers are untouched (already thin).

Verified locally: 705/705 non-remote tests pass. CI runs the full suite.
