### PR TITLE
Print a self-update notice when the core channel index is loaded

### DIFF
--- a/+mip/+channel/check_mip_update.m
+++ b/+mip/+channel/check_mip_update.m
@@ -1,0 +1,37 @@
+function check_mip_update(index, installedVersion)
+%CHECK_MIP_UPDATE   Print a notice when the core channel offers a newer mip.
+%
+% Args:
+%   index            - Parsed index struct (from fetch_index)
+%   installedVersion - Optional. Version string of the running mip; defaults
+%                      to mip.version(). Exposed as an argument for testing.
+%
+% Called by mip.channel.fetch_index whenever the mip-org/core index is
+% loaded (from cache or network). Composes the notice via
+% mip.channel.mip_update_message and prints it. Each distinct notice is
+% printed at most once per mip command: the printed text is remembered in
+% the MIP_UPDATE_NOTICE_SHOWN state key, which mip.m clears at dispatch, so
+% repeated index loads within a single command do not repeat the notice.
+%
+% Best-effort: never raises, so the notice can never break the command in
+% progress.
+
+try
+    if nargin < 2 || isempty(installedVersion)
+        installedVersion = mip.version();
+    end
+    msg = mip.channel.mip_update_message(index, installedVersion);
+    if isempty(msg)
+        return
+    end
+    shown = mip.state.key_value_get('MIP_UPDATE_NOTICE_SHOWN');
+    if ischar(shown) && strcmp(shown, msg)
+        return
+    end
+    mip.state.key_value_set('MIP_UPDATE_NOTICE_SHOWN', msg);
+    fprintf('%s\n', msg);
+catch
+    % The update notice is advisory only; ignore any failure.
+end
+
+end

--- a/+mip/+channel/fetch_index.m
+++ b/+mip/+channel/fetch_index.m
@@ -13,6 +13,9 @@ function index = fetch_index(channel, forceRefresh)
 % <root>/cache/index/<owner>/<channel>.json. The cache entry is reused if it
 % is less than CACHE_TTL_SECONDS old, unless forceRefresh is true. Failed
 % fetches are not cached.
+%
+% Every load of the mip-org/core index (cached or fresh) also triggers the
+% mip self-update notice check (mip.channel.check_mip_update).
 
 CACHE_TTL_SECONDS = 30;
 
@@ -43,6 +46,7 @@ if ~forceRefresh && ~isempty(cacheFile) && isfile(cacheFile)
             try
                 indexJson = fileread(cacheFile);
                 index = parse_index_json(indexJson);
+                maybe_check_mip_update(index, channelOwner, channelName);
                 return
             catch
                 % Corrupt cache; fall through to re-fetch.
@@ -66,6 +70,7 @@ catch ME
 end
 
 index = parse_index_json(indexJson);
+maybe_check_mip_update(index, channelOwner, channelName);
 
 if ~isempty(cacheFile)
     try
@@ -83,6 +88,15 @@ if ~isempty(cacheFile)
     end
 end
 
+end
+
+
+function maybe_check_mip_update(index, channelOwner, channelName)
+% Whenever the core channel index is loaded (cache or network), check
+% whether the running mip is outdated and print a self-update notice.
+if strcmp(channelOwner, 'mip-org') && strcmp(channelName, 'core')
+    mip.channel.check_mip_update(index);
+end
 end
 
 

