### PR TITLE
update: reject @version specifiers

### DIFF
--- a/+mip/update.m
+++ b/+mip/update.m
@@ -36,7 +36,10 @@ function update(varargin)
 %
 % Any packages that were loaded before the update are reloaded afterward.
 %
-% Accepts both bare package names and fully qualified names.
+% Accepts both bare package names and fully qualified names. Version
+% specifiers are not accepted: update always stays on the installed
+% version's branch or release stream. To switch to a different branch or
+% version, use "mip install <package>@<version>" instead.
 
     if nargin < 1
         error('mip:update:noPackage', 'At least one package name is required for update command.');
@@ -45,6 +48,20 @@ function update(varargin)
     % Check for --force, --all, --deps, and --no-compile flags
     [opts, args] = mip.parse.flags(varargin, struct( ...
         'force', false, 'all', false, 'deps', false, 'no_compile', false));
+
+    % Reject @version suffixes up front. Update always stays on the
+    % installed version's branch or release stream (see
+    % checkRemoteNeedsUpdate); switching to a different branch or version
+    % requires an explicit "mip install <pkg>@<version>".
+    for i = 1:length(args)
+        parsed = mip.parse.parse_package_arg(args{i});
+        if ~isempty(parsed.version)
+            error('mip:update:versionNotAllowed', ...
+                  ['A version specifier is not allowed with "mip update" ("%s"). ' ...
+                   'To switch to a different branch or version, run: mip install %s'], ...
+                  args{i}, args{i});
+        end
+    end
 
     % --all: expand to all installed packages. Pinned packages are
     % filtered up-front for --all (the user did not specify an explicit

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -683,7 +683,7 @@ Packages can be **pinned** to block all `mip update` paths from upgrading them; 
 
 ### 7.1 Update Flow (`mip update X Y Z`)
 
-1. Parse `--force`, `--all`, `--deps`, and `--no-compile` flags.
+1. Parse `--force`, `--all`, `--deps`, and `--no-compile` flags. Any named argument carrying an `@version` suffix raises `mip:update:versionNotAllowed` — update always stays on the installed version's branch or release stream (see [§7.1.1](#711-target-version-selection-for-update)); switching to a different branch or version requires an explicit `mip install X@<version>`.
 2. If `--all` is specified, expand the argument list to all installed packages, then drop any pinned packages from the batch (a "Skipping pinned package" message is printed for each). `--force` does **not** override the pin filter (see [§7.11](#711-pinned-packages)). If every installed package is pinned, a message is printed and `mip update --all` returns without error. Otherwise (no `--all`), drop any explicitly named pinned packages from the batch with a "Skipping pinned package" message; the unpinned named packages still update. The user must `mip unpin <pkg>` first to update a pinned package. If every named package is pinned, the call returns without error. If `--deps` is specified, expand each remaining package's installed transitive dependencies into the argument list, dropping any pinned dependencies with a "Skipping pinned dependency" message.
 3. Resolve each argument to a `(fqn, owner, channel, name, pkgDir, pkgInfo, isLocal, sourcePath, editable, noSource)` tuple. Validation errors are raised **before** any destructive action:
    - Not installed → `mip:update:notInstalled`.

--- a/tests/TestUpdateLocal.m
+++ b/tests/TestUpdateLocal.m
@@ -56,6 +56,46 @@ classdef TestUpdateLocal < matlab.unittest.TestCase
                 'mip:update:notInstalled');
         end
 
+        %% --- @version rejection ---
+
+        function testUpdateVersionSpec_ErrorsBareName(testCase)
+            testCase.verifyError(@() mip.update('somepkg@1.2.3'), ...
+                'mip:update:versionNotAllowed');
+        end
+
+        function testUpdateVersionSpec_ErrorsFQN(testCase)
+            testCase.verifyError(@() mip.update('mip-org/core/somepkg@main'), ...
+                'mip:update:versionNotAllowed');
+        end
+
+        function testUpdateVersionSpec_ErrorsForInstalledPackage(testCase)
+            % Rejected even when the package is installed — the user must
+            % use "mip install <pkg>@<version>" to switch versions.
+            srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg', ...
+                'version', '1.0.0');
+            mip.install(srcDir);
+            testCase.verifyError(@() mip.update('local/mypkg@2.0.0'), ...
+                'mip:update:versionNotAllowed');
+        end
+
+        function testUpdateVersionSpec_ErrorsInMultiPackageBatch(testCase)
+            % A @version anywhere in the batch fails fast, before any
+            % package is updated.
+            srcDir = createTestSourcePackage(testCase.SourceDir, 'mypkg', ...
+                'version', '1.0.0');
+            mip.install(srcDir);
+            pkgDir = fullfile(testCase.TestRoot, 'packages', 'local', 'mypkg');
+            info1 = mip.config.read_package_json(pkgDir);
+
+            testCase.verifyError( ...
+                @() mip.update('local/mypkg', 'somepkg@1.0'), ...
+                'mip:update:versionNotAllowed');
+
+            info2 = mip.config.read_package_json(pkgDir);
+            testCase.verifyEqual(info2.timestamp, info1.timestamp, ...
+                'No package should have been updated');
+        end
+
         %% --- Local package update always reinstalls ---
 
         function testUpdateLocalPackage_AlwaysReinstalls(testCase)


### PR DESCRIPTION
Closes #302

`mip update mip@main` silently stripped the `@main` suffix and just re-checked the installed version, reporting "already up to date" instead of switching versions. Version specifiers are now rejected up front:

```
>> mip update mip@main
Error: A version specifier is not allowed with "mip update" ("mip@main"). To switch to a different branch or version, run: mip install mip@main
```

- `mip.update` raises `mip:update:versionNotAllowed` if any named argument carries an `@version` suffix, before any package is touched
- Spec §7.1 updated accordingly