### PR TITLE
Re-apply own paths on re-load so last-loaded wins shadowing

### DIFF
--- a/+mip/load.m
+++ b/+mip/load.m
@@ -177,9 +177,22 @@ function matched = loadSingle(packageArg, installIfMissing, stickyPackage, chann
                 fprintf('Package "%s" is now sticky\n', displayFqn);
             end
         end
+        % Re-apply the package's own mip.json paths so the physical
+        % MATLAB path tracks the refreshed recency above. addpath
+        % de-dupes: re-adding a folder already on the path moves it to
+        % the front rather than duplicating it, so "most recently loaded
+        % wins" now holds for function shadowing too, not just the state
+        % lists (issue #345). Scoped to this package's own paths -- its
+        % transitive dependencies keep their place unless separately
+        % re-loaded.
+        reloadConfig = mip.config.read_package_json(packageDir);
+        if isfield(reloadConfig, 'paths')
+            applyMipJsonPaths(packageDir, reloadConfig);
+        end
         % Apply --addpath/--rmpath/--with even when already loaded so
         % the user can adjust the path of an existing load without
-        % re-loading.
+        % re-loading. Order matches a fresh load (mip.json paths, then
+        % --addpath/--rmpath, then --with) so path precedence is identical.
         applyPathAdjustments(packageDir, addPathRels, rmPathRels);
         matched = applyExtraPaths(packageDir, withGroups);
         return

--- a/tests/TestLoadPackage.m
+++ b/tests/TestLoadPackage.m
@@ -114,6 +114,31 @@ classdef TestLoadPackage < matlab.unittest.TestCase
             testCase.verifyTrue(ismember('gh/mip-org/core/pkgA', direct));
         end
 
+        function testLoadPackage_AlreadyLoaded_ReloadPromotesPathPrecedence(testCase)
+            % Issue #345: re-loading an already-loaded package must move
+            % its source directory back to the front of the MATLAB path,
+            % so "most recently loaded wins" holds for function shadowing,
+            % not just for the recency lists. addpath de-dupes, so the
+            % re-load moves the folder rather than duplicating it.
+            pkgDirA = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgA');
+            pkgDirB = createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'pkgB');
+            srcA = fullfile(pkgDirA, 'pkgA');
+            srcB = fullfile(pkgDirB, 'pkgB');
+
+            mip.load('mip-org/core/pkgA');   % path: [srcA]
+            mip.load('mip-org/core/pkgB');   % path: [srcB, srcA] -- B shadows A
+            testCase.verifyLessThan(pathIndex(srcB), pathIndex(srcA), ...
+                'after loading B, srcB should precede srcA on the path');
+
+            % Re-load pkgA: its source dir must jump ahead of srcB so A wins.
+            mip.load('mip-org/core/pkgA');
+            testCase.verifyLessThan(pathIndex(srcA), pathIndex(srcB), ...
+                'after re-loading A, srcA should precede srcB on the path');
+            % No duplicate path entry was introduced.
+            testCase.verifyEqual( ...
+                sum(strcmp(strsplit(path, pathsep), srcA)), 1);
+        end
+
         function testLoadPackage_WithStickyFlag(testCase)
             createTestPackage(testCase.TestRoot, 'mip-org', 'core', 'testpkg');
             mip.load('mip-org/core/testpkg', '--sticky');
@@ -314,6 +339,15 @@ classdef TestLoadPackage < matlab.unittest.TestCase
                 'depA must not be pruned: it was directly loaded');
         end
 
+    end
+end
+
+function idx = pathIndex(dir)
+%PATHINDEX   1-based position of dir in the MATLAB path (Inf if absent).
+    dirs = strsplit(path, pathsep);
+    idx = find(strcmp(dirs, dir), 1);
+    if isempty(idx)
+        idx = Inf;
     end
 end
 


### PR DESCRIPTION
Fixes #345.

Re-loading an already-loaded package (`mip load A` when `A` is already loaded) refreshed its recency in the state lists but left the physical MATLAB path unchanged. As a result "most recently loaded wins" held for every list-based consumer (bare-name resolution, ambiguous unload, `mip list` sort) but silently did *not* hold for function shadowing — the one place the phrase is most literal.

## Fix

The already-loaded branch of `+mip/load.m` now re-applies the package's own `mip.json` paths (the `applyMipJsonPaths` step it previously skipped before returning early). `addpath` de-dupes by moving an already-present folder to the front, so a re-load promotes the package's directories and restores the invariant `path == reverse(recency list)`.

- Scoped to the package's **own** paths, not its transitive-dependency subtree — re-loading `A` jumps `A`'s functions ahead; its deps keep their place unless separately re-loaded.
- Call order matches a fresh load (mip.json paths, then `--addpath`/`--rmpath`, then `--with`) so path precedence is identical.

This is a behavior change: scripts that defensively re-load will now reorder the path. The new rule ("last load wins, always") is the more predictable one.

## Tests

Added `testLoadPackage_AlreadyLoaded_ReloadPromotesPathPrecedence`: loads A then B (B shadows A), re-loads A, and asserts A's source dir moves ahead of B's on the path with no duplicate entry. Existing recency-list re-load tests continue to hold.