--- a/+mip/+channel/mip_update_message.m
+++ b/+mip/+channel/mip_update_message.m
@@ -1,0 +1,105 @@
+function msg = mip_update_message(index, installedVersion)
+%MIP_UPDATE_MESSAGE   Compose the mip self-update notice for a channel index.
+%
+% Args:
+%   index            - Parsed index struct (from fetch_index)
+%   installedVersion - Version string of the running mip installation
+%
+% Returns:
+%   msg - Notice text suggesting "mip update mip", or '' when no notice
+%         applies.
+%
+% Two checks are performed, in priority order:
+%
+%   1. If the index carries a numeric top-level min_mip_version field and
+%      the installed version is below it, the notice states that an update
+%      is REQUIRED by the channel.
+%   2. Otherwise, if the latest numeric version of the "mip" package
+%      published in the index is greater than the installed version, the
+%      notice suggests updating.
+%
+% No notice is produced when the installed version is non-numeric (e.g. a
+% branch like 'main', or 'unspecified' from a source checkout): there is
+% no meaningful ordering against numeric releases.
+
+msg = '';
+
+if isstring(installedVersion) && isscalar(installedVersion)
+    installedVersion = char(installedVersion);
+end
+if ~ischar(installedVersion) || isempty(installedVersion) || ...
+        ~mip.resolve.is_numeric_version(installedVersion)
+    return
+end
+
+minRequired = read_min_mip_version(index);
+if ~isempty(minRequired) && ...
+        mip.resolve.compare_versions(installedVersion, minRequired) < 0
+    msg = sprintf(['This channel requires mip %s or newer (installed: %s). ' ...
+                   'An update is required: run "mip update mip".'], ...
+                  minRequired, installedVersion);
+    return
+end
+
+latest = latest_numeric_mip_version(index);
+if ~isempty(latest) && ...
+        mip.resolve.compare_versions(latest, installedVersion) > 0
+    msg = sprintf(['A newer version of mip is available (%s; installed: %s). ' ...
+                   'Run "mip update mip" to update.'], ...
+                  latest, installedVersion);
+end
+
+end
+
+
+function minRequired = read_min_mip_version(index)
+% Optional top-level index field. Ignored unless it is a numeric version.
+minRequired = '';
+if ~isstruct(index) || ~isfield(index, 'min_mip_version')
+    return
+end
+v = index.min_mip_version;
+if isstring(v) && isscalar(v)
+    v = char(v);
+end
+if ischar(v) && ~isempty(v) && mip.resolve.is_numeric_version(v)
+    minRequired = v;
+end
+end
+
+
+function latest = latest_numeric_mip_version(index)
+% Highest numeric version among index entries named "mip" (name
+% equivalence, see mip.name.match). Non-numeric versions (e.g. a branch
+% release like 'main') are ignored.
+latest = '';
+if ~isstruct(index) || ~isfield(index, 'packages')
+    return
+end
+packages = index.packages;
+if ~iscell(packages)
+    packages = num2cell(packages);
+end
+for i = 1:length(packages)
+    pkg = packages{i};
+    if ~isstruct(pkg) || ~isfield(pkg, 'name') || ~isfield(pkg, 'version')
+        continue
+    end
+    if ~ischar(pkg.name) && ~(isstring(pkg.name) && isscalar(pkg.name))
+        continue
+    end
+    if ~mip.name.match(pkg.name, 'mip')
+        continue
+    end
+    v = pkg.version;
+    if isstring(v) && isscalar(v)
+        v = char(v);
+    end
+    if ~ischar(v) || isempty(v) || ~mip.resolve.is_numeric_version(v)
+        continue
+    end
+    if isempty(latest) || mip.resolve.compare_versions(v, latest) > 0
+        latest = v;
+    end
+end
+end

--- a/+mip/+channel/mip_update_message.m
+++ b/+mip/+channel/mip_update_message.m
@@ -11,9 +11,9 @@ function msg = mip_update_message(index, installedVersion)
 %
 % Two checks are performed, in priority order:
 %
-%   1. If the index carries a numeric top-level min_mip_version field and
-%      the installed version is below it, the notice states that an update
-%      is REQUIRED by the channel.
+%   1. If the index carries a numeric top-level mip_compatibility_floor
+%      field and the installed version is below it, the notice states that
+%      an update is REQUIRED by the channel.
 %   2. Otherwise, if the latest numeric version of the "mip" package
 %      published in the index is greater than the installed version, the
 %      notice suggests updating.
@@ -32,12 +32,12 @@ if ~ischar(installedVersion) || isempty(installedVersion) || ...
     return
 end
 
-minRequired = read_min_mip_version(index);
-if ~isempty(minRequired) && ...
-        mip.resolve.compare_versions(installedVersion, minRequired) < 0
+floorVersion = read_mip_compatibility_floor(index);
+if ~isempty(floorVersion) && ...
+        mip.resolve.compare_versions(installedVersion, floorVersion) < 0
     msg = sprintf(['This channel requires mip %s or newer (installed: %s). ' ...
                    'An update is required: run "mip update mip".'], ...
-                  minRequired, installedVersion);
+                  floorVersion, installedVersion);
     return
 end
 
