### PR TITLE
Refactor: unify the per-command FQN resolvers onto shared resolve primitives

### DIFF
--- a/+mip/+resolve/installed_fqn.m
+++ b/+mip/+resolve/installed_fqn.m
@@ -1,0 +1,26 @@
+function out = installed_fqn(fqn)
+%INSTALLED_FQN   Canonicalize an FQN to its on-disk installed form.
+%
+% Looks up the actual on-disk directory name for the FQN's last component
+% (case- and dash/underscore-insensitive, see mip.resolve.installed_dir)
+% and returns the FQN rebuilt with that name. Commands canonicalize user
+% input through this once at their boundary, so that stored FQNs and
+% state lookups can use plain string comparison.
+%
+% Args:
+%   fqn - FQN in any accepted input form (see mip.parse.parse_package_arg)
+%
+% Returns:
+%   out - Canonical FQN with the on-disk name, or '' if not installed.
+
+r = mip.parse.parse_package_arg(fqn);
+onDisk = mip.resolve.installed_dir(r.fqn);
+if isempty(onDisk)
+    out = '';
+elseif strcmp(r.type, 'gh')
+    out = mip.parse.make_fqn(r.owner, r.channel, onDisk);
+else
+    out = [r.type '/' onDisk];
+end
+
+end

--- a/+mip/+resolve/resolve_to_installed.m
+++ b/+mip/+resolve/resolve_to_installed.m
@@ -22,26 +22,16 @@ if parsed.is_fqn
     % Canonicalize: find the actual on-disk name (case-insensitive) so that
     % downstream code (and storage) sees the canonical form regardless of
     % how the user typed the name.
-    onDisk = mip.resolve.installed_dir(parsed.fqn);
-    if isempty(onDisk)
-        result = [];
-        return
-    end
-    parsed.name = onDisk;
-    if strcmp(parsed.type, 'gh')
-        fqn = mip.parse.make_fqn(parsed.owner, parsed.channel, onDisk);
-    else
-        fqn = [parsed.type '/' onDisk];
-    end
-    parsed.fqn = fqn;
+    fqn = mip.resolve.installed_fqn(parsed.fqn);
 else
     fqn = mip.resolve.resolve_bare_name(parsed.name);
-    if isempty(fqn)
-        result = [];
-        return
-    end
-    parsed = mip.parse.parse_package_arg(fqn);
 end
+
+if isempty(fqn)
+    result = [];
+    return
+end
+parsed = mip.parse.parse_package_arg(fqn);
 
 pkg_dir = mip.paths.get_package_dir(parsed.fqn);
 

--- a/+mip/+resolve/resolve_to_loaded.m
+++ b/+mip/+resolve/resolve_to_loaded.m
@@ -1,0 +1,24 @@
+function fqn = resolve_to_loaded(packageName)
+%RESOLVE_TO_LOADED   Resolve a bare name among currently loaded packages.
+%
+% Matches use the equivalence rules of mip.name.match (case-insensitive,
+% dash/underscore-equivalent). If multiple loaded packages share the bare
+% name, the most recently loaded one wins (MIP_LOADED_PACKAGES is kept in
+% load order, so the last match is the most recent).
+%
+% Args:
+%   packageName - Bare package name
+%
+% Returns:
+%   fqn - FQN of the matching loaded package, or '' if none match.
+
+fqn = '';
+loadedPackages = mip.state.key_value_get('MIP_LOADED_PACKAGES');
+for i = 1:length(loadedPackages)
+    r = mip.parse.parse_package_arg(loadedPackages{i});
+    if r.is_fqn && mip.name.match(r.name, packageName)
+        fqn = loadedPackages{i};
+    end
+end
+
+end

--- a/+mip/info.m
+++ b/+mip/info.m
@@ -49,13 +49,9 @@ packageName = result.name;
 if result.is_fqn
     % FQN: only check that specific installation. Canonicalize the name
     % to the on-disk form so we report and operate on the canonical FQN.
