### PR TITLE
Refactor: share the orphan mark-and-sweep across the load and install planes

### DIFF
--- a/+mip/+dependency/find_orphans.m
+++ b/+mip/+dependency/find_orphans.m
@@ -1,0 +1,37 @@
+function orphans = find_orphans(roots, universe)
+%FIND_ORPHANS   Find packages in `universe` not needed by any root package.
+%
+% A package is needed if it is a root or a transitive dependency of an
+% in-universe root. `gh/mip-org/core/mip` (the package manager itself)
+% is never an orphan.
+%
+% This is the shared mark phase of the two pruning passes: `mip unload`
+% prunes loaded packages against the directly-loaded roots, and
+% mip.state.prune_unused_packages prunes installed packages against the
+% directly-installed roots.
+%
+% Args:
+%   roots    - Cell array of FQNs that are needed by definition
+%   universe - Cell array of candidate FQNs to check
+%
+% Returns:
+%   orphans - Cell array of FQNs from universe that are not needed, in
+%             universe order.
+
+needed = {};
+for i = 1:length(roots)
+    if ismember(roots{i}, universe)
+        needed = [needed, mip.dependency.find_all_dependencies(roots{i})]; %#ok<AGROW>
+    end
+end
+needed = unique([roots, needed]);
+
+orphans = {};
+for i = 1:length(universe)
+    fqn = universe{i};
+    if ~ismember(fqn, needed) && ~strcmp(fqn, 'gh/mip-org/core/mip')
+        orphans{end+1} = fqn; %#ok<AGROW>
+    end
+end
+
+end

--- a/+mip/+paths/cleanup_package_parents.m
+++ b/+mip/+paths/cleanup_package_parents.m
@@ -1,0 +1,20 @@
+function cleanup_package_parents(fqn)
+%CLEANUP_PACKAGE_PARENTS   Remove empty parent dirs above a removed package.
+%
+% For a gh FQN this walks up through <channel>, <owner>, and the 'gh'
+% root; for a non-gh FQN it only needs to check the source-type directory.
+%
+% Args:
+%   fqn - Canonical FQN of the removed package
+
+packagesDir = mip.paths.get_packages_dir();
+r = mip.parse.parse_package_arg(fqn);
+if strcmp(r.type, 'gh')
+    mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'gh', r.owner, r.channel));
+    mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'gh', r.owner));
+    mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'gh'));
+else
+    mip.paths.cleanup_empty_dirs(fullfile(packagesDir, r.type));
+end
+
+end

--- a/+mip/+state/prune_unused_packages.m
+++ b/+mip/+state/prune_unused_packages.m
@@ -19,47 +19,20 @@ function prune_unused_packages()
 
     directlyInstalled = mip.state.get_directly_installed();
 
-    % Build set of all needed packages (directly installed + their dependencies)
-    neededPackages = {};
-    for i = 1:length(directlyInstalled)
-        directPkg = directlyInstalled{i};
-        if ismember(directPkg, allInstalled)
-            neededPackages = [neededPackages, mip.dependency.find_all_dependencies(directPkg)]; %#ok<AGROW>
-        end
-    end
-
-    neededPackages = unique([directlyInstalled, neededPackages]);
-
-    % Find packages to prune (installed but not needed)
-    % Never prune gh/mip-org/core/mip - it is the package manager itself
-    packagesToPrune = {};
-    for i = 1:length(allInstalled)
-        fqn = allInstalled{i};
-        if ~ismember(fqn, neededPackages) && ...
-                ~strcmp(fqn, 'gh/mip-org/core/mip')
-            packagesToPrune{end+1} = fqn; %#ok<AGROW>
-        end
-    end
+    % Find installed packages no longer needed by any directly-installed package
+    packagesToPrune = mip.dependency.find_orphans(directlyInstalled, allInstalled);
 
     if ~isempty(packagesToPrune)
         displayFqns = cellfun(@mip.parse.display_fqn, packagesToPrune, 'UniformOutput', false);
         fprintf('\nPruning unnecessary packages: %s\n', strjoin(displayFqns, ', '));
-        packagesDir = mip.paths.get_packages_dir();
         for i = 1:length(packagesToPrune)
             fqn = packagesToPrune{i};
-            r = mip.parse.parse_package_arg(fqn);
             pkgDir = mip.paths.get_package_dir(fqn);
 
             try
                 mip.paths.remove_dir(pkgDir);
                 fprintf('  Pruned package "%s"\n', mip.parse.display_fqn(fqn));
-                if strcmp(r.type, 'gh')
-                    mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'gh', r.owner, r.channel));
-                    mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'gh', r.owner));
-                    mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'gh'));
-                else
-                    mip.paths.cleanup_empty_dirs(fullfile(packagesDir, r.type));
-                end
+                mip.paths.cleanup_package_parents(fqn);
             catch ME
                 warning('mip:pruneFailed', ...
                         'Failed to prune package "%s": %s', mip.parse.display_fqn(fqn), ME.message);

--- a/+mip/uninstall.m
+++ b/+mip/uninstall.m
@@ -105,7 +105,7 @@ function uninstall(varargin)
         mip.state.remove_pinned(fqn);
 
         % Clean up empty parent directories (derived from the FQN layout)
-        cleanupPackageParents(fqn);
+        mip.paths.cleanup_package_parents(fqn);
     end
 
     % Prune packages that are no longer needed
