### PR TITLE
Refactor: collapse updateSelf onto checkRemoteNeedsUpdate

### DIFF
--- a/+mip/update.m
+++ b/+mip/update.m
@@ -522,54 +522,16 @@ function updateSelf(p, force)
 % Self-update for gh/mip-org/core/mip. mip cannot be uninstalled through
 % the normal flow, so we download and swap in place.
 
-    fqn = p.fqn;
-    pkgDir = p.pkgDir;
-    pkgInfo = p.pkgInfo;
-
-    installedVersion = pkgInfo.version;
-    channelStr = 'mip-org/core';
-
-    fprintf('Checking for updates to "mip-org/core/mip"...\n');
-
-    index = mip.channel.fetch_index(channelStr);
-    requestedVersions = containers.Map('KeyType', 'char', 'ValueType', 'any');
-    if ~isempty(installedVersion) && ~mip.resolve.is_numeric_version(installedVersion)
-        requestedVersions(p.name) = installedVersion;
-    end
-    try
-        [packageInfoMap, ~] = mip.resolve.build_package_info_map( ...
-            index, 'mip-org', 'core', requestedVersions);
-    catch err
-        if strcmp(err.identifier, 'mip:versionNotFound')
-            error('mip:update:versionNotInChannel', ...
-                  ['Installed mip version "%s" no longer exists in mip-org/core. ' ...
-                   'To switch to a different branch or version, run: mip install mip@<version>'], ...
-                  installedVersion);
-        end
-        rethrow(err);
-    end
-
-    if ~packageInfoMap.isKey(fqn)
-        error('mip:update:notInIndex', 'mip not found in the mip-org/core channel index.');
-    end
-
-    latestInfo = packageInfoMap(fqn);
-
-    if ~force && ~mip.state.check_needs_update(pkgInfo, latestInfo)
-        fprintf('Package "mip-org/core/mip" is already up to date (%s)\n', installedVersion);
+    [needs, latestInfo] = checkRemoteNeedsUpdate(p, force);
+    if ~needs
         return
-    end
-
-    if force
-        fprintf('Force updating "mip-org/core/mip" (%s)\n', installedVersion);
-    else
-        fprintf('Updating "mip-org/core/mip": %s -> %s\n', installedVersion, latestInfo.version);
     end
 
     % mip is the running code, so it can't be unloaded and reinstalled the
     % normal way — hand off to the shared in-place hot-swap.
-    mip.self.hot_swap(pkgDir, pkgInfo, latestInfo);
-    fprintf('Successfully updated "mip-org/core/mip" to %s\n', latestInfo.version);
+    mip.self.hot_swap(p.pkgDir, p.pkgInfo, latestInfo);
+    fprintf('Successfully updated "%s" to %s\n', ...
+            mip.parse.display_fqn(p.fqn), latestInfo.version);
 end
 
 function expanded = expandWithDeps(args)


### PR DESCRIPTION
Third refactor in the stacked series (#316, #317 merged). Targets `main`.

## Problem
`update.m` contained two near-identical implementations of "resolve the latest remote info for an installed package and decide whether to update":

- `checkRemoteNeedsUpdate` (generic path)
- `updateSelf` (the `gh/mip-org/core/mip` self-update) — the same fetch index → pin non-numeric installed version → `build_package_info_map` → translate `mip:versionNotFound` → not-in-index → force/up-to-date/update decision, with `"mip-org/core/mip"` hard-coded where the generic version uses the package struct's fields.

The copies had drifted: the self copy dropped the unavailable-arch branch and worded its errors differently.

## Change
`display_fqn('gh/mip-org/core/mip')` is exactly the string the self copy hard-coded, so `updateSelf` now simply calls `checkRemoteNeedsUpdate(p, force)` and keeps only its distinct action — the in-place hot-swap (mip is the running code and cannot go through unload/reinstall). Net −38 lines; `update.m` now has exactly one fetch→pin→locate→decide site.

## Behavior
- User-visible messages on the normal self-update paths are unchanged (`Checking for updates to "mip-org/core/mip"...`, force/up-to-date/updating lines, success line).
- Error IDs on tested paths are unchanged. The self-update's rare error *wording* becomes the generic form (e.g. `versionNotInChannel` now names the FQN instead of "mip").
- Drift fix: an arch-unavailable mip now reports `mip:update:unavailable` with the available architectures, instead of falling through to `notInIndex`.

## Scope note (from the dedup survey)
The originally-surveyed third copy — `install.m::fetchChannelIndex` — was assessed and deliberately left alone: it is a different shape (multi-channel accumulator, user-`@version` pins projected per channel, deferred unavailable-arch handling). Both flows already share the real core, `mip.resolve.build_package_info_map`; merging them would need pin-source/error-vs-defer/merge-vs-return flags — a worse function. A follow-up PR will fix `info.m`'s drifted hand-rolled copy of the arch-selection policy (`select_best_variant`).

CI runs the full suite.

