### PR TITLE
Refactor: single-source the mip.yaml → mip.json metadata derivation

### DIFF
--- a/+mip/+build/prepare_package.m
+++ b/+mip/+build/prepare_package.m
@@ -42,13 +42,6 @@ end
 fprintf('Preparing package "%s" (version %s)\n', packageName, ...
         effectiveVersion);
 
-% Match build for current architecture
-[buildEntry, effectiveArch] = mip.build.match_build(mipConfig, architecture);
-fprintf('Matched build for architecture: %s\n', effectiveArch);
-
-% Resolve build config (merge top-level defaults with build overrides)
-resolvedConfig = mip.build.resolve_build_config(mipConfig, buildEntry);
-
 % Create staging directory
 if ~exist(stagingDir, 'dir')
     mkdir(stagingDir);
@@ -71,28 +64,18 @@ if numStripped > 0
     fprintf('Stripping pre-existing compiled binaries...\n');
 end
 
-% Compute resolved path lists relative to the source subdir
-pathsList = mip.build.compute_addpaths(pkgSubdir, resolvedConfig.paths);
-extraPaths = struct();
-for key = fieldnames(resolvedConfig.extra_paths)'
-    extraPaths.(key{1}) = mip.build.compute_addpaths( ...
-        pkgSubdir, resolvedConfig.extra_paths.(key{1}));
-end
+% Match the build and derive mip.json metadata from the staged copy
+[effectiveArch, jsonOpts] = mip.build.resolve_metadata(pkgSubdir, mipConfig, architecture);
+fprintf('Matched build for architecture: %s\n', effectiveArch);
 
 % Run compilation if specified
-if isfield(resolvedConfig, 'compile_script') && ...
-        ~isempty(resolvedConfig.compile_script)
+if isfield(jsonOpts, 'compile_script')
     fprintf('Compiling...\n');
-    mip.build.run_compile(pkgSubdir, resolvedConfig.compile_script);
+    mip.build.run_compile(pkgSubdir, jsonOpts.compile_script);
 end
 
 % Create mip.json
 fprintf('Creating mip.json...\n');
-jsonOpts = struct();
-jsonOpts.paths = pathsList;
-if ~isempty(fieldnames(extraPaths))
-    jsonOpts.extra_paths = extraPaths;
-end
 sourceHashFile = fullfile(pkgSubdir, '.source_hash');
 if exist(sourceHashFile, 'file')
     fid = fopen(sourceHashFile, 'r');
@@ -114,12 +97,6 @@ releaseVersionFile = fullfile(pkgSubdir, '.release_version');
 if exist(releaseVersionFile, 'file')
     jsonOpts.version = effectiveVersion;
     delete(releaseVersionFile);
-end
-if isfield(resolvedConfig, 'test_script') && ~isempty(resolvedConfig.test_script)
-    jsonOpts.test_script = resolvedConfig.test_script;
-end
-if isfield(resolvedConfig, 'compile_script') && ~isempty(resolvedConfig.compile_script)
-    jsonOpts.compile_script = resolvedConfig.compile_script;
 end
 mip.build.create_mip_json(stagingDir, mipConfig, effectiveArch, jsonOpts);
 