-    onDisk = mip.resolve.installed_dir(result.fqn);
-    if ~isempty(onDisk)
-        if strcmp(result.type, 'gh')
-            installedFqns = {mip.parse.make_fqn(result.owner, result.channel, onDisk)};
-        else
-            installedFqns = {[result.type '/' onDisk]};
-        end
+    fqn = mip.resolve.installed_fqn(result.fqn);
+    if ~isempty(fqn)
+        installedFqns = {fqn};
     else
         installedFqns = {};
     end

--- a/+mip/load.m
+++ b/+mip/load.m
@@ -394,25 +394,16 @@ function fqn = resolveToFqn(packageArg)
         % dash/underscore-insensitive) so the rest of load uses the
         % canonical form, matching what's already in the loaded/sticky
         % state lists.
-        onDisk = mip.resolve.installed_dir(result.fqn);
-        if isempty(onDisk)
-            error('mip:packageNotFound', ...
-                  'Package "%s" is not installed. Run "mip install %s" first.', ...
-                  packageArg, packageArg);
-        end
-        if strcmp(result.type, 'gh')
-            fqn = mip.parse.make_fqn(result.owner, result.channel, onDisk);
-        else
-            fqn = [result.type '/' onDisk];
-        end
+        fqn = mip.resolve.installed_fqn(result.fqn);
     else
         % Resolve bare name to installed FQN
         fqn = mip.resolve.resolve_bare_name(result.name);
-        if isempty(fqn)
-            error('mip:packageNotFound', ...
-                  'Package "%s" is not installed. Run "mip install %s" first.', ...
-                  result.name, result.name);
-        end
+    end
+
+    if isempty(fqn)
+        error('mip:packageNotFound', ...
+              'Package "%s" is not installed. Run "mip install %s" first.', ...
+              packageArg, packageArg);
     end
 end
 

--- a/+mip/test.m
+++ b/+mip/test.m
@@ -115,23 +115,12 @@ function r = resolveTestTarget(packageArg)
 
     parsed = mip.parse.parse_package_arg(packageArg);
 
-    if parsed.is_fqn
-        r = mip.resolve.resolve_to_installed(packageArg);
-        return
-    end
-
-    loadedPackages = mip.state.key_value_get('MIP_LOADED_PACKAGES');
-    matchIdx = [];
-    for i = 1:length(loadedPackages)
-        loadedInfo = mip.parse.parse_package_arg(loadedPackages{i});
-        if loadedInfo.is_fqn && mip.name.match(loadedInfo.name, parsed.name)
-            matchIdx(end+1) = i; %#ok<AGROW>
+    if ~parsed.is_fqn
+        loadedFqn = mip.resolve.resolve_to_loaded(parsed.name);
+        if ~isempty(loadedFqn)
+            r = mip.resolve.resolve_to_installed(loadedFqn);
+            return
         end
-    end
-
-    if ~isempty(matchIdx)
-        r = mip.resolve.resolve_to_installed(loadedPackages{matchIdx(end)});
-        return
     end
 
     r = mip.resolve.resolve_to_installed(packageArg);

--- a/+mip/uninstall.m
+++ b/+mip/uninstall.m
@@ -34,13 +34,9 @@ function uninstall(varargin)
             % Canonicalize to the on-disk name so the stored FQN we
             % remove from directly_installed.txt matches what was added
             % during install.
-            onDisk = mip.resolve.installed_dir(result.fqn);
-            if isempty(onDisk)
+            fqn = mip.resolve.installed_fqn(result.fqn);
+            if isempty(fqn)
                 fqn = result.fqn;
-            elseif strcmp(result.type, 'gh')
-                fqn = mip.parse.make_fqn(result.owner, result.channel, onDisk);
-            else
-                fqn = [result.type '/' onDisk];
             end
             pkgDir = mip.paths.get_package_dir(fqn);
         else

--- a/+mip/unload.m
+++ b/+mip/unload.m
@@ -84,50 +84,19 @@ function fqn = resolveLoadedFqn(packageArg)
         % Canonicalize to the on-disk name so we match the form stored in
         % MIP_LOADED_PACKAGES. If not installed at all, fall back to the
         % canonical typed form (caller will report "not loaded").
-        onDisk = mip.resolve.installed_dir(result.fqn);
-        if isempty(onDisk)
+        fqn = mip.resolve.installed_fqn(result.fqn);
+        if isempty(fqn)
             fqn = result.fqn;
