### PR TITLE
Repoint README channel starting point at maintained examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ channel layout — see [mip.sh/docs](https://mip.sh/docs).
 
 ## Publishing a package or channel
 
-See [mip.sh/docs](https://mip.sh/docs). Starting point for a new channel:
-[mip-channel-template](https://github.com/mip-org/mip-channel-template).
+See [Hosting a Channel](https://mip.sh/docs/hosting-a-channel). The easiest way
+to start a new channel is to copy a maintained example —
+[mip-example](https://github.com/mip-org/mip-example) (a single package) or
+[mip-hello](https://github.com/mip-org/mip-hello) (a few packages) — both kept
+current with the build system.
 
 ## Authors
 


### PR DESCRIPTION
The Publishing section linked `mip-channel-template` as the starting point for a new channel, but that repo is archived (read-only) and predates the current thin-caller channel model.

Repoint at the maintained `mip-example` and `mip-hello` example channels, matching the [Hosting a Channel](https://mip.sh/docs/hosting-a-channel) docs.

Fixes mip-org/devnotes#5