@@ -52,18 +52,18 @@ end
 end
 
 
-function minRequired = read_min_mip_version(index)
+function floorVersion = read_mip_compatibility_floor(index)
 % Optional top-level index field. Ignored unless it is a numeric version.
-minRequired = '';
-if ~isstruct(index) || ~isfield(index, 'min_mip_version')
+floorVersion = '';
+if ~isstruct(index) || ~isfield(index, 'mip_compatibility_floor')
     return
 end
-v = index.min_mip_version;
+v = index.mip_compatibility_floor;
 if isstring(v) && isscalar(v)
     v = char(v);
 end
 if ischar(v) && ~isempty(v) && mip.resolve.is_numeric_version(v)
-    minRequired = v;
+    floorVersion = v;
 end
 end
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1175,7 +1175,7 @@ Whenever the `mip-org/core` index is loaded through [`mip.channel.fetch_index`](
 
 Two checks run, in priority order:
 
-1. **Required minimum version.** The index may carry an optional top-level `min_mip_version` field (a numeric version string). If the installed mip version is numerically below it, the notice states that an update is **required** and suggests `mip update mip`. This is advisory only: mip keeps functioning normally — no command is blocked. A `min_mip_version` that is missing, empty, or non-numeric is ignored.
+1. **Compatibility floor.** The index may carry an optional top-level `mip_compatibility_floor` field (a numeric version string). If the installed mip version is numerically below it, the notice states that an update is **required** and suggests `mip update mip`. This is advisory only: mip keeps functioning normally — no command is blocked. A `mip_compatibility_floor` that is missing, empty, or non-numeric is ignored.
 2. **Newer version available.** Otherwise, the latest **numeric** version published for the `mip` package in the index (name equivalence per [§1.8](#18-name-equivalence); non-numeric versions like `main` are ignored) is compared against the installed version. If it is greater, the notice suggests running `mip update mip`.
 
 Both checks are skipped entirely when the installed mip version is **non-numeric** (e.g. a branch install like `main`, or `unspecified` from a source checkout) — there is no meaningful ordering against numeric releases. The installed version is resolved via `mip.version()` ([§9.4](#94-mip-version)).

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -290,6 +290,8 @@ The `--editable` / `-e` flag is only valid when at least one local path is prese
 
 Channel index fetches go through an on-disk cache (see [§11.6](#116-channel-index-cache)). Repeat fetches of the same channel within the cache TTL are served from the cache without hitting the network.
 
+Every load of the `mip-org/core` index (cached or fresh, from any command) also triggers the mip self-update notice check (see [§11.8](#118-core-channel-mip-self-update-notice)).
+
 #### 3.1.3 Version Selection (`select_best_version`)
 
 Given all available versions for a package:
@@ -1166,6 +1168,22 @@ This replaces the earlier Windows-only "move aside on `rmdir` failure" logic and
 **Which removals use it.** `mip uninstall`, dependency pruning ([§6.2](#62-dependency-pruning-after-uninstall)), and the old-package backups discarded after a successful `mip update`/`mip install` replacement all go through `remove_dir`. Throwaway temporary directories (freshly downloaded/extracted staging, failed-download cleanup) and the self-update of mip itself use a plain `rmdir` — they never hold a binary that was loaded in this session. The self-uninstall root deletion is also a direct `rmdir` (the trash cannot hold its own root), preceded by clearing all MEX ([§6.4](#64-self-uninstall-mip-uninstall-mip)).
 
 The `.trash` directory lives beside `packages/` under the mip root, so it is never mistaken for a package and is not scanned by package discovery.
+
+### 11.8 Core-Channel mip Self-Update Notice
+
+Whenever the `mip-org/core` index is loaded through [`mip.channel.fetch_index`](../+mip/+channel/fetch_index.m) — from the network **or** from the on-disk cache ([§11.6](#116-channel-index-cache)), and regardless of which command triggered the fetch — mip checks whether the running mip installation is outdated and prints a self-update notice ([`mip.channel.check_mip_update`](../+mip/+channel/check_mip_update.m), message composition in [`mip.channel.mip_update_message`](../+mip/+channel/mip_update_message.m)). Non-core channel indexes are never checked.
+
+Two checks run, in priority order:
+
+1. **Required minimum version.** The index may carry an optional top-level `min_mip_version` field (a numeric version string). If the installed mip version is numerically below it, the notice states that an update is **required** and suggests `mip update mip`. This is advisory only: mip keeps functioning normally — no command is blocked. A `min_mip_version` that is missing, empty, or non-numeric is ignored.
+2. **Newer version available.** Otherwise, the latest **numeric** version published for the `mip` package in the index (name equivalence per [§1.8](#18-name-equivalence); non-numeric versions like `main` are ignored) is compared against the installed version. If it is greater, the notice suggests running `mip update mip`.
+
+Both checks are skipped entirely when the installed mip version is **non-numeric** (e.g. a branch install like `main`, or `unspecified` from a source checkout) — there is no meaningful ordering against numeric releases. The installed version is resolved via `mip.version()` ([§9.4](#94-mip-version)).
+
+Noise control and robustness:
+
+- Each distinct notice is printed **at most once per mip command**: the printed text is remembered in the `MIP_UPDATE_NOTICE_SHOWN` state key, which the `mip` CLI entry point clears at dispatch. Repeated core-index loads within a single command (e.g. a multi-package install) therefore print the notice only once, while the next command prints it again.
+- The check is **best-effort and never raises**: a malformed index, an unreadable version, or any other failure is silently ignored so the notice can never break the command in progress.
 
 ---
 

--- a/mip.m
+++ b/mip.m
@@ -71,6 +71,11 @@ end
 mip.state.key_value_append('MIP_LOADED_PACKAGES', 'gh/mip-org/core/mip');
 mip.state.key_value_append('MIP_STICKY_PACKAGES', 'gh/mip-org/core/mip');
 
+% Let the core-channel self-update notice print again for this command
+% (mip.channel.check_mip_update prints each distinct notice at most once
+% per command).
+mip.state.key_value_set('MIP_UPDATE_NOTICE_SHOWN', '');
+
 % Normalize command to lowercase
 command = lower(command);
 

--- a/tests/TestMipUpdateNotice.m
+++ b/tests/TestMipUpdateNotice.m
@@ -1,0 +1,263 @@
+classdef TestMipUpdateNotice < matlab.unittest.TestCase
+%TESTMIPUPDATENOTICE   Self-update notice when loading the core channel index.
+%   Covers mip.channel.mip_update_message (notice composition, including the
+%   optional min_mip_version index field), mip.channel.check_mip_update
+%   (printing + once-per-command suppression), and the fetch_index wiring
+%   (the check applies only to the mip-org/core channel).
+
+    properties
+        OrigMipRoot
+        OrigNoticeShown
+        TestRoot
+    end
+
+    methods (TestMethodSetup)
+        function setupTestEnvironment(testCase)
+            testCase.OrigMipRoot = getenv('MIP_ROOT');
+            testCase.OrigNoticeShown = getappdata(0, 'MIP_UPDATE_NOTICE_SHOWN');
+            testCase.TestRoot = [tempname '_mip_notice_test'];
+            mkdir(testCase.TestRoot);
+            mkdir(fullfile(testCase.TestRoot, 'packages'));
+            setenv('MIP_ROOT', testCase.TestRoot);
+            mip.state.key_value_set('MIP_UPDATE_NOTICE_SHOWN', '');
+        end
+    end
+
+    methods (TestMethodTeardown)
+        function teardownTestEnvironment(testCase)
+            setenv('MIP_ROOT', testCase.OrigMipRoot);
+            setappdata(0, 'MIP_UPDATE_NOTICE_SHOWN', testCase.OrigNoticeShown);
+            if exist(testCase.TestRoot, 'dir')
+                rmdir(testCase.TestRoot, 's');
+            end
+        end
+    end
+
+    methods (Test)
+
+        % ---- mip_update_message: latest-version suggestion ----
+
+        function testNewerVersionSuggestsUpdate(testCase)
+            index = makeIndex({mipEntry('1.2.0')});
+            msg = mip.channel.mip_update_message(index, '1.1.0');
+            testCase.verifySubstring(msg, '1.2.0');
+            testCase.verifySubstring(msg, '1.1.0');
+            testCase.verifySubstring(msg, 'mip update mip');
+            testCase.verifyEmpty(strfind(msg, 'required'));
+        end
+
+        function testUpToDateNoMessage(testCase)
+            index = makeIndex({mipEntry('1.2.0')});
+            msg = mip.channel.mip_update_message(index, '1.2.0');
+            testCase.verifyEmpty(msg);
+        end
+
+        function testInstalledNewerNoMessage(testCase)
+            index = makeIndex({mipEntry('1.2.0')});
+            msg = mip.channel.mip_update_message(index, '1.3.0');
+            testCase.verifyEmpty(msg);
+        end
+
+        function testNonNumericInstalledNoMessage(testCase)
+            % A source checkout ('unspecified') or branch install ('main')
+            % has no meaningful ordering against numeric releases.
+            index = makeIndex({mipEntry('99.0.0')});
+            index.min_mip_version = '99.0.0';
+            testCase.verifyEmpty(mip.channel.mip_update_message(index, 'main'));
+            testCase.verifyEmpty(mip.channel.mip_update_message(index, 'unspecified'));
+            testCase.verifyEmpty(mip.channel.mip_update_message(index, ''));
+        end
+
+        function testNoMipEntryNoMessage(testCase)
+            index = makeIndex({pkgEntry('chebfun', '5.0.0')});
+            msg = mip.channel.mip_update_message(index, '1.0.0');
+            testCase.verifyEmpty(msg);
+        end
+
+        function testNonNumericIndexVersionsIgnored(testCase)
+            % A branch release of mip (e.g. 'main') never triggers the notice.
+            index = makeIndex({mipEntry('main')});
+            msg = mip.channel.mip_update_message(index, '1.0.0');
+            testCase.verifyEmpty(msg);
+        end
+
+        function testHighestNumericVersionWins(testCase)
+            % Numeric comparison, not lexical: 1.10.0 > 1.9.0.
+            index = makeIndex({mipEntry('1.9.0'), mipEntry('1.10.0'), mipEntry('main')});
+            msg = mip.channel.mip_update_message(index, '1.9.5');
+            testCase.verifySubstring(msg, '1.10.0');
+        end
+
+        function testNameEquivalenceMatchesMip(testCase)
+            % The identity check uses name equivalence (case-insensitive).
+            index = makeIndex({pkgEntry('MIP', '2.0.0')});
+            msg = mip.channel.mip_update_message(index, '1.0.0');
+            testCase.verifySubstring(msg, '2.0.0');
+        end
+
+        function testStructArrayPackagesHandled(testCase)
+            % index.packages may arrive as a struct array rather than a cell.
+            index = struct('packages', ...
+                struct('name', 'mip', 'version', '3.0.0', 'architecture', 'any'));
+            msg = mip.channel.mip_update_message(index, '1.0.0');
+            testCase.verifySubstring(msg, '3.0.0');
+        end
+
+        % ---- mip_update_message: min_mip_version ----
+
+        function testMinVersionUnsatisfiedSaysRequired(testCase)
+            index = makeIndex({mipEntry('1.2.0')});
+            index.min_mip_version = '1.2.0';
+            msg = mip.channel.mip_update_message(index, '1.1.0');
+            testCase.verifySubstring(msg, 'required');
+            testCase.verifySubstring(msg, '1.2.0');
+            testCase.verifySubstring(msg, '1.1.0');
+            testCase.verifySubstring(msg, 'mip update mip');
+        end
+
+        function testMinVersionSatisfiedFallsBackToSuggestion(testCase)
+            index = makeIndex({mipEntry('1.3.0')});
+            index.min_mip_version = '1.1.0';
+            msg = mip.channel.mip_update_message(index, '1.2.0');
+            testCase.verifySubstring(msg, '1.3.0');
+            testCase.verifyEmpty(strfind(msg, 'required'));
+        end
+
+        function testMinVersionWithoutMipEntryStillRequired(testCase)
+            % min_mip_version applies even if the index publishes no mip entry.
+            index = makeIndex({pkgEntry('chebfun', '5.0.0')});
+            index.min_mip_version = '2.0.0';
+            msg = mip.channel.mip_update_message(index, '1.0.0');
+            testCase.verifySubstring(msg, 'required');
+        end
+
+        function testNonNumericMinVersionIgnored(testCase)
+            index = makeIndex({mipEntry('1.0.0')});
+            index.min_mip_version = 'main';
+            msg = mip.channel.mip_update_message(index, '1.0.0');
+            testCase.verifyEmpty(msg);
+        end
+
+        function testEmptyMinVersionIgnored(testCase)
+            index = makeIndex({mipEntry('1.0.0')});
+            index.min_mip_version = '';
+            msg = mip.channel.mip_update_message(index, '1.0.0');
+            testCase.verifyEmpty(msg);
+        end
+
+        % ---- check_mip_update: printing and suppression ----
+
+        function testCheckPrintsNotice(testCase)
+            index = makeIndex({mipEntry('9.9.9')});
+            output = evalc('mip.channel.check_mip_update(index, ''1.0.0'')');
+            testCase.verifySubstring(output, 'mip update mip');
+        end
+
+        function testCheckSuppressesRepeatNotice(testCase)
+            index = makeIndex({mipEntry('9.9.9')});
+            evalc('mip.channel.check_mip_update(index, ''1.0.0'')');
+            output = evalc('mip.channel.check_mip_update(index, ''1.0.0'')');
+            testCase.verifyEmpty(output);
+        end
+
+        function testCheckPrintsAgainAfterMarkerCleared(testCase)
+            % mip.m clears the marker at dispatch, so the next command
+            % prints the notice again.
+            index = makeIndex({mipEntry('9.9.9')});
+            evalc('mip.channel.check_mip_update(index, ''1.0.0'')');
+            mip.state.key_value_set('MIP_UPDATE_NOTICE_SHOWN', '');
+            output = evalc('mip.channel.check_mip_update(index, ''1.0.0'')');
+            testCase.verifySubstring(output, 'mip update mip');
+        end
+
+        function testCheckPrintsDifferentNotice(testCase)
+            % A different notice (e.g. new version published) is not suppressed.
+            index1 = makeIndex({mipEntry('9.9.9')});
+            index2 = makeIndex({mipEntry('10.0.0')});
+            evalc('mip.channel.check_mip_update(index1, ''1.0.0'')');
+            output = evalc('mip.channel.check_mip_update(index2, ''1.0.0'')');
+            testCase.verifySubstring(output, '10.0.0');
+        end
+
+        function testCheckNoNoticeWhenUpToDate(testCase)
+            index = makeIndex({mipEntry('1.0.0')});
+            output = evalc('mip.channel.check_mip_update(index, ''1.0.0'')');
+            testCase.verifyEmpty(output);
+        end
+
+        function testCheckNeverErrorsOnMalformedIndex(testCase)
+            % Advisory only: malformed input must not break the caller.
+            evalc('mip.channel.check_mip_update(struct(), ''1.0.0'')');
+            evalc('mip.channel.check_mip_update(struct(''packages'', 42), ''1.0.0'')');
+            evalc('mip.channel.check_mip_update([], ''1.0.0'')');
+            index = makeIndex({mipEntry('9.9.9')});
+            evalc('mip.channel.check_mip_update(index, 42)');
+            % Default installed-version path (resolved via mip.version()).
+            evalc('mip.channel.check_mip_update(index)');
+            testCase.verifyTrue(true);
+        end
+
+        % ---- fetch_index wiring ----
+
+        function testFetchIndexNonCoreChannelNoNotice(testCase)
+            % The check applies only to mip-org/core: a non-core index with a
+            % huge mip version and min_mip_version prints nothing, regardless
+            % of the installed mip version.
+            writeCache(testCase.TestRoot, 'mylab/custom', ...
+                makeIndex({mipEntry('999999.0.0')}, '999999.0.0'));
+            output = evalc('mip.channel.fetch_index(''mylab/custom'')');
+            testCase.verifyEmpty(strfind(output, 'mip update mip'));
+        end
+
+        function testFetchIndexCoreChannelNoMipEntryNoNotice(testCase)
+            writeCache(testCase.TestRoot, 'mip-org/core', ...
+                makeIndex({pkgEntry('chebfun', '5.0.0')}));
+            output = evalc('mip.channel.fetch_index(''mip-org/core'')');
+            testCase.verifyEmpty(strfind(output, 'mip update mip'));
+        end
+
+        function testFetchIndexCoreChannelRunsCheck(testCase)
+            % The wiring stores the composed notice in the state marker when
+            % one applies. With a source-checkout mip (non-numeric version)
+            % no notice applies; either way fetch_index must not error and
+            % must return the index.
+            writeCache(testCase.TestRoot, 'mip-org/core', ...
+                makeIndex({mipEntry('999999.0.0')}));
+            index = mip.channel.fetch_index('mip-org/core');
+            testCase.verifyEqual(index.packages{1}.name, 'mip');
+        end
+
+    end
+end
+
+
+function e = pkgEntry(name, version)
+e = struct('name', name, 'version', version, 'architecture', 'any', ...
+           'mhl_url', 'https://example.invalid/pkg.mhl', ...
+           'dependencies', {{}});
+end
+
+function e = mipEntry(version)
+e = pkgEntry('mip', version);
+end
+
+function index = makeIndex(entries, minMipVersion)
+index = struct('packages', {entries});
+if nargin >= 2
+    index.min_mip_version = minMipVersion;
+end
+end
+
+function writeCache(rootDir, channel, index)
+% Write a synthetic channel index into the on-disk cache so fetch_index
+% serves it without network access.
+parts = strsplit(channel, '/');
+cacheDir = fullfile(rootDir, 'cache', 'index', parts{1});
+if ~isfolder(cacheDir)
+    mkdir(cacheDir);
+end
+cacheFile = fullfile(cacheDir, [parts{2} '.json']);
+fid = fopen(cacheFile, 'w');
+fwrite(fid, jsonencode(index), 'char');
+fclose(fid);
+end

--- a/tests/TestMipUpdateNotice.m
+++ b/tests/TestMipUpdateNotice.m
@@ -1,7 +1,7 @@
 classdef TestMipUpdateNotice < matlab.unittest.TestCase
 %TESTMIPUPDATENOTICE   Self-update notice when loading the core channel index.
 %   Covers mip.channel.mip_update_message (notice composition, including the
-%   optional min_mip_version index field), mip.channel.check_mip_update
+%   optional mip_compatibility_floor index field), mip.channel.check_mip_update
 %   (printing + once-per-command suppression), and the fetch_index wiring
 %   (the check applies only to the mip-org/core channel).
 
@@ -62,7 +62,7 @@ classdef TestMipUpdateNotice < matlab.unittest.TestCase
             % A source checkout ('unspecified') or branch install ('main')
             % has no meaningful ordering against numeric releases.
             index = makeIndex({mipEntry('99.0.0')});
-            index.min_mip_version = '99.0.0';
+            index.mip_compatibility_floor = '99.0.0';
             testCase.verifyEmpty(mip.channel.mip_update_message(index, 'main'));
             testCase.verifyEmpty(mip.channel.mip_update_message(index, 'unspecified'));
             testCase.verifyEmpty(mip.channel.mip_update_message(index, ''));
@@ -103,11 +103,11 @@ classdef TestMipUpdateNotice < matlab.unittest.TestCase
             testCase.verifySubstring(msg, '3.0.0');
         end
 
-        % ---- mip_update_message: min_mip_version ----
+        % ---- mip_update_message: mip_compatibility_floor ----
 
-        function testMinVersionUnsatisfiedSaysRequired(testCase)
+        function testFloorUnsatisfiedSaysRequired(testCase)
             index = makeIndex({mipEntry('1.2.0')});
-            index.min_mip_version = '1.2.0';
+            index.mip_compatibility_floor = '1.2.0';
             msg = mip.channel.mip_update_message(index, '1.1.0');
             testCase.verifySubstring(msg, 'required');
             testCase.verifySubstring(msg, '1.2.0');
@@ -115,32 +115,32 @@ classdef TestMipUpdateNotice < matlab.unittest.TestCase
             testCase.verifySubstring(msg, 'mip update mip');
         end
 
-        function testMinVersionSatisfiedFallsBackToSuggestion(testCase)
+        function testFloorSatisfiedFallsBackToSuggestion(testCase)
             index = makeIndex({mipEntry('1.3.0')});
-            index.min_mip_version = '1.1.0';
+            index.mip_compatibility_floor = '1.1.0';
             msg = mip.channel.mip_update_message(index, '1.2.0');
             testCase.verifySubstring(msg, '1.3.0');
             testCase.verifyEmpty(strfind(msg, 'required'));
         end
 
-        function testMinVersionWithoutMipEntryStillRequired(testCase)
-            % min_mip_version applies even if the index publishes no mip entry.
+        function testFloorWithoutMipEntryStillRequired(testCase)
+            % mip_compatibility_floor applies even if the index publishes no mip entry.
             index = makeIndex({pkgEntry('chebfun', '5.0.0')});
-            index.min_mip_version = '2.0.0';
+            index.mip_compatibility_floor = '2.0.0';
             msg = mip.channel.mip_update_message(index, '1.0.0');
             testCase.verifySubstring(msg, 'required');
         end
 
-        function testNonNumericMinVersionIgnored(testCase)
+        function testNonNumericFloorIgnored(testCase)
             index = makeIndex({mipEntry('1.0.0')});
-            index.min_mip_version = 'main';
+            index.mip_compatibility_floor = 'main';
             msg = mip.channel.mip_update_message(index, '1.0.0');
             testCase.verifyEmpty(msg);
         end
 
-        function testEmptyMinVersionIgnored(testCase)
+        function testEmptyFloorIgnored(testCase)
             index = makeIndex({mipEntry('1.0.0')});
-            index.min_mip_version = '';
+            index.mip_compatibility_floor = '';
             msg = mip.channel.mip_update_message(index, '1.0.0');
             testCase.verifyEmpty(msg);
         end
@@ -201,7 +201,7 @@ classdef TestMipUpdateNotice < matlab.unittest.TestCase
 
         function testFetchIndexNonCoreChannelNoNotice(testCase)
             % The check applies only to mip-org/core: a non-core index with a
-            % huge mip version and min_mip_version prints nothing, regardless
+            % huge mip version and mip_compatibility_floor prints nothing, regardless
             % of the installed mip version.
             writeCache(testCase.TestRoot, 'mylab/custom', ...
                 makeIndex({mipEntry('999999.0.0')}, '999999.0.0'));
@@ -241,10 +241,10 @@ function e = mipEntry(version)
 e = pkgEntry('mip', version);
 end
 
-function index = makeIndex(entries, minMipVersion)
+function index = makeIndex(entries, floorVersion)
 index = struct('packages', {entries});
 if nargin >= 2
-    index.min_mip_version = minMipVersion;
+    index.mip_compatibility_floor = floorVersion;
 end
 end
 


### PR DESCRIPTION
Whenever the `mip-org/core` index is loaded through `fetch_index` (cache hit or fresh download, from any command), mip now checks whether the running installation is outdated:

- If the latest numeric version of the `mip` package in the index is greater than the installed numeric version, a notice suggests running `mip update mip`.
- The index may carry an optional top-level `mip_compatibility_floor` field. When the installed mip is below it, the notice states that the update is **required** — but nothing is blocked; mip keeps functioning normally.

Both checks are skipped when the installed version is non-numeric (branch installs, source checkouts). Each distinct notice prints at most once per command (`mip.m` clears the marker at dispatch), and the check never raises, so it can't break the command in progress. Non-core channels are not checked.

Message composition lives in `mip.channel.mip_update_message` (pure, unit-tested); printing/suppression in `mip.channel.check_mip_update`. Documented in specification §11.8.

The companion change that emits `mip_compatibility_floor` from a channel-root `channel.yaml` is in mip_channel_tools.