### PR TITLE
Refactor: use select_best_variant for mip info's remote variant display

### DIFF
--- a/+mip/info.m
+++ b/+mip/info.m
@@ -296,27 +296,7 @@ function showRemoteChannelInfo(channelStr, packageName, index)
     % Show dependencies from latest compatible variant
     latestVersion = allVersions{end};
     latestVariants = versionMap(latestVersion);
-    currentArch = mip.build.arch();
-    compatibleVariant = [];
-
-    canFallbackToWasm = startsWith(currentArch, 'numbl_') && ~strcmp(currentArch, 'numbl_wasm');
-    for i = 1:length(latestVariants)
-        v = latestVariants{i};
-        arch = v.architecture;
-        if strcmp(arch, currentArch) || strcmp(arch, 'any')
-            compatibleVariant = v;
-            break;
-        end
-    end
-    if isempty(compatibleVariant) && canFallbackToWasm
-        for i = 1:length(latestVariants)
-            v = latestVariants{i};
-            if strcmp(v.architecture, 'numbl_wasm')
-                compatibleVariant = v;
-                break;
-            end
-        end
-    end
+    compatibleVariant = mip.resolve.select_best_variant(latestVariants, mip.build.arch());
 
     if ~isempty(compatibleVariant) && isfield(compatibleVariant, 'dependencies') && ~isempty(compatibleVariant.dependencies)
         deps = compatibleVariant.dependencies;


### PR DESCRIPTION
Fourth refactor in the stacked series, stacked on top of #318. Targets `refactor/unify-remote-update-info`; GitHub will retarget it to `main` once #318 merges.

## Problem
`info.m`'s `showRemoteChannelInfo` hand-rolled its own arch-compatibility scan to decide which variant's dependency list to print under "Dependencies (latest):" — a drifted copy of the canonical policy in `mip.resolve.select_best_variant`:

- **hand-rolled:** first variant in index order whose arch is an exact match **or** `'any'`; `numbl_wasm` fallback only after that.
- **canonical (`select_best_variant`, used by install/update via `build_package_info_map`):** exact match > `numbl_wasm` fallback > `'any'`, regardless of index order.

So with variants listed as `['any', 'linux_x86_64']` on a linux box, `mip info` would show the `'any'` variant's dependencies while `mip install` would actually install the exact `linux_x86_64` variant.

## Change
Replace the 21-line hand-rolled scan with one call to `mip.resolve.select_best_variant`. `mip info` now shows the dependencies of the variant that install would actually pick on this machine.

## Behavior
Display-only, and only in the edge cases above (identical whenever the exact match precedes `'any'` in the index, or only one variant is compatible). No test asserts the old edge behavior; error IDs untouched.

CI runs the full suite.