-        elseif strcmp(result.type, 'gh')
-            fqn = mip.parse.make_fqn(result.owner, result.channel, onDisk);
-        else
-            fqn = [result.type '/' onDisk];
         end
         return
     end
 
-    % Search loaded packages for a bare name match. Stored entries are in
-    % canonical (on-disk) form; the user's bare name may differ in case
-    % or `-`/`_`, so match by name equivalence.
-    loadedPackages = mip.state.key_value_get('MIP_LOADED_PACKAGES');
-    matches = {};
-    for i = 1:length(loadedPackages)
-        loaded = loadedPackages{i};
-        r = mip.parse.parse_package_arg(loaded);
-        if r.is_fqn && mip.name.match(r.name, result.name)
-            matches{end+1} = loaded; %#ok<AGROW>
-        end
-    end
-
-    if isempty(matches)
+    % Search loaded packages for a bare name match; the most recently
+    % loaded match wins.
+    fqn = mip.resolve.resolve_to_loaded(result.name);
+    if isempty(fqn)
         fqn = result.name;  % Return bare name; caller will handle "not loaded"
-        return
     end
-
-    if length(matches) == 1
-        fqn = matches{1};
-        return
-    end
-
-    % Multiple matches: pick the most recently loaded (last in load order)
-    lastIdx = 0;
-    for i = 1:length(matches)
-        for j = 1:length(loadedPackages)
-            if strcmp(loadedPackages{j}, matches{i}) && j > lastIdx
-                lastIdx = j;
-            end
-        end
-    end
-    fqn = loadedPackages{lastIdx};
 end
 
 function executeUnload(packageDir, fqn)


### PR DESCRIPTION
Sixth refactor in the stacked series, stacked on top of #320. Targets `refactor/shared-orphan-mark-sweep`; GitHub will retarget it as the stack merges.

## Problem
Six places turned a user argument (bare name or FQN, any case/`-`/`_` variant) into a canonical FQN, each with its own copy of the machinery:

| Site | Bare-name handling | Not-found policy |
|---|---|---|
| `mip.resolve.resolve_to_installed` | `resolve_bare_name` | returns `[]` |
| `load.m::resolveToFqn` | `resolve_bare_name` | errors `mip:packageNotFound` |
| `unload.m::resolveLoadedFqn` | scan **loaded**, most-recent wins | falls back to typed form |
| `test.m::resolveTestTarget` | scan **loaded**, most-recent wins | installed fallback |
| `uninstall.m` (inline) | `find_all_installed_by_name` + ambiguity prompt | `notInstalled` list |
| `info.m` (inline) | `find_all_installed_by_name` | empty list (remote-only) |

Underneath were two copy-pasted operations: the *canonicalize-FQN-to-on-disk-name* block (parse → `installed_dir` → rebuild, branching on `gh`) inlined five times, and the *resolve-bare-name-among-loaded* scan (name-equivalence match, most-recently-loaded tiebreak) duplicated twice with different loop shapes.

## Change
Two new resolve-layer primitives:

- **`mip.resolve.installed_fqn(fqn)`** — FQN → on-disk canonical FQN, or `''` if not installed. This is the *semantic* canonicalization commands perform once at their boundary so stored FQNs and state lookups can use plain string comparison. (Distinct from `mip.parse.canonical_fqn`, which is purely syntactic and preserves typed case; both are needed, for different layers.)
- **`mip.resolve.resolve_to_loaded(name)`** — bare name → FQN of the most recently loaded match, or `''`.

`resolve_to_installed` and the five command resolvers are now one call to these plus each command's own not-found/ambiguity policy, which stays at the call site and is finally readable at a glance. Net **−99/+30** across the six call-site files; the two new primitives add ~50 lines (half docstrings), for **−99/+80** overall.

`+parse` is untouched: its utilities (`parse_package_arg`, `canonical_fqn`, `display_fqn`, the `make_*_fqn` family) are the syntactic substrate these primitives compose.

## Behavior
Unchanged, including the most-recently-loaded tiebreak (one shared implementation now serves unload and test). One message detail: `mip load`'s bare-name not-found message now echoes the argument as typed (including any `@version` suffix) rather than the parsed name.

CI runs the full suite.

