### PR TITLE
Move test_mip.m into tests/

### DIFF
--- a/mip.yaml
+++ b/mip.yaml
@@ -9,7 +9,7 @@ dependencies: []
 paths:
   - path: "."
 
-test_script: test_mip.m
+test_script: tests/test_mip.m
 
 builds:
   - architectures: [any]

--- a/tests/test_mip.m
+++ b/tests/test_mip.m
@@ -1,12 +1,11 @@
 % Test script for the mip package.
-% Invoked by `mip test mip`. Runs the unit tests in tests/run_tests.m,
+% Invoked by `mip test mip`. Runs the unit tests in run_tests.m,
 % errors if any test failed, and prints SUCCESS otherwise.
 
 scriptDir = fileparts(mfilename('fullpath'));
-testsDir = fullfile(scriptDir, 'tests');
 
-addpath(testsDir);
-cleanupObj = onCleanup(@() rmpath(testsDir));
+addpath(scriptDir);
+cleanupObj = onCleanup(@() rmpath(scriptDir));
 
 results = run_tests();
 

--- a/tests/test_mip.m
+++ b/tests/test_mip.m
@@ -2,10 +2,6 @@
 % Invoked by `mip test mip`. Runs the unit tests in run_tests.m,
 % errors if any test failed, and prints SUCCESS otherwise.
 
-scriptDir = fileparts(mfilename('fullpath'));
-
-addpath(scriptDir);  % run_tests removes it again in its own cleanup
-
 results = run_tests();
 
 if isempty(results) || ~all([results.Passed])

--- a/tests/test_mip.m
+++ b/tests/test_mip.m
@@ -4,8 +4,7 @@
 
 scriptDir = fileparts(mfilename('fullpath'));
 
-addpath(scriptDir);
-cleanupObj = onCleanup(@() rmpath(scriptDir));
+addpath(scriptDir);  % run_tests removes it again in its own cleanup
 
 results = run_tests();
 


### PR DESCRIPTION
Thirteenth change in the stacked series, stacked on top of #328.

Moves the `mip.yaml` test_script entry point (`test_mip.m`, run by `mip test mip`) from the repo root into `tests/`, alongside the suite it runs. `mip.yaml` now declares `test_script: tests/test_mip.m` (the test runner cds to the source root and `run()` accepts relative subpaths), and the script's own path logic adds its containing directory instead of deriving `tests/` from the root.

CI runs the full suite.