--- a/+mip/+build/resolve_metadata.m
+++ b/+mip/+build/resolve_metadata.m
@@ -1,0 +1,49 @@
+function [effectiveArch, jsonOpts] = resolve_metadata(baseDir, mipConfig, architecture)
+%RESOLVE_METADATA   Derive a package's mip.json metadata from its mip.yaml.
+%
+% The shared mip.yaml -> mip.json derivation: match the build for the
+% architecture, merge the build entry with the top-level defaults, and
+% compute the resolved path lists relative to baseDir. Callers pass the
+% result to mip.build.create_mip_json, adding their own fields on top
+% (e.g. editable/source_path for editable installs, or the channel
+% build's hash/version overrides for staged builds).
+%
+% Args:
+%   baseDir      - Directory the path lists are computed against (the
+%                  staged source copy, or the original source directory
+%                  for editable installs)
+%   mipConfig    - Struct from read_mip_yaml
+%   architecture - (Optional) Architecture override. Default: current.
+%
+% Returns:
+%   effectiveArch - Architecture the build was matched for
+%   jsonOpts      - Struct with .paths and, when present, .extra_paths,
+%                   .compile_script, and .test_script
+
+if nargin < 3
+    architecture = '';
+end
+
+[buildEntry, effectiveArch] = mip.build.match_build(mipConfig, architecture);
+resolvedConfig = mip.build.resolve_build_config(mipConfig, buildEntry);
+
+jsonOpts = struct();
+jsonOpts.paths = mip.build.compute_addpaths(baseDir, resolvedConfig.paths);
+
+extraPaths = struct();
+for key = fieldnames(resolvedConfig.extra_paths)'
+    extraPaths.(key{1}) = mip.build.compute_addpaths( ...
+        baseDir, resolvedConfig.extra_paths.(key{1}));
+end
+if ~isempty(fieldnames(extraPaths))
+    jsonOpts.extra_paths = extraPaths;
+end
+
+if isfield(resolvedConfig, 'compile_script') && ~isempty(resolvedConfig.compile_script)
+    jsonOpts.compile_script = resolvedConfig.compile_script;
+end
+if isfield(resolvedConfig, 'test_script') && ~isempty(resolvedConfig.test_script)
+    jsonOpts.test_script = resolvedConfig.test_script;
+end
+
+end

--- a/+mip/+install/from_local.m
+++ b/+mip/+install/from_local.m
@@ -158,19 +158,11 @@ function installEditable(sourceDir, mipConfig, pkgDir, fqn, noCompile)
 
     fprintf('Installing "%s" in editable mode...\n', fqn);
 
-    % Match build and resolve config to determine paths
-    [buildEntry, effectiveArch] = mip.build.match_build(mipConfig);
-    resolvedConfig = mip.build.resolve_build_config(mipConfig, buildEntry);
-
-    % Compute paths relative to the source directory. These are stored
-    % in mip.json verbatim; mip.load resolves them against source_path at
-    % load time (source_path = sourceDir for editable installs).
-    pathsList = mip.build.compute_addpaths(sourceDir, resolvedConfig.paths);
-    extraPaths = struct();
-    for key = fieldnames(resolvedConfig.extra_paths)'
-        extraPaths.(key{1}) = mip.build.compute_addpaths( ...
-            sourceDir, resolvedConfig.extra_paths.(key{1}));
-    end
+    % Match the build and derive mip.json metadata. Paths are computed
+    % relative to the source directory and stored in mip.json verbatim;
+    % mip.load resolves them against source_path at load time
+    % (source_path = sourceDir for editable installs).
+    [effectiveArch, jsonOpts] = mip.build.resolve_metadata(sourceDir, mipConfig);
 
     % Create package directory
     parentDir = fileparts(pkgDir);
@@ -179,43 +171,22 @@ function installEditable(sourceDir, mipConfig, pkgDir, fqn, noCompile)
     end
     mkdir(pkgDir);
 
-    % Determine compile_script
-    compileScript = '';
-    if isfield(resolvedConfig, 'compile_script') && ~isempty(resolvedConfig.compile_script)
-        compileScript = resolvedConfig.compile_script;
-    end
-
-    % Determine test_script
-    testScript = '';
-    if isfield(resolvedConfig, 'test_script') && ~isempty(resolvedConfig.test_script)
-        testScript = resolvedConfig.test_script;
-    end
-
-    % Create mip.json (include compile_script and test_script)
-    jsonOpts = struct('editable', true, 'source_path', sourceDir);
-    jsonOpts.paths = pathsList;
-    if ~isempty(fieldnames(extraPaths))
-        jsonOpts.extra_paths = extraPaths;
-    end
-    if ~isempty(compileScript)
-        jsonOpts.compile_script = compileScript;
-    end
-    if ~isempty(testScript)
-        jsonOpts.test_script = testScript;
-    end
+    % Create mip.json (a thin wrapper pointing to the original source)
+    jsonOpts.editable = true;
+    jsonOpts.source_path = sourceDir;
     mip.build.create_mip_json(pkgDir, mipConfig, effectiveArch, jsonOpts);
 
     fprintf('Editable install complete. Changes in %s will be reflected immediately.\n', sourceDir);
 
     % Compile unless --no-compile was specified
-    if ~isempty(compileScript)
+    if isfield(jsonOpts, 'compile_script')
         if noCompile
             fprintf('\nCompilation skipped (--no-compile).\n');
             fprintf('To compile later, run:\n');
             fprintf('  mip compile %s\n', mipConfig.name);
         else
             fprintf('\nCompiling...\n');
-            mip.build.run_compile(sourceDir, compileScript);
+            mip.build.run_compile(sourceDir, jsonOpts.compile_script);
             fprintf('\nIf you edit files that require recompilation, run:\n');
             fprintf('  mip compile %s\n', mipConfig.name);
         end


### PR DESCRIPTION
Tenth refactor in the stacked series, stacked on top of #325. Targets `refactor/decompose-install`; GitHub will retarget it as the stack merges.

## Problem
The mip.yaml → mip.json derivation — the core of the package format — was implemented twice, with drift:

- `mip.build.prepare_package` (staged/channel builds)
- `mip.install.from_local::installEditable` (editable installs)

Both ran the same ~35-line sequence: `match_build` → `resolve_build_config` → `compute_addpaths` for `paths` and each `extra_paths` group → assemble the `jsonOpts` fields (`paths`, `extra_paths`, `compile_script`, `test_script`) for `create_mip_json`. One inlined the `isfield` conditionals, the other went through temps; any change to the derivation had to be made in both.

## Change
New **`mip.build.resolve_metadata(baseDir, mipConfig, architecture)`** → `[effectiveArch, jsonOpts]` — the single home for the derivation. Callers add only their distinct fields on top:

- `installEditable`: `jsonOpts.editable = true; jsonOpts.source_path = sourceDir;`
- `prepare_package`: the channel build's `.source_hash`/`.commit_hash`/`.release_version` overrides.

Call sites: −67/+15; the helper adds ~50 lines (half docstring).

## Behavior
`create_mip_json` reads opts by field name, so the produced `mip.json` is byte-identical. One cosmetic output reorder in `prepare_package`: "Matched build for architecture" now prints after the copy/strip lines, since the metadata is derived from the staged copy (no test asserts the order). An arch-mismatch error consequently fires after the copy rather than before; callers already clean their staging dirs on failure.

CI runs the full suite.
