### PR TITLE
Refactor: unify the replace machinery behind mip.install.replace_installed

### DIFF
--- a/+mip/+install/from_repository.m
+++ b/+mip/+install/from_repository.m
@@ -284,14 +284,39 @@ function installedFqns = executeInstall(resolvedPackages, allPackagesToInstall, 
 
     installedFqns = {};
 
-    % If a user-requested @version differs from what's installed, replace it.
-    % Old versions are staged to backup dirs; restored on failure below.
-    [reloadAfterInstall, replacementBackups] = replaceExistingVersions(resolvedPackages, packageInfoMap);
+    % If a user-requested @version differs from what's installed, replace
+    % it via the shared download-first machinery. Each replacement is
+    % atomic per package: a failed download leaves that package untouched,
+    % and earlier replacements stand.
+    reloadAfterInstall = {};
+    for i = 1:length(resolvedPackages)
+        s = resolvedPackages{i};
+        if isempty(s.requested_version)
+            continue
+        end
+        pkgDir = mip.paths.get_package_dir(s.fqn);
+        if ~exist(pkgDir, 'dir')
+            continue
+        end
+        installedInfo = mip.config.read_package_json(pkgDir);
+        if strcmp(installedInfo.version, s.requested_version)
+            continue
+        end
+        if ~packageInfoMap.isKey(s.fqn) || ...
+                ~strcmp(packageInfoMap(s.fqn).version, s.requested_version)
+            continue
+        end
+        fprintf('Replacing "%s" %s with requested version %s...\n', ...
+                mip.parse.display_fqn(s.fqn), installedInfo.version, s.requested_version);
+        if mip.install.replace_installed(s.fqn, pkgDir, packageInfoMap(s.fqn))
+            reloadAfterInstall{end+1} = s.fqn; %#ok<AGROW>
+        end
+        fprintf('Successfully installed "%s"\n', mip.parse.display_fqn(s.fqn));
+        installedFqns{end+1} = s.fqn; %#ok<AGROW>
+    end
 
-    % From here on, any error must restore @version backups. If a download
-    % was actually attempted, also prune orphan deps installed during this
-    % call (they aren't in directly_installed.txt yet). Restore happens
-    % before prune so prune doesn't drop deps of the restored packages.
+    % If a download was attempted and failed, prune orphan deps installed
+    % during this call (they aren't in directly_installed.txt yet).
     installAttempted = false;
     try
         % Determine which packages need installing vs already installed.
@@ -302,6 +327,10 @@ function installedFqns = executeInstall(resolvedPackages, allPackagesToInstall, 
         toInstallFqns = {};
         for i = 1:length(allPackagesToInstall)
             fqn = allPackagesToInstall{i};
+            if ismember(fqn, installedFqns)
+                % Just replaced above - neither fresh nor "already installed".
+                continue
+            end
             result = mip.parse.parse_package_arg(fqn);
             existingName = mip.resolve.installed_dir(fqn);
             if ~isempty(existingName) && ~strcmp(existingName, result.name)
@@ -342,7 +371,6 @@ function installedFqns = executeInstall(resolvedPackages, allPackagesToInstall, 
         end
     catch ME
         fprintf('\nInstall failed; rolling back...\n');
-        restoreReplacementBackups(replacementBackups);
         if installAttempted
             try
                 mip.state.prune_unused_packages();
@@ -353,8 +381,6 @@ function installedFqns = executeInstall(resolvedPackages, allPackagesToInstall, 
         end
         rethrow(ME);
     end
-    cleanupReplacementBackups(replacementBackups);
-
     if ~isempty(toInstallFqns)
         for i = 1:length(resolvedPackages)
             s = resolvedPackages{i};
@@ -391,77 +417,6 @@ function installedFqns = executeInstall(resolvedPackages, allPackagesToInstall, 
                 fprintf('  - %s\n', mip.parse.display_fqn(allInstalled{k}));
             end
         end
-    end
-end
-
-function [reloadAfterInstall, replacementBackups] = replaceExistingVersions(resolvedPackages, packageInfoMap)
-% Replace installed packages when the user requested a different @version.
-% Old packages are moved to backup dirs (returned in replacementBackups) so the
-% caller can restore them if a subsequent download/install fails.
-% Returns FQNs that were loaded before replacement (caller should reload them).
-    reloadAfterInstall = {};
-    replacementBackups = struct('fqn', {}, 'pkgDir', {}, 'backupDir', {}, ...
-                                'wasDirectlyInstalled', {});
-    for i = 1:length(resolvedPackages)
-        s = resolvedPackages{i};
-        if isempty(s.requested_version)
-            continue;
-        end
-        pkgDir = mip.paths.get_package_dir(s.fqn);
-        if ~exist(pkgDir, 'dir')
-            continue;
-        end
-        installedInfo = mip.config.read_package_json(pkgDir);
-        if strcmp(installedInfo.version, s.requested_version)
-            continue;
-        end
-        if ~packageInfoMap.isKey(s.fqn) || ...
-                ~strcmp(packageInfoMap(s.fqn).version, s.requested_version)
-            continue;
-        end
-        fprintf('Replacing "%s" %s with requested version %s...\n', ...
-                mip.parse.display_fqn(s.fqn), installedInfo.version, s.requested_version);
-        if mip.state.is_loaded(s.fqn)
-            mip.unload(s.fqn);
-            reloadAfterInstall{end+1} = s.fqn; %#ok<AGROW>
-        end
-        wasDirectlyInstalled = mip.state.is_directly_installed(s.fqn);
-        backupDir = mip.paths.backup_dir(pkgDir);
-        if wasDirectlyInstalled
-            mip.state.remove_directly_installed(s.fqn);
-        end
-        replacementBackups(end+1) = struct(...
-            'fqn', s.fqn, ...
-            'pkgDir', pkgDir, ...
-            'backupDir', backupDir, ...
-            'wasDirectlyInstalled', wasDirectlyInstalled); %#ok<AGROW>
-    end
-end
-
-function restoreReplacementBackups(replacementBackups)
-% Restore packages from backup dirs after a failed replace install.
-    for i = 1:length(replacementBackups)
-        b = replacementBackups(i);
-        try
-            mip.paths.restore_dir(b.backupDir, b.pkgDir);
-            if b.wasDirectlyInstalled
-                mip.state.add_directly_installed(b.fqn);
-            end
-        catch restoreErr
-            warning('mip:rollbackFailed', ...
-                    'Could not restore "%s" from backup: %s', ...
-                    mip.parse.display_fqn(b.fqn), restoreErr.message);
-        end
-    end
-end
-
-function cleanupReplacementBackups(replacementBackups)
-% Remove backup dirs (the replaced old packages) after a successful replace
-% install. These may carry binaries that were loaded before the replace, so
-% route them through the robust trash-based removal.
-    for i = 1:length(replacementBackups)
-        b = replacementBackups(i);
-        mip.paths.remove_dir(b.backupDir);
     end
 end
 

--- a/+mip/+install/replace_installed.m
+++ b/+mip/+install/replace_installed.m
@@ -1,0 +1,55 @@
+function wasLoaded = replace_installed(fqn, pkgDir, latestInfo)
+%REPLACE_INSTALLED   Replace an installed package with a channel version.
+%
+% The shared replace machinery for `mip update` (remote packages) and
+% `mip install <pkg>@<version>` (version switches). Download-first: the
+% new version is downloaded and extracted to a staging directory before
+% the installed copy is touched, so a failed download leaves the package
+% installed and loaded. The old directory is then moved to a backup, the
+% staged version swapped in, and the backup removed; if the swap fails
+% the backup is restored. Atomic per package.
+%
+% Args:
+%   fqn        - Canonical FQN of the installed package
+%   pkgDir     - Its installed directory
+%   latestInfo - Channel-index variant struct (mhl_url, mhl_sha256, ...)
+%
+% Returns:
+%   wasLoaded - true if the package was loaded (it is unloaded here;
+%               the caller decides when to reload).
+
+    tempDir = tempname;
+    mkdir(tempDir);
+    cleanupTemp = onCleanup(@() rmTempDir(tempDir));
+
+    expectedSha = '';
+    if isfield(latestInfo, 'mhl_sha256')
+        expectedSha = latestInfo.mhl_sha256;
+    end
+    mhlPath = mip.channel.download_mhl(latestInfo.mhl_url, tempDir, expectedSha);
+    stagingDir = fullfile(tempDir, 'staging');
+    mip.channel.extract_mhl(mhlPath, stagingDir);
+
+    % Download succeeded — now it is safe to unload and swap.
+    wasLoaded = mip.state.is_loaded(fqn);
+    if wasLoaded
+        mip.unload(fqn);
+    end
+
+    backupDir = mip.paths.backup_dir(pkgDir);
+    try
+        movefile(stagingDir, pkgDir);
+    catch ME
+        mip.paths.restore_dir(backupDir, pkgDir);
+        rethrow(ME);
+    end
+    % The backup is the replaced old package; remove it robustly in case
+    % a binary it shipped was loaded before the replace.
+    mip.paths.remove_dir(backupDir);
+end
+
+function rmTempDir(d)
+    if exist(d, 'dir')
+        rmdir(d, 's');
+    end
+end

--- a/+mip/update.m
+++ b/+mip/update.m
@@ -151,12 +151,9 @@ function update(varargin)
                         if ~needs
                             continue
                         end
-                        p.latestInfo = latestInfo;
-                        if mip.state.is_loaded(p.fqn)
-                            fprintf('Unloading "%s" before update...\n', mip.parse.display_fqn(p.fqn));
-                            mip.unload(p.fqn);
-                        end
-                        downloadAndReplace(p);
+                        mip.install.replace_installed(p.fqn, p.pkgDir, latestInfo);
+                        fprintf('Successfully updated "%s" to %s\n', ...
+                                mip.parse.display_fqn(p.fqn), latestInfo.version);
                         updatedRemoteFqns{end+1} = p.fqn; %#ok<AGROW>
                     end
             end
@@ -368,47 +365,6 @@ function [tf, latestInfo] = checkRemoteNeedsUpdate(p, force)
 
     fprintf('Updating "%s": %s -> %s\n', displayFqn, installedVersion, latestInfo.version);
     tf = true;
-end
-
-function downloadAndReplace(p)
-% Download the new version to a staging directory, then swap it in.
-% The old package is moved to a backup and restored if the swap fails,
-% so a failure at any point does not destroy the installed copy.
-
-    displayFqn = mip.parse.display_fqn(p.fqn);
-
-    tempDir = tempname;
-    mkdir(tempDir);
-    try
-        expectedSha = '';
-        if isfield(p.latestInfo, 'mhl_sha256')
-            expectedSha = p.latestInfo.mhl_sha256;
-        end
-        mhlPath = mip.channel.download_mhl(p.latestInfo.mhl_url, tempDir, expectedSha);
-        stagingDir = fullfile(tempDir, 'staging');
-        mip.channel.extract_mhl(mhlPath, stagingDir);
-
-        % Download succeeded — swap old package out and new one in
-        backupDir = mip.paths.backup_dir(p.pkgDir);
-        try
-            movefile(stagingDir, p.pkgDir);
-        catch ME
-            mip.paths.restore_dir(backupDir, p.pkgDir);
-            rethrow(ME);
-        end
-        % The backup is the replaced old package; remove it robustly in case
-        % a binary it shipped was loaded before the update.
-        mip.paths.remove_dir(backupDir);
-        fprintf('Successfully updated "%s" to %s\n', displayFqn, p.latestInfo.version);
-    catch ME
-        if exist(tempDir, 'dir')
-            rmdir(tempDir, 's');
-        end
-        rethrow(ME);
-    end
-    if exist(tempDir, 'dir')
-        rmdir(tempDir, 's');
-    end
 end
 
 function installMissingDeps(remoteFqns)


### PR DESCRIPTION
Twelfth refactor in the stacked series, stacked on top of #327.

update's remote path and install's @version replacement were two implementations of "replace an installed package with a chosen version, preserving load state". Both now call **mip.install.replace_installed** — download-first staging swap, atomic per package — keeping only their version policy and reload strategy. Net −129/+40 at call sites plus the ~55-line primitive; update's `downloadAndReplace` and from_repository's backup-ledger trio are deleted.

**Approved behavior changes:** (1) replacement is download-first on both paths — a failed download leaves the package installed *and loaded*; update's redundant "Unloading … before update" line is dropped. (2) A multi-@version install batch is atomic per package like update — earlier replacements stand if a later one fails. The `directly_installed` mark is no longer removed/restored mid-replacement. Spec §7.1 and the explicit-version-upgrade section updated; `TestInstallVersionRollback`'s single-package semantics unchanged.

CI runs the full suite.