@@ -125,21 +125,6 @@ function removePackageDir(pkgDir, displayFqn)
     catch rmErr
         error('mip:uninstallFailed', ...
               'Failed to uninstall package "%s": %s', displayFqn, rmErr.message);
-    end
-end
-
-function cleanupPackageParents(fqn)
-% Remove empty parent directories above the uninstalled package. For a
-% gh FQN this walks up through <channel>, <owner>, and the 'gh' root; for
-% a non-gh FQN it only needs to check the source-type directory.
-    packagesDir = mip.paths.get_packages_dir();
-    r = mip.parse.parse_package_arg(fqn);
-    if strcmp(r.type, 'gh')
-        mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'gh', r.owner, r.channel));
-        mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'gh', r.owner));
-        mip.paths.cleanup_empty_dirs(fullfile(packagesDir, 'gh'));
-    else
-        mip.paths.cleanup_empty_dirs(fullfile(packagesDir, r.type));
     end
 end
 

--- a/+mip/unload.m
+++ b/+mip/unload.m
@@ -26,7 +26,7 @@ function unload(varargin)
     packageArgs = {};
     for i = 1:length(varargin)
         if ~startsWith(varargin{i}, '--')
-            packageArgs{end+1} = varargin{i};
+            packageArgs{end+1} = varargin{i}; %#ok<AGROW>
         end
     end
 
@@ -250,25 +250,8 @@ function pruneUnusedPackages()
         return
     end
 
-    % Build set of all needed packages (directly loaded + their dependencies)
-    neededPackages = {};
-    for i = 1:length(MIP_DIRECTLY_LOADED_PACKAGES)
-        directPkg = MIP_DIRECTLY_LOADED_PACKAGES{i};
-        neededPackages = [neededPackages, mip.dependency.find_all_dependencies(directPkg)]; %#ok<*AGROW>
-    end
-
-    % Add directly loaded packages themselves
-    neededPackages = unique([MIP_DIRECTLY_LOADED_PACKAGES, neededPackages]);
-
-    % Find packages to prune (loaded but not needed)
-    % Never prune gh/mip-org/core/mip - it is the package manager itself
-    packagesToPrune = {};
-    for i = 1:length(MIP_LOADED_PACKAGES)
-        pkg = MIP_LOADED_PACKAGES{i};
-        if ~ismember(pkg, neededPackages) && ~strcmp(pkg, 'gh/mip-org/core/mip')
-            packagesToPrune{end+1} = pkg;
-        end
-    end
+    % Find loaded packages no longer needed by any directly-loaded package
+    packagesToPrune = mip.dependency.find_orphans(MIP_DIRECTLY_LOADED_PACKAGES, MIP_LOADED_PACKAGES);
 
     % Prune each unnecessary package
     if ~isempty(packagesToPrune)

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -248,8 +248,7 @@ function updateLocalPackage(p, noCompile)
     backupDir = [tempname '_mip_backup'];
     movefile(p.pkgDir, backupDir);
     mip.state.remove_directly_installed(p.fqn);
-    packagesDir = mip.paths.get_packages_dir();
-    mip.paths.cleanup_empty_dirs(fullfile(packagesDir, p.type));
+    mip.paths.cleanup_package_parents(p.fqn);
 
     fprintf('Reinstalling "%s" from %s...\n', displayFqn, p.sourcePath);
     try


### PR DESCRIPTION
Fifth refactor in the stacked series, stacked on top of #319. Targets `refactor/info-canonical-variant-selection`; GitHub will retarget it as the stack merges.

## Problem
mip tracks packages on two parallel planes:

| | loaded plane | installed plane |
|---|---|---|
| roots | `MIP_DIRECTLY_LOADED_PACKAGES` | `directly_installed.txt` |
| universe | `MIP_LOADED_PACKAGES` | the packages tree |
| prune action | rmpath + state removal | `remove_dir` + parent cleanup |

Pruning on each plane carried its own copy of the same mark-and-sweep — mark roots plus their transitive dependencies (`find_all_dependencies`) as needed, sweep the complement, never touch `gh/mip-org/core/mip` — once in `unload.m::pruneUnusedPackages`, once in `mip.state.prune_unused_packages`. `check_broken_dependencies` already treats the two planes as one concept behind an `'installed'|'loaded'` mode switch; the prune code didn't.

Separately, the empty-parent-directory cascade (clean `<channel>`, `<owner>`, `gh` — or the source-type dir) was duplicated verbatim in `uninstall.m::cleanupPackageParents` and inside `prune_unused_packages`, with a third non-gh-only variant inline in `update.m::updateLocalPackage`.

## Change
- New `mip.dependency.find_orphans(roots, universe)` — the shared mark phase. Both prunes are now one call plus their plane-specific sweep action.
- New `mip.paths.cleanup_package_parents(fqn)` — the shared parent-cleanup cascade, used by uninstall, prune, and local update.

Net −67/+7 across the four call-site files, plus the two new shared functions.

## Behavior
Unchanged: same prune sets (a `roots ⊆ universe` guard that the installed plane already had is a no-op on the loaded plane, since `DIRECTLY_LOADED ⊆ LOADED` is maintained by `load`/`set_unloaded`/`unloadAll`), same ordering, same messages.

CI runs the full suite.
