### PR TITLE
Refactor: make list_installed_packages the single source of truth for the installed tree

### DIFF
--- a/+mip/+resolve/find_all_installed_by_name.m
+++ b/+mip/+resolve/find_all_installed_by_name.m
@@ -6,53 +6,21 @@ function matches = find_all_installed_by_name(packageName)
 % directory name for each match and include the 'gh/' prefix for
 % GitHub channel packages.
 %
+% A view over mip.state.list_installed_packages (the single source of
+% truth for the installed tree), filtered by name and sorted.
+%
 % Returns:
-%   matches - Cell array of canonical FQN strings for each source-type /
-%             owner / channel combination where this name is installed.
+%   matches - Sorted cell array of canonical FQN strings for each
+%             source-type / owner / channel combination where this name
+%             is installed.
 
 matches = {};
-packagesDir = mip.paths.get_packages_dir();
-if ~exist(packagesDir, 'dir')
-    return
-end
-
-topEntries = dir(packagesDir);
-for i = 1:length(topEntries)
-    if ~topEntries(i).isdir || startsWith(topEntries(i).name, '.')
-        continue
-    end
-    topName = topEntries(i).name;
-    topPath = fullfile(packagesDir, topName);
-
-    if strcmp(topName, 'gh')
-        ownerDirs = dir(topPath);
-        for j = 1:length(ownerDirs)
-            if ~ownerDirs(j).isdir || startsWith(ownerDirs(j).name, '.')
-                continue
-            end
-            owner = ownerDirs(j).name;
-            ownerPath = fullfile(topPath, owner);
-            chanDirs = dir(ownerPath);
-            for k = 1:length(chanDirs)
-                if ~chanDirs(k).isdir || startsWith(chanDirs(k).name, '.')
-                    continue
-                end
-                ch = chanDirs(k).name;
-                candidateFqn = mip.parse.make_fqn(owner, ch, packageName);
-                onDisk = mip.resolve.installed_dir(candidateFqn);
-                if ~isempty(onDisk)
-                    matches{end+1} = mip.parse.make_fqn(owner, ch, onDisk); %#ok<AGROW>
-                end
-            end
-        end
-    else
-        candidateFqn = [topName '/' packageName];
-        onDisk = mip.resolve.installed_dir(candidateFqn);
-        if ~isempty(onDisk)
-            matches{end+1} = [topName '/' onDisk]; %#ok<AGROW>
-        end
+for fqn = mip.state.list_installed_packages()
+    r = mip.parse.parse_package_arg(fqn{1});
+    if mip.name.match(r.name, packageName)
+        matches{end+1} = fqn{1}; %#ok<AGROW>
     end
 end
-
 matches = sort(matches);
+
 end

--- a/+mip/+resolve/resolve_bare_name.m
+++ b/+mip/+resolve/resolve_bare_name.m
@@ -18,52 +18,8 @@ function fqn = resolve_bare_name(packageName)
 
 fqn = '';
 
-packagesDir = mip.paths.get_packages_dir();
-if ~exist(packagesDir, 'dir')
-    return
-end
-
-matches = {};
-
-topEntries = dir(packagesDir);
-for i = 1:length(topEntries)
-    if ~topEntries(i).isdir || startsWith(topEntries(i).name, '.')
-        continue
-    end
-    topName = topEntries(i).name;
-    topPath = fullfile(packagesDir, topName);
-
-    if strcmp(topName, 'gh')
-        ownerDirs = dir(topPath);
-        for j = 1:length(ownerDirs)
-            if ~ownerDirs(j).isdir || startsWith(ownerDirs(j).name, '.')
-                continue
-            end
-            owner = ownerDirs(j).name;
-            ownerPath = fullfile(topPath, owner);
-
-            chanDirs = dir(ownerPath);
-            for k = 1:length(chanDirs)
-                if ~chanDirs(k).isdir || startsWith(chanDirs(k).name, '.')
-                    continue
-                end
-                ch = chanDirs(k).name;
-                candidateFqn = mip.parse.make_fqn(owner, ch, packageName);
-                onDisk = mip.resolve.installed_dir(candidateFqn);
-                if ~isempty(onDisk)
-                    matches{end+1} = mip.parse.make_fqn(owner, ch, onDisk); %#ok<AGROW>
-                end
-            end
-        end
-    else
-        candidateFqn = [topName '/' packageName];
-        onDisk = mip.resolve.installed_dir(candidateFqn);
-        if ~isempty(onDisk)
-            matches{end+1} = [topName '/' onDisk]; %#ok<AGROW>
-        end
-    end
-end
-
+% find_all_installed_by_name returns the name matches in sorted order.
+matches = mip.resolve.find_all_installed_by_name(packageName);
 if isempty(matches)
     return
 end
@@ -76,7 +32,7 @@ for i = 1:length(matches)
     end
 end
 
-matches = sort(matches);
+% Otherwise the alphabetically-first FQN.
 fqn = matches{1};
 
 end


### PR DESCRIPTION
The second refactor in the stacked series, stacked on top of #316. Targets `refactor/unify-line-list-state-stores`; GitHub will retarget it to `main` once #316 merges.

## Problem
The on-disk layout — *"packages live at `gh/<owner>/<channel>/<name>` or `<type>/<name>`, matched case-/`-`/`_`-insensitively"* — was re-encoded in three functions that each walked the packages tree with their own copy of the `gh/`-vs-non-gh nesting:

- `mip.state.list_installed_packages` — all installed FQNs
- `mip.resolve.find_all_installed_by_name` — FQNs matching a name
- `mip.resolve.resolve_bare_name` — best FQN for a bare name

The latter two also called `installed_dir` *inside their loop*, re-scanning a directory for every owner/channel candidate — redundant work layered on duplicated code. Three copies drifting independently.

## Change
`list_installed_packages` already returns every installed FQN built from real on-disk directory names, so the other two are just views of it:

- `find_all_installed_by_name(name)` → its output filtered by `mip.name.match`.
- `resolve_bare_name(name)` → the priority pick (`gh/mip-org/core` first, else alphabetical) over that filtered list.

Both hand-rolled traversals are deleted, along with the per-candidate directory re-scanning. The `gh/`-vs-non-gh nesting now lives in one place in this layer.

## Behavior
Unchanged: same match set, same on-disk-name casing, same priority and sort order. `find_all_installed_by_name`'s sorted-output guarantee (which `resolve_bare_name` now relies on) is documented in its docstring.

CI runs the full suite.

## Follow-on (planned, stacked)
- Unify FQN→path construction so `get_package_dir`/`installed_dir` stop re-encoding the gh-vs-non-gh branch.
- Collapse the triplicated, drifted bare-dependency rule (`resolve_dependency` / `build_dependency_graph.resolveBareDep` / `topological_sort`'s core-only inline).
