### PR TITLE
Auto-dispatch mip build on mip-core on push to main

### DIFF
--- a/.github/workflows/dispatch-core-build.yml
+++ b/.github/workflows/dispatch-core-build.yml
@@ -1,0 +1,40 @@
+name: Dispatch mip build on mip-core
+
+# On every push to `main`, ask the mip-core channel to rebuild the `mip`
+# package's `main` release, which tracks this repo's `main` branch
+# (packages/mip/main/source.yaml in mip-org/mip-core). Without this, the
+# channel only notices the moved branch on its daily scheduled probe (up to
+# 24h later).
+#
+# Cross-repo dispatch: the default GITHUB_TOKEN is scoped to this repo and
+# cannot start a workflow in mip-org/mip-core. This uses a personal classic
+# PAT with the `repo` scope, stored as the MIP_CORE_DISPATCH_TOKEN secret.
+# (`repo` is the classic scope the workflow-dispatch API needs; the narrower
+# `public_repo` also works while mip-core stays public.)
+#
+# build-package.yml rebuilds only if the package's source hash actually moved
+# (force=false), so a push that doesn't change the packaged tree is a no-op.
+# The `mip` package is architecture `any` (see mip.yaml), so one dispatch
+# covers it.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch mip build on mip-core
+        env:
+          GH_TOKEN: ${{ secrets.MIP_CORE_DISPATCH_TOKEN }}
+        run: |
+          gh workflow run build-package.yml \
+            --repo mip-org/mip-core \
+            -f package_path=packages/mip/main \
+            -f architecture=any \
+            -f force=false


### PR DESCRIPTION
On every push to `main`, dispatch `build-package.yml` on `mip-org/mip-core` to rebuild the `mip` package's `main` release (`packages/mip/main`), which tracks this repo's `main` branch. Without this, the channel only notices the moved branch on its daily scheduled probe (up to 24h later).

## How it works
- Trigger: push to `main` (also `workflow_dispatch` for manual runs).
- Fires `gh workflow run build-package.yml` against `mip-org/mip-core` for `packages/mip/main`, architecture `any` (the `mip` package is `any` per its `mip.yaml`).
- `force=false`, so `build-package.yml` rebuilds only when the package's source hash actually moved — a push that doesn't change the packaged tree is a no-op.

## Required secret
Cross-repo dispatch needs a credential the default `GITHUB_TOKEN` can't provide (it's scoped to this repo). This reads a repository secret **`MIP_CORE_DISPATCH_TOKEN`** — a classic PAT with the `repo` scope. Already configured on this repo.

## Verifying after merge
Once on `main`: either the next push to `main` triggers it, or run it manually via **Actions → Dispatch mip build on mip-core → Run workflow**, then confirm a new **Build Package** run appears in `mip-org/mip-core` for `packages/mip/main`.